### PR TITLE
RTK changes, combining apis and changing cache tags

### DIFF
--- a/mcweb/frontend/src/app/services/collectionsApi.js
+++ b/mcweb/frontend/src/app/services/collectionsApi.js
@@ -1,26 +1,16 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { managerApi } from "./managerApi";
 
-export const collectionsApi = createApi({
-  reducerPath: 'collectionsApi',
-  baseQuery: fetchBaseQuery({
-    baseUrl: '/api/sources/collections/',
-    prepareHeaders: (headers, { getState }) => {
-      // Django requires this for security (cross-site forgery protection) once logged in
-      headers.set('X-Csrftoken', window.CSRF_TOKEN);
-      return headers;
-    },
-  }),
-  tagTypes: ['Collection'],
+export const collectionsApi = managerApi.injectEndpoints({
   endpoints: (builder) => ({
     getFeaturedCollections: builder.query({
       query: () => ({
-        url:'',
+        url:'collections/',
         method: 'GET'
       })
     }),
     getCollection: builder.query({
       query: (id) => ({
-        url: `${id}/`,
+        url: `collections/${id}/`,
         method: 'GET'
       }),
       providesTags: (result, error, id) =>
@@ -30,21 +20,21 @@ export const collectionsApi = createApi({
     }),
     postCollection: builder.mutation({
       query: (collection) => ({
-        url: '',
+        url: 'collections/',
         method: 'POST',
         body: { ...collection }
       })
     }),
     updateCollection: builder.mutation({
       query: (collection) => ({
-        url: `/${collection.id}/`,
+        url: `collections/${collection.id}/`,
         method: 'PATCH',
         body: { ... collection }
       })
     }),
     deleteCollection: builder.mutation({
       query: ({id}) => ({
-        url: `/${id}/`,
+        url: `collections/${id}/`,
         method: 'DELETE',
         body: {... id}
       }),

--- a/mcweb/frontend/src/app/services/managerApi.js
+++ b/mcweb/frontend/src/app/services/managerApi.js
@@ -1,0 +1,15 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+export const managerApi = createApi({
+    reducerPath: 'managerApi',
+    baseQuery: fetchBaseQuery({
+        baseUrl: '/api/sources/',
+        prepareHeaders: (headers, { getState }) => {
+            // Django requires this for security (cross-site forgery protection) once logged in
+            headers.set('X-Csrftoken', window.CSRF_TOKEN);
+            return headers;
+        },
+    }),
+    tagTypes: ['Source', 'Collection'],
+    endpoints: () => ({})
+})

--- a/mcweb/frontend/src/app/services/sourceApi.js
+++ b/mcweb/frontend/src/app/services/sourceApi.js
@@ -1,20 +1,10 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { managerApi } from "./managerApi"
 
-export const sourcesApi = createApi({
-  reducerPath: 'sourcesApi',
-  baseQuery: fetchBaseQuery({
-    baseUrl: '/api/sources/sources/',
-    prepareHeaders: (headers, { getState }) => {
-      // Django requires this for security (cross-site forgery protection) once logged in
-      headers.set('X-Csrftoken', window.CSRF_TOKEN);
-      return headers;
-    },
-  }),
-  tagTypes: ['Source'],
+export const sourcesApi = managerApi.injectEndpoints({
   endpoints: (builder) => ({
     getSource: builder.query({
       query: (id) => ({
-        url: `${id}/`,
+        url: `sources/${id}/`,
         method: 'GET'
       }),
       providesTags: (result, error, id) =>
@@ -24,7 +14,7 @@ export const sourcesApi = createApi({
     }),
     postSource: builder.mutation({
       query: (source) => ({
-        url: '',
+        url: 'sources/',
         method: 'POST',
         body: { ...source }
       })
@@ -32,14 +22,14 @@ export const sourcesApi = createApi({
     updateSource: builder.mutation({
       query: (source) => {
         return {
-        url: `/${source.id}/`,
+          url: `sources/${source.id}/`,
         method: 'PATCH',
         body:  {...source}
       }}
     }),
     deleteSource: builder.mutation({
       query: ({ id }) => ({
-        url: `/${id}/`,
+        url: `sources/${id}/`,
         method: 'DELETE',
         body: { ...id }
       }),

--- a/mcweb/frontend/src/app/services/sourcesCollectionsApi.js
+++ b/mcweb/frontend/src/app/services/sourcesCollectionsApi.js
@@ -1,20 +1,10 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { managerApi } from './managerApi';
 
-export const sourcesCollectionsApi = createApi({
-    reducerPath: 'sourcesCollectionsApi',
-    baseQuery: fetchBaseQuery({
-        baseUrl: '/api/sources/sources-collections/',
-        prepareHeaders: (headers, { getState }) => {
-            // Django requires this for security (cross-site forgery protection) once logged in
-            headers.set('X-Csrftoken', window.CSRF_TOKEN);
-            return headers;
-        },
-    }),
-    tagTypes: ['Source', 'Collection'],
+export const sourcesCollectionsApi = managerApi.injectEndpoints({
     endpoints: (builder) => ({
-        getSourceAndAssociations: builder.query({
+        getSourceAssociations: builder.query({
             query: (id) => ({
-                url: `${id}/`,
+                url: `sources-collections/${id}/`,
                 method: 'GET'
             }),
             providesTags: (result, error, collectionId) =>
@@ -22,9 +12,9 @@ export const sourcesCollectionsApi = createApi({
                     ? [...result['collections'].map(({ id }) => ({ type: 'Collection', id })), 'Collection']
                     : ['Collection']
         }),
-        getCollectionAndAssociations: builder.query({
+        getCollectionAssociations: builder.query({
             query: (id) => ({
-                url: `${id}/?collection=true`,
+                url: `sources-collections/${id}/?collection=true`,
                 method: 'GET'
             }),
             providesTags: (result, error, collectionId) =>
@@ -34,17 +24,15 @@ export const sourcesCollectionsApi = createApi({
         }),
         createSourceCollectionAssociation: builder.mutation({
             query: (payload) => ({
-                url: ``,
+                url: `sources-collections/`,
                 method: 'POST',
                 body: {'source_id': payload.source_id, 'collection_id': payload.collection_id}
             }),
-            invalidatesTags: (result, error, ids) =>
-                [{ type: 'Collection', id: ids.collection_id }, { type: 'Source', id: ids.source_id }],
-                
+            invalidatesTags: ['Collection', 'Source'],
         }),
         deleteSourceCollectionAssociation: builder.mutation({
             query: (ids) => ({
-                url:`${ids.source_id}/?collection_id=${ids.collection_id}`,
+                url:`sources-collections/${ids.source_id}/?collection_id=${ids.collection_id}`,
                 method: 'DELETE'
             }),
             invalidatesTags: (result, error, ids) => 
@@ -55,8 +43,8 @@ export const sourcesCollectionsApi = createApi({
 
 
 export const {
-    useGetSourceAndAssociationsQuery,
-    useGetCollectionAndAssociationsQuery,
+    useGetSourceAssociationsQuery,
+    useGetCollectionAssociationsQuery,
     useCreateSourceCollectionAssociationMutation,
     useDeleteSourceCollectionAssociationMutation
 } = sourcesCollectionsApi

--- a/mcweb/frontend/src/app/store.js
+++ b/mcweb/frontend/src/app/store.js
@@ -4,9 +4,7 @@ import { setupListeners } from '@reduxjs/toolkit/query/react';
 //rtk apis
 import { api as authApi } from './services/authApi';
 import { searchApi } from './services/searchApi';
-import { sourcesCollectionsApi } from './services/sourcesCollectionsApi';
-import { collectionsApi } from './services/collectionsApi';
-import { sourcesApi } from './services/sourceApi'
+import { managerApi } from './services/managerApi';
 
 //reducers
 import authReducer from '../features/auth/authSlice';
@@ -34,25 +32,16 @@ const setupStore = () => {
       [searchApi.reducerPath]: searchApi.reducer,
       search: searchReducer,
 
-      // sourcesCollection api responsible for associations' CRUD 
-      [sourcesCollectionsApi.reducerPath]: sourcesCollectionsApi.reducer,
-
-      // collection api 
-      [collectionsApi.reducerPath]: collectionsApi.reducer,
-
-      // sources api responsible for collections' CRUD 
-      [sourcesApi.reducerPath]: sourcesApi.reducer,
-
+      // api responsible for all Sources or Collections CRUD
+      [managerApi.reducerPath]: managerApi.reducer,
 
     },
     // Adding the api middleware enables caching, invalidation, polling,
     // and other useful features of `rtk-query`.
     middleware: (getDefaultMiddleware) => 
       getDefaultMiddleware().concat(authApi.middleware, 
-        searchApi.middleware, 
-        sourcesCollectionsApi.middleware,
-        collectionsApi.middleware,
-        sourcesApi.middleware
+        searchApi.middleware,
+        managerApi.middleware, 
         ),
     
   });

--- a/mcweb/frontend/src/features/collections/CollectionList.js
+++ b/mcweb/frontend/src/features/collections/CollectionList.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useGetSourceAndAssociationsQuery, useDeleteSourceCollectionAssociationMutation } from '../../app/services/sourcesCollectionsApi';
+import { useGetSourceAssociationsQuery, useDeleteSourceCollectionAssociationMutation } from '../../app/services/sourcesCollectionsApi';
 import CollectionItem from './CollectionItem';
 
 export default function CollectionList(props) {
@@ -7,7 +7,7 @@ export default function CollectionList(props) {
     const {
         data,
         isLoading
-    } = useGetSourceAndAssociationsQuery(sourceId);
+    } = useGetSourceAssociationsQuery(sourceId);
 
     const [deleteSourceCollectionAssociation, deleteResult] = useDeleteSourceCollectionAssociationMutation();
 

--- a/mcweb/frontend/src/features/sources/SourceList.js
+++ b/mcweb/frontend/src/features/sources/SourceList.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useGetCollectionAndAssociationsQuery } from '../../app/services/sourcesCollectionsApi';
+import { useGetCollectionAssociationsQuery } from '../../app/services/sourcesCollectionsApi';
 import { useDeleteSourceCollectionAssociationMutation } from '../../app/services/sourcesCollectionsApi';
 import { useGetCollectionQuery } from '../../app/services/collectionsApi';
 import SourceItem from './SourceItem';
@@ -9,7 +9,7 @@ export default function SourceList(props) {
     const {
         data,
         isLoading
-    } = useGetCollectionAndAssociationsQuery(collectionId);
+    } = useGetCollectionAssociationsQuery(collectionId);
 
     const [deleteSourceCollectionAssociation, deleteResult] = useDeleteSourceCollectionAssociationMutation();
 


### PR DESCRIPTION
Changes to RTK api structure.
- A single api called managerApi was made.
  - each of the existing apis have been transformed to extend managerApi
    - this is to help with better cache results
- Change invalidationTags for createAssociation 