### PR TITLE
Clean up search api

### DIFF
--- a/mcweb/backend/search/providers/exceptions.py
+++ b/mcweb/backend/search/providers/exceptions.py
@@ -11,3 +11,8 @@ class UnknownProviderException(Exception):
 class UnavailableProviderException(Exception):
     def __init__(self, platform, source):
         super().__init__("Unavailable provider {} from {}".format(platform, source))
+
+
+class QueryingEverythingUnsupportedQuery(Exception):
+    def __init__(self):
+        super().__init__("Can't query everything")

--- a/mcweb/backend/search/providers/onlinenews.py
+++ b/mcweb/backend/search/providers/onlinenews.py
@@ -14,7 +14,6 @@ from util.cache import cache_by_kwargs
 Source = apps.get_model('sources', 'Source')
 Collection = apps.get_model('sources', 'Collection')
 
-
 class OnlineNewsMediaCloudProvider(ContentProvider):
 
     def __init__(self, api_key):
@@ -23,6 +22,9 @@ class OnlineNewsMediaCloudProvider(ContentProvider):
         self._api_key = api_key
         self._mc_client = MediaCloud(api_key)
         self._mc_client.TIMEOUT_SECS = 300  # give backend 5 mins to responsd
+
+    def everything_query(self) -> str:
+        return '*'
 
     @cache_by_kwargs()
     def sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 20,
@@ -182,6 +184,9 @@ class OnlineNewsWaybackMachineProvider(ContentProvider):
         super(OnlineNewsWaybackMachineProvider, self).__init__()
         self._client = SearchApiClient(self.DEFAULT_COLLECTION)
         self._logger = logging.getLogger(__name__)
+
+    def everything_query(self) -> str:
+        return '*'
 
     @cache_by_kwargs()
     def sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 20,

--- a/mcweb/backend/search/providers/provider.py
+++ b/mcweb/backend/search/providers/provider.py
@@ -5,6 +5,7 @@ import datetime
 from operator import itemgetter
 from abc import ABC
 import mediacloud.api
+from .exceptions import QueryingEverythingUnsupportedQuery
 
 # helpful for turning any date into the standard Media Cloud date format
 MC_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
@@ -18,6 +19,9 @@ class ContentProvider(ABC):
 
     def __init__(self):
         self._logger = logging.getLogger(__name__)
+
+    def everything_query(self) -> str:
+        raise QueryingEverythingUnsupportedQuery()
 
     def sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 20,
                **kwargs) -> List[Dict]:

--- a/mcweb/backend/search/providers/reddit.py
+++ b/mcweb/backend/search/providers/reddit.py
@@ -22,6 +22,9 @@ class RedditPushshiftProvider(ContentProvider):
         super(RedditPushshiftProvider, self).__init__()
         self._logger = logging.getLogger(__name__)
 
+    def everything_query(self) -> str:
+        return '*'
+
     def sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 20, **kwargs) -> List[Dict]:
         """
         Return a list of top submissions matching the query.

--- a/mcweb/backend/search/providers/youtube.py
+++ b/mcweb/backend/search/providers/youtube.py
@@ -33,6 +33,10 @@ class YouTubeYouTubeProvider(ContentProvider):
     def count_over_time(self, query: str, start_date: dt.datetime, end_date: dt.datetime, **kwargs) -> Dict:
         raise UnsupportedOperationException("The YouTube API doesn't support counts over time")
 
+    def normalized_count_over_time(self, query: str, start_date: dt.datetime, end_date: dt.datetime,
+                                   **kwargs) -> Dict:
+        raise UnsupportedOperationException("Can't search YouTube API for all videos in a timeframe")
+
     def count(self, query: str, start_date: dt.datetime, end_date: dt.datetime, **kwargs) -> int:
         """
         Count how many videos match the query.

--- a/mcweb/backend/search/urls.py
+++ b/mcweb/backend/search/urls.py
@@ -12,7 +12,6 @@ urlpatterns = [
     path('total-count', views.total_count),
     path('sample', views.sample),
     path('count-over-time', views.count_over_time),
-    path('normalized-count-over-time', views.normalized_count_over_time),
     path('download-counts-over-time-csv', views.download_counts_over_time_csv),
     path('download-all-content-csv', views.download_all_content_csv)
 ]

--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -51,10 +51,14 @@ def total_count(request):
 def count_over_time(request):
     start_date, end_date, query_str, collections, provider_name = parse_query(request)
     provider = providers.provider_by_name(provider_name)
