### PR TITLE
Feature custom search end dates

### DIFF
--- a/mcweb/backend/search/providers/twitter.py
+++ b/mcweb/backend/search/providers/twitter.py
@@ -168,4 +168,6 @@ class TwitterTwitterProvider(ContentProvider):
     def _fix_end_date(cls, orig_end_date: dt.datetime) -> dt.datetime:
         # twitter end dates are NOT inclusive, so we need to add one day here to make it match the general
         # behavior of our system (and UI copywriting)
-        return orig_end_date + dt.timedelta(days=1)
+        # also: can't search results more recent than 10 seconds ago (or something like that)
+        return min(orig_end_date + dt.timedelta(days=1),
+                   dt.datetime.now() - dt.timedelta(minutes=5))

--- a/mcweb/frontend/src/features/search/query/querySlice.js
+++ b/mcweb/frontend/src/features/search/query/querySlice.js
@@ -1,10 +1,11 @@
 import { createSlice } from '@reduxjs/toolkit';
 import dayjs from 'dayjs';
-import { PROVIDER_NEWS_MEDIA_CLOUD } from '../util/platforms';
+import { PROVIDER_NEWS_MEDIA_CLOUD, latestAllowedEndDate } from '../util/platforms';
+
+const DEFAULT_PROVIDER = PROVIDER_NEWS_MEDIA_CLOUD;
+const DEFAULT_COLLECTIONS = [{ id: 34412234, name: 'United States - National' }];
 
 const startDate = dayjs().subtract(34, 'day').format('MM/DD/YYYY');
-
-const endDate = dayjs().subtract(4, 'day').format('MM/DD/YYYY');
 
 const querySlice = createSlice({
   name: 'query',
@@ -12,11 +13,11 @@ const querySlice = createSlice({
     queryString: '',
     queryList: [[], [], []],
     negatedQueryList: [[], [], []],
-    platform: PROVIDER_NEWS_MEDIA_CLOUD, // "Choose a Platform",
+    platform: DEFAULT_PROVIDER,
     startDate,
-    endDate,
-    collections: [{ id: 34412234, name: 'United States - National' }],
-    previewCollections: [{ id: 34412234, name: 'United States - National' }],
+    endDate: latestAllowedEndDate(DEFAULT_PROVIDER),
+    collections: DEFAULT_COLLECTIONS,
+    previewCollections: DEFAULT_COLLECTIONS,
     sources: [],
     lastSearchTime: dayjs().format(),
     anyAll: 'any',

--- a/mcweb/frontend/src/features/search/util/platforms.js
+++ b/mcweb/frontend/src/features/search/util/platforms.js
@@ -1,3 +1,5 @@
+import dayjs from 'dayjs';
+
 // keep in sync with mcweb/frontend/views.py
 
 export const PLATFORM_TWITTER = 'twitter';
@@ -25,3 +27,10 @@ export const PROVIDER_NEWS_WAYBACK_MACHINE = providerName(
 );
 export const PROVIDER_REDDIT_PUSHSHIFT = providerName(PLATFORM_REDDIT, PLATFORM_SOURCE_PUSHSHIFT);
 export const PROVIDER_YOUTUBE_YOUTUBE = providerName(PLATFORM_YOUTUBE, PLATFORM_SOURCE_YOUTUBE);
+
+export const latestAllowedEndDate = (provider) => {
+  const today = dayjs();
+  if (provider === PROVIDER_NEWS_MEDIA_CLOUD) return today.subtract('1', 'day');
+  if (provider === PROVIDER_NEWS_WAYBACK_MACHINE) return today.subtract('4', 'day');
+  return today;
+};


### PR DESCRIPTION
Had to fix this for a quick project I was trying out.
Each platform has a limit for the most recent search allowed - this encodes those in `platforms.js` and then uses them to make sure user isn't searching more recent data than the platform allows for.