### PR TITLE
Bug twitter end date

### DIFF
--- a/mcweb/backend/search/platforms/twitter.py
+++ b/mcweb/backend/search/platforms/twitter.py
@@ -34,9 +34,9 @@ class TwitterTwitterProvider(ContentProvider):
             "query": query,
             "max_results": limit,
             "start_time": start_date.isoformat("T") + "Z",
-            "end_time": end_date.isoformat("T") + "Z",
+            "end_time": self._fix_end_date(end_date).isoformat("T") + "Z",
             "tweet.fields": ",".join(["author_id", "created_at", "public_metrics"]),
-            "expansions": "author_id"
+            "expansions": "author_id",
         }
         results = self._cached_query("tweets/search/all", params)
         return TwitterTwitterProvider._tweets_to_rows(results)
@@ -61,7 +61,7 @@ class TwitterTwitterProvider(ContentProvider):
             query=query,
             granularity='day',
             start_time=start_date.isoformat("T") + "Z",
-            end_time=end_date.isoformat("T") + "Z",
+            end_time=self._fix_end_date(end_date).isoformat("T") + "Z",
         )
         more_data = True
         next_token = None
@@ -93,7 +93,7 @@ class TwitterTwitterProvider(ContentProvider):
             "query": query,
             "max_results": page_size,
             "start_time": start_date.isoformat("T") + "Z",
-            "end_time": end_date.isoformat("T") + "Z",
+            "end_time": self._fix_end_date(end_date).isoformat("T") + "Z",
             "tweet.fields": ",".join(["author_id", "created_at", "public_metrics"]),
             "expansions": "author_id",
         }
@@ -163,3 +163,9 @@ class TwitterTwitterProvider(ContentProvider):
     def __repr__(self):
         # important to keep this unique among platforms so that the caching works right
         return "TwitterTwitterProvider"
+
+    @classmethod
+    def _fix_end_date(cls, orig_end_date: dt.datetime) -> dt.datetime:
+        # twitter end dates are NOT inclusive, so we need to add one day here to make it match the general
+        # behavior of our system (and UI copywriting)
+        return orig_end_date + dt.timedelta(days=1)

--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -3,8 +3,9 @@ from operator import itemgetter
 import json
 from .platforms import PLATFORM_ONLINE_NEWS, PLATFORM_SOURCE_MEDIA_CLOUD, PLATFORM_REDDIT, PLATFORM_SOURCE_PUSHSHIFT, PLATFORM_TWITTER, PLATFORM_SOURCE_TWITTER, PLATFORM_YOUTUBE, PLATFORM_SOURCE_YOUTUBE, PLATFORM_SOURCE_WAYBACK_MACHINE
 
+
 def fill_in_dates(start_date, end_date, existing_counts):
-    delta = end_date - start_date
+    delta = (end_date + dt.timedelta(1)) - start_date
     date_count_dict = {k['date']: k['count'] for k in existing_counts}
 
     # whether or not the dates in existing_counts are string types
@@ -21,6 +22,7 @@ def fill_in_dates(start_date, end_date, existing_counts):
         else:
             filled_counts.append({'count': date_count_dict[day_string], 'date': day_string})
     return filled_counts
+
 
 def parse_query(request):
     payload = json.loads(request.body)

--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -2,7 +2,6 @@ import json
 import logging
 import csv
 import time
-from operator import itemgetter
 import collections as py_collections
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.views.decorators.http import require_http_methods
@@ -12,9 +11,8 @@ import mcweb.backend.search.platforms.exceptions
 import mcweb.backend.util.csv_stream as csv_stream
 from .utils import fill_in_dates, parse_query
 
-
-
 logger = logging.getLogger(__name__)
+
 
 @require_http_methods(["POST"])
 def total_count(request):
@@ -24,6 +22,7 @@ def total_count(request):
     # everything_count = provider.normalized_count_over_time(query_str, start_date, end_date, collections=collections)
     return HttpResponse(json.dumps({"count": total_attention}), content_type="application/json", status=200)
 
+
 @require_http_methods(["POST"])
 def count_over_time(request):
     start_date, end_date, query_str, collections, platform, platform_source = parse_query(request)
@@ -31,17 +30,16 @@ def count_over_time(request):
     count_attention_over_time = provider.count_over_time(query_str, start_date, end_date, collections=collections)
     zero_filled_counts = fill_in_dates(start_date, end_date, count_attention_over_time['counts'])
     count_attention_over_time['counts'] = zero_filled_counts
-    return HttpResponse(json.dumps({"count_over_time": count_attention_over_time }, default=str), content_type="application/json", status=200)
+    return HttpResponse(json.dumps({"count_over_time": count_attention_over_time}, default=str), content_type="application/json", status=200)
+
 
 @require_http_methods(["POST"])
 def sample(request):
     start_date, end_date, query_str, collections, platform, platform_source = parse_query(request)
     provider = platforms.provider_for(platform, platform_source)
     sample_stories = provider.sample(query_str, start_date, end_date, collections=collections)
-    return HttpResponse(json.dumps({"sample": sample_stories }, default=str), content_type="application/json", status=200)
+    return HttpResponse(json.dumps({"sample": sample_stories}, default=str), content_type="application/json", status=200)
 
-
-logger = logging.getLogger(__name__)
 
 @require_http_methods(["POST"])
 @action(detail=False)
@@ -65,6 +63,7 @@ def download_counts_over_time_csv(request):
         else:
             writer.writerow([day["date"], day["count"]])
     return response
+
 
 @require_http_methods(["POST"])
 @action(detail=False)

--- a/mcweb/frontend/src/features/search/results/CountOverTimeChart.jsx
+++ b/mcweb/frontend/src/features/search/results/CountOverTimeChart.jsx
@@ -22,7 +22,7 @@ export default function CountOverTimeChart() {
     collections,
     sources,
     lastSearchTime,
-    anyAll
+    anyAll,
   } = useSelector((state) => state.query);
 
   const [hidden, setHidden] = useState(false);
@@ -67,6 +67,7 @@ export default function CountOverTimeChart() {
       const newData = data.count_over_time.counts.map((day) => [dateHelper(day.date), day.count]);
       return newData;
     }
+    return data;
   };
 
   const options = {
@@ -122,9 +123,7 @@ export default function CountOverTimeChart() {
   if (isLoading) {
     return (
       <div>
-        {' '}
         <CircularProgress size="75px" />
-        {' '}
       </div>
     );
   }
@@ -135,7 +134,7 @@ export default function CountOverTimeChart() {
       <h2>Attention Over Time</h2>
 
       {hidden && (
-      <Alert severity="warning">Our access doesn't support fetching attention over time data.</Alert>
+      <Alert severity="warning">Our access doesn&apos;t support fetching attention over time data.</Alert>
       )}
       {!hidden && (
       <>


### PR DESCRIPTION
Twitter search end date is not inclusive in their API, so we have to add a day to all our searches so it is consistent across platforms.

Also this fixes a bug in the date-filling-in to make sure that last day comes through in the attention-over-time chart.