-    count_attention_over_time = provider.count_over_time(query_str, start_date, end_date, collections=collections)
-    zero_filled_counts = fill_in_dates(start_date, end_date, count_attention_over_time['counts'])
-    count_attention_over_time['counts'] = zero_filled_counts
-    return HttpResponse(json.dumps({"count_over_time": count_attention_over_time}, default=str), content_type="application/json", status=200)
+    try:
+        results = provider.normalized_count_over_time(query_str, start_date, end_date, collections=collections)
+    except UnsupportedOperationException:
+        # for platforms that don't support querying over time
+        results = provider.count_over_time(query_str, start_date, end_date, collections=collections)
+    #logger.debug("NORMALIZED COUNT OVER TIME: %, %".format(start_date, end_date))
+    return HttpResponse(json.dumps({"count_over_time": results}, default=str), content_type="application/json",
+                        status=200)
 
 
 @handle_provider_errors
@@ -63,16 +67,8 @@ def sample(request):
     start_date, end_date, query_str, collections, provider_name = parse_query(request)
     provider = providers.provider_by_name(provider_name)
     sample_stories = provider.sample(query_str, start_date, end_date, collections=collections)
-    return HttpResponse(json.dumps({"sample": sample_stories }, default=str), content_type="application/json", status=200)
-
-@handle_provider_errors
-@require_http_methods(["POST"])
-def normalized_count_over_time(request):
-    start_date, end_date, query_str, collections, provider_name = parse_query(request)
-    provider = providers.provider_by_name(provider_name)
-    logger.debug("NORMALIZED COUNT OVER TIME: %, %".format(start_date, end_date))
-    counts_data = provider.normalized_count_over_time(query_str, start_date, end_date, collections=collections)
-    return HttpResponse(json.dumps({"count_over_time": counts_data }, default=str), content_type="application/json", status=200)
+    return HttpResponse(json.dumps({"sample": sample_stories }, default=str), content_type="application/json",
+                        status=200)
 
 
 @require_http_methods(["GET"])

--- a/mcweb/frontend/src/app/services/searchApi.js
+++ b/mcweb/frontend/src/app/services/searchApi.js
@@ -39,13 +39,6 @@ export const searchApi = createApi({
         body: { queryObject },
       }),
     }),
