### PR TITLE
download directly via GET, not via JS blob

### DIFF
--- a/mcweb/backend/search/urls.py
+++ b/mcweb/backend/search/urls.py
@@ -13,8 +13,8 @@ urlpatterns = [
     path('sample', views.sample),
     path('count-over-time', views.count_over_time),
     path('normalized-count-over-time', views.normalized_count_over_time),
-    path('download-counts-over-time', views.download_counts_over_time_csv),
-    path('download-sample-stories', views.download_all_content_csv)
+    path('download-counts-over-time-csv', views.download_counts_over_time_csv),
+    path('download-all-content-csv', views.download_all_content_csv)
 ]
 
 urlpatterns += router.urls

--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -15,16 +15,15 @@ def fill_in_dates(start_date, end_date, existing_counts):
     for i in range(delta.days):
         day = start_date + dt.timedelta(days=i)
         day_string = dt.datetime.strftime(day, "%Y-%m-%d %H:%M:%S")
-        if (day_string not in date_count_dict.keys()):
+        if day_string not in date_count_dict.keys():
             filled_counts.append({"count": 0, "date": day_string})
         else:
             filled_counts.append({'count': date_count_dict[day_string], 'date': day_string})
     return filled_counts
 
 
-def parse_query(request):
-    payload = json.loads(request.body)
-    payload = payload.get("queryObject")
+def parse_query(request, http_method: str = 'POST') -> tuple:
+    payload = json.loads(request.body).get("queryObject") if http_method == 'POST' else json.loads(request.GET.get("queryObject"))
     provider_name = payload["platform"]
     query_str = payload["query"]
     collections = payload["collections"]
@@ -33,4 +32,4 @@ def parse_query(request):
     start_date = dt.datetime.strptime(start_date, '%m/%d/%Y')
     end_date = payload["endDate"]
     end_date = dt.datetime.strptime(end_date, '%m/%d/%Y')
-    return (start_date, end_date, query_str, collections, provider_name)
+    return start_date, end_date, query_str, collections, provider_name

--- a/mcweb/frontend/src/app/services/searchApi.js
+++ b/mcweb/frontend/src/app/services/searchApi.js
@@ -53,37 +53,6 @@ export const searchApi = createApi({
         body: { queryObject },
       }),
     }),
-    downloadCountsOverTimeCSV: builder.mutation({
-      query: (queryObject) => ({
-        url: 'download-counts-over-time',
-        method: 'POST',
-        body: { queryObject },
-        responseHandler: async (response) => (
-        // const downloadLink = window.URL.createObjectURL(await response.blob());
-        // const titledLink = await downloadLink.setAttribute("download",
-        // 'count-over-time-csv.csv');
-        // console.log(await response.blob());
-        // console.log(URL.createObjectURL(await response.blob()));
-        // return await window.location.assign(titledLink);
-          window.location.assign(window.URL.createObjectURL(await response.blob()))),
-      }),
-    }),
-    downloadSampleStoriesCSV: builder.mutation({
-      query: (queryObject) => ({
-        url: 'download-sample-stories',
-        method: 'POST',
-        body: { queryObject },
-        responseHandler: async (response) => (
-          // const downloadLink = window.URL.createObjectURL(await response.blob());
-          // const titledLink = await downloadLink.setAttribute("download",
-          // 'count-over-time-csv.csv');
-          // console.log(await response.blob());
-          // console.log(URL.createObjectURL(await response.blob()));
-          // return await window.location.assign(titledLink);
-          window.location.assign(window.URL.createObjectURL(await response.blob()))),
-
-      }),
-    }),
   }),
 });
 
@@ -96,7 +65,5 @@ export const {
   useGetTotalCountMutation,
   useGetCountOverTimeMutation,
   useGetSampleStoriesMutation,
-  useDownloadCountsOverTimeCSVMutation,
-  useDownloadSampleStoriesCSVMutation,
   useGetNormalizedCountOverTimeMutation,
 } = searchApi;

