### PR TITLE
Add scss capabilities via webpack config

### DIFF
--- a/mcweb/frontend/src/App.js
+++ b/mcweb/frontend/src/App.js
@@ -10,7 +10,8 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 // MUI Styling
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Container from '@mui/material/Container';
-
+// Import our style sheet
+import '../../frontend/src/styles/Application.scss'
 // user status
 import Account from './features/auth/Account'
 import SignIn from './features/auth/SignIn'

--- a/mcweb/frontend/src/features/auth/Account.js
+++ b/mcweb/frontend/src/features/auth/Account.js
@@ -14,7 +14,7 @@ const Account = () => {
   }
   return (
     <div style={{ paddingTop: "200px" }}>
-      <h1 style={fontStyle}>Account Username: {currentUser.username}</h1>
+      <h1 className="profile-username">Account Username: {currentUser.username}</h1>
       <h1 style={fontStyle}>Email: {currentUser.email}</h1>
       <h1 style={fontStyle}>isStaff: {currentUser.isStaff.toString()}</h1>
       <h1 style={fontStyle}>isSuperUser: {currentUser.isSuperuser.toString()}</h1>

--- a/mcweb/frontend/src/styles/Application.scss
+++ b/mcweb/frontend/src/styles/Application.scss
@@ -1,0 +1,3 @@
+.profile-username {
+    color: green;
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@mui/x-date-pickers": "^5.0.0-beta.0",
     "@reduxjs/toolkit": "^1.8.2",
     "css": "^3.0.0",
+    "css-loader": "^6.7.1",
     "date-fns": "^2.28.0",
     "dayjs": "^1.11.3",
     "humps": "^2.0.1",
@@ -45,6 +46,9 @@
     "react-router-dom": "^6.3.0",
     "redux": "^4.2.0",
     "redux-thunk": "^2.4.1",
+    "sass": "^1.54.4",
+    "sass-loader": "^13.0.2",
+    "style-loader": "^3.3.1",
     "styled-components": "^5.3.5"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,11 @@ module.exports = {
   module: {
     rules: [
       {
+        test: /\.scss$/,
+        use: ["style-loader","css-loader", "sass-loader"]
+      },
+      {
+        test:/\.js$/,
         exclude: /node_modules/,
         use: {
           loader: "babel-loader"


### PR DESCRIPTION
- npm install
- Can test in mcweb/frontend/src/features/auth/Account.js (account page) I have added a className to the h1 account-username, can adjust styling in mcweb/frontned/src/styles/Application.scss to test
- Npm packages added:
  - css-loader (to allow css imports in react), style-loader (to load in styles), sass, sass-loader (to have sass and allow it to 
    precompile) 
- Added new rule to webpack config to check for .scss and then compile with new loaders
- Adjusted previous rule to include 'test' to only check for .js extensions 
- Imported Application.scss to App.js
- Future additions:
  - better file structure
    - Application.scss should be import file
    - will have directories for variables, mixins, pre-styled components, features (or specific folder for each feature?)  