-    getNormalizedCountOverTime: builder.mutation({
-      query: (queryObject) => ({
-        url: 'normalized-count-over-time',
-        method: 'POST',
-        body: { queryObject },
-      }),
-    }),
     getSampleStories: builder.mutation({
       query: (queryObject) => ({
         url: 'sample',
@@ -65,5 +58,4 @@ export const {
   useGetTotalCountMutation,
   useGetCountOverTimeMutation,
   useGetSampleStoriesMutation,
-  useGetNormalizedCountOverTimeMutation,
 } = searchApi;

--- a/mcweb/frontend/src/features/search/results/TotalAttentionChart.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionChart.jsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import { useSelector } from 'react-redux';
@@ -62,8 +63,8 @@ export default function TotalAttentionChart({ data, normalized }) {
     }],
   };
   if (normalized) {
-    options.yAxis.labels.format = '{value: .1f}%';
-    options.series[0].data[0].dataLabels = { format: `{point.y: ${data} %}` };
+    options.yAxis.labels.format = '{value: .2f}%';
+    options.series[0].data[0].dataLabels = { format: `{point.y: ${data.toPrecision(4)} %}` };
   }
 
   return (
@@ -72,3 +73,8 @@ export default function TotalAttentionChart({ data, normalized }) {
     </div>
   );
 }
+
+TotalAttentionChart.propTypes = {
+  data: PropTypes.number.isRequired,
+  normalized: PropTypes.bool.isRequired,
+};

--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -12,8 +12,8 @@ import {
   PROVIDER_REDDIT_PUSHSHIFT, PROVIDER_NEWS_MEDIA_CLOUD, PROVIDER_NEWS_WAYBACK_MACHINE,
 } from '../util/platforms';
 
-const supportsNormalizedCount = (platform) => [PROVIDER_NEWS_MEDIA_CLOUD, PROVIDER_NEWS_WAYBACK_MACHINE,
-  PROVIDER_REDDIT_PUSHSHIFT].includes(platform);
+export const supportsNormalizedCount = (platform) => [PROVIDER_NEWS_MEDIA_CLOUD,
+  PROVIDER_NEWS_WAYBACK_MACHINE, PROVIDER_REDDIT_PUSHSHIFT].includes(platform);
 
 function TotalAttentionResults() {
   const {
@@ -91,7 +91,7 @@ function TotalAttentionResults() {
         <div className="col-8">
           {(error) && (
             <Alert severity="warning">
-              Our access doesn&apos;t support fetching attention over time data.
+              Our access doesn&apos;t support fetching total attention data.
               (
               {error.data.note}
               )

--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -7,8 +7,13 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import TotalAttentionChart from './TotalAttentionChart';
 import queryGenerator from '../util/queryGenerator';
-import { useGetTotalCountMutation, useGetNormalizedCountOverTimeMutation } from '../../../app/services/searchApi';
-import { PROVIDER_NEWS_MEDIA_CLOUD, PROVIDER_NEWS_WAYBACK_MACHINE } from '../util/platforms';
+import { useGetTotalCountMutation } from '../../../app/services/searchApi';
+import {
+  PROVIDER_REDDIT_PUSHSHIFT, PROVIDER_NEWS_MEDIA_CLOUD, PROVIDER_NEWS_WAYBACK_MACHINE,
+} from '../util/platforms';
+
+const supportsNormalizedCount = (platform) => [PROVIDER_NEWS_MEDIA_CLOUD, PROVIDER_NEWS_WAYBACK_MACHINE,
+  PROVIDER_REDDIT_PUSHSHIFT].includes(platform);
 
 function TotalAttentionResults() {
   const {
@@ -39,40 +44,15 @@ function TotalAttentionResults() {
 
   const [query, { isLoading, data, error }] = useGetTotalCountMutation();
 
-  const [normalizedQuery, nqResult] = useGetNormalizedCountOverTimeMutation();
-
   const collectionIds = collections.map((collection) => collection.id);
 
-  const normalizeData = (oldData) => {
-    let newData;
-    if (platform === PROVIDER_NEWS_MEDIA_CLOUD || platform === PROVIDER_NEWS_WAYBACK_MACHINE) {
-      const { total } = oldData;
-      const normalizedTotal = oldData.normalized_total;
-      if (normalized) {
-        newData = (Math.round(((total / normalizedTotal) + Number.EPSILON) * 10000) / 100);
-      } else {
-        newData = total;
-      }
-    } else {
-      newData = oldData.count;
-    }
-    return newData;
-  };
+  // using EPSILON in the denominator here prevents against div by zero errors
+  // (which returns infinity in JS)
+  const normalizeData = (oldData) => 100 * (oldData.count.relevant
+    / (oldData.count.total + Number.EPSILON));
 
   useEffect(() => {
-    if ((queryList[0].length !== 0 || (advanced && queryString !== 0))
-      && (platform === PROVIDER_NEWS_MEDIA_CLOUD
-      || platform === PROVIDER_NEWS_WAYBACK_MACHINE)) {
-      normalizedQuery({
-        query: fullQuery,
-        startDate,
-        endDate,
-        collections: collectionIds,
-        sources,
-        platform,
-      });
-      setNormalized(true);
-    } else if ((queryList[0].length !== 0) || (advanced && queryString !== 0)) {
+    if ((queryList[0].length !== 0) || (advanced && queryString !== 0)) {
       query({
         query: fullQuery,
         startDate,
@@ -80,13 +60,12 @@ function TotalAttentionResults() {
         collections: collectionIds,
         sources,
         platform,
-
       });
-      setNormalized(false);
+      setNormalized(supportsNormalizedCount(platform));
     }
   }, [lastSearchTime]);
 
-  if (isLoading || nqResult.isLoading) {
+  if (isLoading) {
     return (
       <div>
         {' '}
@@ -96,7 +75,7 @@ function TotalAttentionResults() {
     );
   }
 
-  if (!data && !nqResult.data && !error && !nqResult.error) return null;
+  if (!data && !error) return null;
 
   return (
     <div className="results-item-wrapper">
@@ -110,19 +89,19 @@ function TotalAttentionResults() {
           </p>
         </div>
         <div className="col-8">
-          {(error || nqResult.error) && (
+          {(error) && (
             <Alert severity="warning">
               Our access doesn&apos;t support fetching attention over time data.
               (
-              {error.data.note || nqResult.error.data.note}
+              {error.data.note}
               )
             </Alert>
           )}
-          {(error === undefined && nqResult.error === undefined) && (
-          <TotalAttentionChart
-            data={data ? normalizeData(data) : normalizeData(nqResult.data.count_over_time)}
-            normalized={normalized}
-          />
+          {(error === undefined) && (
+            <TotalAttentionChart
+              data={(normalized) ? normalizeData(data) : data.count.relevant}
+              normalized={normalized}
+            />
           )}
           <div className="clearfix">
             {(platform === PROVIDER_NEWS_MEDIA_CLOUD

--- a/mcweb/frontend/src/features/search/resultsSlice.js
+++ b/mcweb/frontend/src/features/search/resultsSlice.js
@@ -9,13 +9,13 @@ const resultsSlice = createSlice({
     sample: null,
   },
   reducers: {
-    setQueryResults: (state, { payload }) => {
-      state.count = payload.count;
-      state.countOverTime = payload.count_over_time;
-      state.sample = payload.sample;
-      state.words = payload.words;
-    },
-
+    setQueryResults: (state, { payload }) => ({
+      ...state,
+      count: payload.count,
+      countOverTime: payload.count_over_time,
+      sample: payload.sample,
+      words: payload.words,
+    }),
   },
 });
 


### PR DESCRIPTION
The calls to total count and count over time were a bit intermixed in a confusing way. I centralized the counts so there are simpler queries that just return the raw counts and the total or normalized ones on the server as they can. Then the JS just decides what to do based on whether the data is there or not. I believe this will make things more debuggable (it is helping me on the user quota work).