--- a/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
+++ b/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
@@ -10,7 +10,6 @@ import MenuItem from '@mui/material/MenuItem';
 import queryGenerator from '../util/queryGenerator';
 import CountOverTimeChart from './CountOverTimeChart';
 import {
-  useDownloadCountsOverTimeCSVMutation,
   useGetCountOverTimeMutation,
   useGetNormalizedCountOverTimeMutation,
 } from '../../../app/services/searchApi';
@@ -44,13 +43,15 @@ export default function CountOverTimeResults() {
 
   const queryString = queryGenerator(queryList, negatedQueryList, platform, anyAll);
 
-  const [downloadCsv] = useDownloadCountsOverTimeCSVMutation();
-
   const [query, { isLoading, data, error }] = useGetCountOverTimeMutation();
 
   const [normalizedQuery, normalizedResults] = useGetNormalizedCountOverTimeMutation();
 
   const collectionIds = collections.map((collection) => collection.id);
+
+  const handleDownloadRequest = (queryObject) => {
+    window.location = `/api/search/download-counts-over-time-csv?queryObject=${encodeURIComponent(JSON.stringify(queryObject))}`;
+  };
 
   const dateHelper = (dateString) => {
     dayjs.extend(utc);
@@ -194,7 +195,7 @@ export default function CountOverTimeResults() {
             <Button
               variant="text"
               onClick={() => {
-                downloadCsv({
+                handleDownloadRequest({
                   query: queryString,
                   startDate,
                   endDate,

--- a/mcweb/frontend/src/features/search/results/SampleStories.jsx
+++ b/mcweb/frontend/src/features/search/results/SampleStories.jsx
@@ -144,7 +144,7 @@ export default function SampleStories() {
               });
             }}
           >
-            Download CSV
+            Download CSV of All Content
           </Button>
         </div>
       </div>

--- a/mcweb/frontend/src/features/search/results/SampleStories.jsx
+++ b/mcweb/frontend/src/features/search/results/SampleStories.jsx
@@ -5,7 +5,7 @@ import dayjs from 'dayjs';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 
-import { useGetSampleStoriesMutation, useDownloadSampleStoriesCSVMutation } from '../../../app/services/searchApi';
+import { useGetSampleStoriesMutation } from '../../../app/services/searchApi';
 import queryGenerator from '../util/queryGenerator';
 import {
   PROVIDER_REDDIT_PUSHSHIFT, PROVIDER_NEWS_MEDIA_CLOUD, PROVIDER_NEWS_WAYBACK_MACHINE,
@@ -31,9 +31,12 @@ export default function SampleStories() {
   const queryString = queryGenerator(queryList, negatedQueryList, platform, anyAll);
 
   const [query, { isLoading, data }] = useGetSampleStoriesMutation();
-  const [downloadStories] = useDownloadSampleStoriesCSVMutation();
 
   const collectionIds = collections.map((collection) => collection.id);
+
+  const handleDownloadRequest = (queryObject) => {
+    window.location = `/api/search/download-all-content-csv?queryObject=${encodeURIComponent(JSON.stringify(queryObject))}`;
+  };
 
   useEffect(() => {
     if (queryList[0].length !== 0) {
@@ -131,14 +134,13 @@ export default function SampleStories() {
           <Button
             variant="text"
             onClick={() => {
-              downloadStories({
+              handleDownloadRequest({
                 query: queryString,
                 startDate,
                 endDate,
                 collections: collectionIds,
                 sources,
                 platform,
-
               });
             }}
           >


### PR DESCRIPTION
This correctly streams the full content downloads. The issue was that we were downloading via a RTK as a JS blob. This is overly architected - we can just call the download directly and the Django streaming libraries work.

This required me to switch the calls to GET, because I couldn't figure out how to generate a POST dynamically. So now `parse_query` takes an optional 2nd argument to indicate when it should pulls the query object from url params instead of from form JSON data.

I switched by the counts-over-time and all-content downloads to use this approach so it is consistent.

To test, you can put a breakpoint in one of the Provider `all_items` methods after a yield. You'll see in the browser once you start a download that when your breakpoint hits the file has already started streaming, even though we are still fetching a second page of data. This indicates that it really is streaming.