### PR TITLE
initial setup and instructions for deploying to our server

### DIFF
--- a/doc/deploying.md
+++ b/doc/deploying.md
@@ -1,0 +1,57 @@
+Deploying
+=========
+
+We deploy via containers on Ubuntu servers. In particular, we utilize [Dokku PaaS](https://dokku.com) to support simpler
+configuration and deployment.
+
+Setup
+-----
+
+The application requires a few pieces to exist and be able to communicate with each other:
+
+### Postgres Database
+
+This stores all the user, source, collection, and feed data.
+
+```
+dokku postgres:create mcweb-db
+```
+
+### Redis Cache
+
+This caches query results to reduce overhead.
+
+```
+dokku redis:create mcweb-cache
+```
+
+### Webapp
+
+This Django app serves up all the content and UI.
+
+1. create the app: `dokku apps:create mcweb`
+2. link to database: `dokku postgres:link mcweb-db mcweb`
+3. link to cache: `dokku redis:link mcweb-cache mcweb`
+4. setup config:
+```
+unset HITFILE  # don't save secretes to ~/.bash_history
+dokku config:set --no-restart mcweb \
+    DEBUG=False \
+    DATABASE_URI=$(dokku postgres:info mcweb-db --dsn)
+    CACHE_URL=$(dokku redis:info mcweb-cache --dsn)
+    SECRET_KEY=SOME_RANDOM_STR \
+    TWITTER_API_BEARER_TOKEN=YOUR_TOKEN \
+    YOUTUBE_API_KEY=YOUR_YT_API_KEY \
+    MEDIA_CLOUD_API_KEY=YOUR_MC_API_KEY \
+```
+5. setup the domain: `dokku domains:add mcweb search.mediacloud.org`
+6. on your local machine setup the remote: `git remote add mcweb-prod dokku@<SERVER>:mcweb`
+
+Deploying
+---------
+
+1. update the version number in settings.py (ie. "0.1.1")
+2. once we have a changelog, update the changlog to note changes/fixes
+3. run all the tests to make sure they still pass
+4. commit and tag the release with the appopriate version number (ie. "v0.1.1")
+5. push the tag to the server: `git push mcweb-prod v0.1.1:main`

--- a/mcweb/frontend/templates/frontend/index.html
+++ b/mcweb/frontend/templates/frontend/index.html
@@ -7,12 +7,15 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <link rel="stylesheet" href="https://bootswatch.com/4/cosmo/bootstrap.min.css">
     <title>Media Cloud</title>
+    <script>
+        settings = {};
+        settings.appVersion = "{{ version }}";
+    </script>
 </head>
 
 <body>
     <div id="app"></div>
     {% load static %}
-    
 
     <script src="{% static "frontend/main.js" %}"></script>
 </body>

--- a/mcweb/frontend/views.py
+++ b/mcweb/frontend/views.py
@@ -1,13 +1,12 @@
 import logging
-from django.shortcuts import redirect, render
+from django.shortcuts import render
 from django.views.decorators.csrf import ensure_csrf_cookie
-
-# views are python functions or classes that
-# receive a web request and return a web response
-
+from mcweb.settings import VERSION
 
 logger = logging.getLogger(__name__)
 
+
 @ensure_csrf_cookie
 def index(request):
-    return render(request, 'frontend/index.html')
+    # the main entry point for the web app - it just renders the index HTML file to load all the JS
+    return render(request, 'frontend/index.html', dict(version=VERSION))

--- a/mcweb/settings.py
+++ b/mcweb/settings.py
@@ -15,6 +15,9 @@ import os
 import dj_database_url
 import environ
 
+# The static version of the app
+VERSION = "0.1.0"
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent
 


### PR DESCRIPTION
This adds documentation at `doc/deploying.md`.
It also adds a static version number in `settings.py`, which is relayed to JS in index.html as a global `settings.version`. We should add a `<Footer>` that shows the version number at the bottom of each page, much like our current app does.