### PR TITLE
bump wayback provider to latest version

### DIFF
--- a/mcweb/backend/search/providers/onlinenews.py
+++ b/mcweb/backend/search/providers/onlinenews.py
@@ -202,7 +202,6 @@ class OnlineNewsWaybackMachineProvider(ContentProvider):
     def item(self, item_id: str, collection: str = DEFAULT_COLLECTION) -> Dict:
         return self._client.article(item_id)
 
-    @cache_by_kwargs()
     def all_items(self, query: str, start_date: dt.datetime, end_date: dt.datetime, page_size: int = 1000,
                   collection: str = DEFAULT_COLLECTION, **kwargs):
         for page in self._client.all_articles(self._assembled_query_str(query, **kwargs), start_date, end_date, **kwargs):

--- a/mcweb/backend/search/providers/twitter.py
+++ b/mcweb/backend/search/providers/twitter.py
@@ -109,7 +109,6 @@ class TwitterTwitterProvider(ContentProvider):
             next_token = results['meta']['next_token'] if 'next_token' in results['meta'] else None
             more_data = next_token is not None
 
-
     @cache_by_kwargs()
     def _cached_query(self, endpoint: str, params: Dict = None) -> Dict:
         """
@@ -154,6 +153,7 @@ class TwitterTwitterProvider(ContentProvider):
             'reply_count': item['public_metrics']['reply_count'],
             'like_count': item['public_metrics']['like_count'],
             'quote_count': item['public_metrics']['quote_count'],
+            'content': item['text']
         }
 
     def normalized_count_over_time(self, query: str, start_date: dt.datetime, end_date: dt.datetime,

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ gunicorn==20.1.*
 whitenoise==6.2.*
 sentry-sdk==1.11.*
 requests  # let the other dependencies sort out which is the right version
-wayback-news-search==0.1.*
+wayback-news-search==1.0.*


### PR DESCRIPTION
Updated to new version that uses public API endpoint URL.
Also tweaked unit tests to pass, and had to remove a cache that wasn't working with a yield call.