### PR TITLE
django many to many association backend routes

### DIFF
--- a/mcweb/backend/sources/api.py
+++ b/mcweb/backend/sources/api.py
@@ -1,7 +1,7 @@
 from django.shortcuts import get_object_or_404
 from .models import Collection, Feed, Source
 from rest_framework import viewsets, permissions
-from .serializer import CollectionSerializer, FeedsSerializer, SourcesSerializer, SourcesCollectionsSerializer
+from .serializer import CollectionSerializer, FeedsSerializer, SourcesSerializer, SourcesCollectionsSerializer, CollectionsSourcesSerializer
 from rest_framework.response import Response
 from collections import namedtuple
 
@@ -32,7 +32,7 @@ class SourcesCollectionsViewSet(viewsets.ViewSet):
     def retrieve(self, request, pk=None): 
         Sources_collections_tuple = namedtuple('Sources_collections_tuple', ('sources', 'collections'))
         collectionBool = request.query_params.get('collection')
-        if (collectionBool):
+        if (collectionBool == 'true'):
             queryset = Collection.objects.all()
             collection = get_object_or_404(queryset, pk=pk)
             associations = collection.source_set.all()
@@ -47,11 +47,11 @@ class SourcesCollectionsViewSet(viewsets.ViewSet):
             source = get_object_or_404(queryset, pk=pk)
             associations = source.collections.all()
             ret_obj = Sources_collections_tuple(
-                sources=associations,
-                collections=collection
+                collections=associations,
+                sources=source
             )
-            serializer = SourcesCollectionsSerializer(ret_obj)
+            serializer = CollectionsSourcesSerializer(ret_obj)
             return Response(serializer.data)
-        # return Response(print(request))
+
         
 

--- a/mcweb/backend/sources/api.py
+++ b/mcweb/backend/sources/api.py
@@ -1,7 +1,9 @@
+from django.shortcuts import get_object_or_404
 from .models import Collection, Feed, Source
 from rest_framework import viewsets, permissions
-from .serializer import CollectionSerializer, FeedsSerializer, SourcesSerializer
-
+from .serializer import CollectionSerializer, FeedsSerializer, SourcesSerializer, SourcesCollectionsSerializer
+from rest_framework.response import Response
+from collections import namedtuple
 
 class CollectionViewSet(viewsets.ModelViewSet):
     queryset = Collection.objects.all()
@@ -24,4 +26,32 @@ class SourcesViewSet(viewsets.ModelViewSet):
     permission_classes = [
         permissions.IsAuthenticated
     ]
-    serializer_class = SourcesSerializer
+    serializer_class = SourcesSerializer 
+
+class SourcesCollectionsViewSet(viewsets.ViewSet):
+    def retrieve(self, request, pk=None): 
+        Sources_collections_tuple = namedtuple('Sources_collections_tuple', ('sources', 'collections'))
+        collectionBool = request.query_params.get('collection')
+        if (collectionBool):
+            queryset = Collection.objects.all()
+            collection = get_object_or_404(queryset, pk=pk)
+            associations = collection.source_set.all()
+            ret_obj = Sources_collections_tuple(
+                sources=associations,
+                collections=collection
+            )
+            serializer = SourcesCollectionsSerializer(ret_obj)
+            return Response(serializer.data)
+        else :
+            queryset = Source.objects.all()
+            source = get_object_or_404(queryset, pk=pk)
+            associations = source.collections.all()
+            ret_obj = Sources_collections_tuple(
+                sources=associations,
+                collections=collection
+            )
+            serializer = SourcesCollectionsSerializer(ret_obj)
+            return Response(serializer.data)
+        # return Response(print(request))
+        
+

--- a/mcweb/backend/sources/api.py
+++ b/mcweb/backend/sources/api.py
@@ -1,7 +1,7 @@
 from django.shortcuts import get_object_or_404
 from .models import Collection, Feed, Source
 from rest_framework import viewsets, permissions
-from .serializer import CollectionSerializer, FeedsSerializer, SourcesSerializer, SourcesCollectionsSerializer, CollectionsSourcesSerializer
+from .serializer import CollectionSerializer, FeedsSerializer, SourcesSerializer, SourcesCollectionSerializer, CollectionsSourceSerializer
 from rest_framework.response import Response
 from collections import namedtuple
 
@@ -30,28 +30,60 @@ class SourcesViewSet(viewsets.ModelViewSet):
 
 class SourcesCollectionsViewSet(viewsets.ViewSet):
     def retrieve(self, request, pk=None): 
-        Sources_collections_tuple = namedtuple('Sources_collections_tuple', ('sources', 'collections'))
-        collectionBool = request.query_params.get('collection')
-        if (collectionBool == 'true'):
-            queryset = Collection.objects.all()
-            collection = get_object_or_404(queryset, pk=pk)
-            associations = collection.source_set.all()
+        Sources_collections_tuple = namedtuple('Sources_collections_tuple', ('sources', 'collections')) #create tuple to pass through the serializer
+        collection_bool = request.query_params.get('collection') #check in the query_params if collection=true, if 'true' the pk is a collection pk, else pk is for a source
+        if (collection_bool == 'true'):
+            collections_queryset = Collection.objects.all()
+            collection = get_object_or_404(collections_queryset, pk=pk) #see if there is a collection given wildcard and queryset
+            source_associations = collection.source_set.all() #get the associations for the collection
             ret_obj = Sources_collections_tuple(
-                sources=associations,
+                sources=source_associations,
                 collections=collection
-            )
-            serializer = SourcesCollectionsSerializer(ret_obj)
+            ) # create tuple to be able to pass to serializer
+            serializer = SourcesCollectionSerializer(ret_obj)
             return Response(serializer.data)
         else :
