### PR TITLE
add support for Matomo analytics codes (fix #119)

### DIFF
--- a/mcweb/.env-template
+++ b/mcweb/.env-template
@@ -18,3 +18,7 @@ MEDIA_CLOUD_API_KEY=MY_MEDIA_CLOUD_API_KEY
 
 # Sentry logging, only needs to be set in prod 
 SENTRY_DSN=""
+
+# Analytics codes for tracking
+ANALYTICS_MATOMO_DOMAIN=//url.to.my.server/
+ANALYTICS_MATOMO_SITE_ID=ID_OF_SITE_IN_MATOMO

--- a/mcweb/frontend/templates/frontend/index.html
+++ b/mcweb/frontend/templates/frontend/index.html
@@ -24,6 +24,22 @@
 
         <script src="{% static "frontend/main.js" %}"></script>
 
+
+        {% if analytics_matomo_domain and analytics_matomo_id %}
+            <script src="{% static "frontend/main.js" %}">
+              var _paq = window._paq = window._paq || [];
+              /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+              _paq.push(['trackPageView']);
+              _paq.push(['enableLinkTracking']);
+              (function() {
+                var u="{{ analytics_matomo_domain }}";
+                _paq.push(['setTrackerUrl', u+'matomo.php']);
+                _paq.push(['setSiteId', {{ analytics_matomo_id }}]);
+                var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+              })();
+            </script>
+        {%  endif %}
     </body>
 
 </html>

--- a/mcweb/frontend/views.py
+++ b/mcweb/frontend/views.py
@@ -1,11 +1,14 @@
 import logging
 from django.shortcuts import render
 from django.views.decorators.csrf import ensure_csrf_cookie
-
+import os
 from settings import VERSION
 import backend.search.providers as providers
 
 logger = logging.getLogger(__name__)
+
+ANALYTICS_MATOMO_DOMAIN = os.getenv('ANALYTICS_MATOMO_DOMAIN', None)
+ANALYTICS_MATOMO_SITE_ID = os.getenv('ANALYTICS_MATOMO_SITE_ID', None)
 
 
 @ensure_csrf_cookie
@@ -13,5 +16,7 @@ def index(request):
     # the main entry point for the web app - it just renders the index HTML file to load all the JS
     return render(request, 'frontend/index.html', dict(
         version=VERSION,
-        providers=providers.available_provider_names()
+        providers=providers.available_provider_names(),
+        analytics_matomo_domain=ANALYTICS_MATOMO_DOMAIN,
+        analytics_matomo_id=ANALYTICS_MATOMO_SITE_ID,
     ))


### PR DESCRIPTION
Just need to set two env-vars on server:
```
ANALYTICS_MATOMO_DOMAIN=//analytics.mediacloud.org/
ANALYTICS_MATOMO_SITE_ID=1
```