### PR TITLE
changed permission from AllowAny to IsAuthenticated

### DIFF
--- a/mcweb/backend/sources/api.py
+++ b/mcweb/backend/sources/api.py
@@ -6,7 +6,7 @@ from .serializer import CollectionSerializer, FeedsSerializer, SourcesSerializer
 class CollectionViewSet(viewsets.ModelViewSet):
     queryset = Collection.objects.all()
     permission_classes = [
-        permissions.AllowAny
+        permissions.IsAuthenticated
     ]
     serializer_class = CollectionSerializer
 
@@ -14,7 +14,7 @@ class CollectionViewSet(viewsets.ModelViewSet):
 class FeedsViewSet(viewsets.ModelViewSet):
     queryset = Feed.objects.all()
     permission_classes = [
-        permissions.AllowAny
+        permissions.IsAuthenticated
     ]
     serializer_class = FeedsSerializer
 
@@ -22,6 +22,6 @@ class FeedsViewSet(viewsets.ModelViewSet):
 class SourcesViewSet(viewsets.ModelViewSet):
     queryset = Source.objects.all()
     permission_classes = [
-        permissions.AllowAny
+        permissions.IsAuthenticated
     ]
     serializer_class = SourcesSerializer

--- a/mcweb/backend/users/api.py
+++ b/mcweb/backend/users/api.py
@@ -9,6 +9,10 @@ class UserViewSet(viewsets.ModelViewSet):
     serializer_class = UserSerializer
     current_user = serializers.SerializerMethodField('_user')
 
+    permission_classes = [
+        permissions.IsAuthenticated
+    ]
+
     # TO DO: restrict list and get of non-current to admins only
     def get_object(self):
         pk = self.kwargs.get('pk')


### PR DESCRIPTION
[IsAuthenticated] (https://www.django-rest-framework.org/api-guide/permissions/#isauthenticated)
The IsAuthenticated permission class will deny permission to any unauthenticated user, and allow permission otherwise.

This permission is suitable if you want your API to only be accessible to **registered users.**

This solves the issue of "features you will need to be logged in to use" --> if a person is logged in they are authenticated 