-            queryset = Source.objects.all()
-            source = get_object_or_404(queryset, pk=pk)
-            associations = source.collections.all()
+            sources_queryset = Source.objects.all()
+            source = get_object_or_404(sources_queryset, pk=pk)
+            collection_associations = source.collections.all()
             ret_obj = Sources_collections_tuple(
-                collections=associations,
+                collections=collection_associations,
                 sources=source
             )
-            serializer = CollectionsSourcesSerializer(ret_obj)
+            serializer = CollectionsSourceSerializer(ret_obj)
             return Response(serializer.data)
+
+
+    def destroy(self, request, pk=None):
+        collection_bool = request.query_params.get('collection')
+        if (collection_bool == 'true'): #check in the query_params if collection=true, if 'true' the pk is a collection pk, else pk is for a source
+            collections_queryset = Collection.objects.all() # make collection queryset
+            collection = get_object_or_404(collections_queryset, pk=pk) # get collection based on wildcard :id(pk)
+            source_id = request.query_params.get('source_id') #get source_id from params
+            sources_queryset = Source.objects.all() # make source queryset
+            source = get_object_or_404(sources_queryset, pk=source_id) #find source
+            collection.source_set.remove(source) #remove association from collection
+            return Response("deleted")
+        else :
+            sources_queryset = Source.objects.all()
+            source = get_object_or_404(sources_queryset, pk=pk)
+            collection_id = request.query_params.get('collection_id')
+            collections_queryset= Collection.objects.all()
+            collection = get_object_or_404(collections_queryset, pk=collection_id)
+            source.collections.remove(collection)
+            return Response("deleted")
+
+    def create(self,request):
+        source_id = request.data['source_id']
+        sources_queryset = Source.objects.all()
+        source = get_object_or_404(sources_queryset, pk=source_id)
+        collection_id = request.data['collection_id']
+        collections_queryset = Collection.objects.all()
+        collection = get_object_or_404(collections_queryset, pk=collection_id)
+        source.collections.add(collection)
+        return Response("success")
+
+
 
         
 

--- a/mcweb/backend/sources/serializer.py
+++ b/mcweb/backend/sources/serializer.py
@@ -30,10 +30,10 @@ class SourcesSerializer(serializers.ModelSerializer):
         model = Source
         fields = '__all__'
 
-class SourcesCollectionsSerializer(serializers.Serializer):
+class SourcesCollectionSerializer(serializers.Serializer): 
     collections = CollectionSerializer()
     sources = SourcesSerializer(many=True)
 
-class CollectionsSourcesSerializer(serializers.Serializer):
+class CollectionsSourceSerializer(serializers.Serializer):
     collections = CollectionSerializer(many=True)
     sources = SourcesSerializer()

--- a/mcweb/backend/sources/serializer.py
+++ b/mcweb/backend/sources/serializer.py
@@ -29,3 +29,11 @@ class SourcesSerializer(serializers.ModelSerializer):
     class Meta:
         model = Source
         fields = '__all__'
+
+class SourcesCollectionsSerializer(serializers.Serializer):
+    collections = CollectionSerializer()
+    sources = SourcesSerializer(many=True)
+
+class CollectionsSourcesSerializer(serializers.Serializer):
+    collections = CollectionSerializer(many=True)
+    sources = SourcesSerializer()

--- a/mcweb/backend/sources/urls.py
+++ b/mcweb/backend/sources/urls.py
@@ -1,10 +1,11 @@
 from django.urls import URLPattern
 from rest_framework import routers 
-from .api import FeedsViewSet, SourcesViewSet, CollectionViewSet
+from .api import FeedsViewSet, SourcesViewSet, CollectionViewSet, SourcesCollectionsViewSet
 
 router = routers.DefaultRouter() 
 router.register('feeds', FeedsViewSet, 'feeds')
 router.register('sources', SourcesViewSet, 'sources')
 router.register('collections', CollectionViewSet, 'collections')
+router.register('sources-collections', SourcesCollectionsViewSet,'sources-collections' )
 
 urlpatterns = router.urls


### PR DESCRIPTION
Add backend routes to specifically handle the associations between sources and collection.

- 'sources-collections' registered with router in urls.py
- 2 serializers added in serializer.py
  - One to serialize a single collection, with many sources
  - another to serialize many collections and a single source
- The controller/viewset logic is in api.py
  - overrode retrieve, destroy and create methods 
    - retrieve and destroy routes utilize a 'collection_bool', a param passed from the request to see if we are dealing with a 
       collection or source as the pk  
 ### Routes for testing
#### Modifying Collections

- GET /api/sources-collections/:id/?collection=true  
  - will return the collection as well as an array of associated sources 
  - if id cannot be found, "detail": "Not found." will be returned
- POST /api/sources_collections/
  - payload should be comprised of a source_id and a collection_id 
  - if either id cannot be found  "detail": "Not found." will be returned
  - "success" 200 will be returned on success 
 - DELETE /api/sources_collections/:id/?collection=true&source_id=:id
   -  if either id cannot be found  "detail": "Not found." will be returned
   - "deleted" 200 will be returned on success     
  
#### Modifying Sources
- GET /api/sources-collections/:id/?collection=false
  - 'collection=false' param not required
  - will return the source as well as an array of associated collections
- POST route is the same, payload should be the same
- DELETE /api/sources_collections/:id/?collection=false&collection_id=:id    
  -  'collection=false' param not required
  -  collection_id is required
 