### PR TITLE
Attempted fix for querying after receiving an error

### DIFF
--- a/mcweb/frontend/src/features/search/Search.jsx
+++ b/mcweb/frontend/src/features/search/Search.jsx
@@ -4,14 +4,13 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useSnackbar } from 'notistack';
 import dayjs from 'dayjs';
 import { useNavigate } from 'react-router-dom';
+import { searchApi } from '../../app/services/searchApi';
 import PlatformPicker from './query/PlatformPicker';
-import { openModal } from '../ui/uiSlice';
 import SelectedMedia from './query/SelectedMedia';
 import SearchDatePicker from './query/SearchDatePicker';
 import SimpleSearch from './query/SimpleSearch';
 import SampleStories from './results/SampleStories';
 import { setSearchTime, removeSelectedMedia } from './query/querySlice';
-import TotalAttentionChart from './results/TotalAttentionChart';
 import TotalAttentionResults from './results/TotalAttentionResults';
 import CountOverTimeResults from './results/CountOverTimeResults';
 import MediaPicker from './query/media-picker/MediaPicker';
@@ -44,9 +43,6 @@ export default function Search() {
     anyAll,
   };
 
-  if (platform === 'Choose a Platform') {
-    dispatch(openModal('platformPicker'));
-  }
   return (
     <div className="search-container">
 
@@ -115,6 +111,7 @@ export default function Search() {
                       `/search${urlSerializer(queryObject)}`,
                       { options: { replace: true } },
                     );
+                    dispatch(searchApi.util.resetApiState());
                     dispatch(setSearchTime(dayjs().format()));
                   } catch {
                     enqueueSnackbar('Query is empty', { variant: 'error' });


### PR DESCRIPTION
- Added a a reset searchApi cache command to run after hitting search
  - will clear any previously received errors after search button has been pressed