### PR TITLE
Send the search immediately when the url is entered with search params

### DIFF
--- a/mcweb/frontend/src/features/search/Search.jsx
+++ b/mcweb/frontend/src/features/search/Search.jsx
@@ -126,7 +126,7 @@ export default function Search() {
                       { options: { replace: true } },
                     );
                     dispatch(searchApi.util.resetApiState());
-                    dispatch(setSearchTime(dayjs().format()));
+                    dispatch(setSearchTime(dayjs().unix()));
                   } catch {
                     enqueueSnackbar('Query is empty', { variant: 'error' });
                   }

--- a/mcweb/frontend/src/features/search/query/querySlice.js
+++ b/mcweb/frontend/src/features/search/query/querySlice.js
@@ -19,7 +19,7 @@ const querySlice = createSlice({
     collections: DEFAULT_COLLECTIONS,
     previewCollections: DEFAULT_COLLECTIONS,
     sources: [],
-    lastSearchTime: dayjs().format(),
+    lastSearchTime: 0,
     anyAll: 'any',
     advanced: false,
   },

--- a/mcweb/frontend/src/features/search/util/setSearchQuery.js
+++ b/mcweb/frontend/src/features/search/util/setSearchQuery.js
@@ -11,6 +11,7 @@ import {
   setPreviewSelectedMedia,
   setAdvanced,
   setQueryString,
+  setSearchTime,
 } from '../query/querySlice';
 
 const formatQuery = (query) => {
@@ -94,6 +95,7 @@ const setSearchQuery = (searchParams) => {
     dispatch(setPreviewSelectedMedia(collections));
   }
 
+  dispatch(setSearchTime(dayjs().unix()));
   return null;
 };
 


### PR DESCRIPTION
- In setSearchQuery.js, set the lastSearchTime, to trigger results components to send search.