### PR TITLE
add content language detection for Twitter and Reddit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ tmp/*.csv
 
 .vscode
 package-lock.json
+
+# language detected model downloaded by install script
+mcweb/backend/search/providers/language/lid.176.bin

--- a/install.sh
+++ b/install.sh
@@ -3,3 +3,5 @@ python mcweb/manage.py migrate
 npm run build
 python mcweb/manage.py collectstatic --noinput
 
+curl -SL https://dl.fbaipublicfiles.com/fasttext/supervised-models/lid.176.bin -o lid.176.bin
+mv lid.176.bin mcweb/backend/search/providers/language/

--- a/mcweb/backend/search/providers/language/__init__.py
+++ b/mcweb/backend/search/providers/language/__init__.py
@@ -1,0 +1,24 @@
+import fasttext
+from typing import List
+import os
+
+# this install.sh script will have downloaded and moved this to the proper place
+MODEL_NAME = 'lid.176.bin'
+
+this_dir = os.path.dirname(os.path.realpath(__file__))
+
+try:
+    model = fasttext.load_model(os.path.join(this_dir, MODEL_NAME))
+except ValueError:
+    raise ValueError("Couldn't load fasttext lang detection model - make sure install.sh ran and saved to {}".format(
+        os.path.join(this_dir, MODEL_NAME)))
+
+
+def detect(text: str) -> List:
+    cleaned_text = text.replace('\n', '')
+    return model.predict([cleaned_text])  # [['__label__en']], [array([0.9331119], dtype=float32)]
+
+
+def top_detected(text: str) -> str:
+    guesses = detect(text)
+    return guesses[0][0][0].replace('__label__', '')

--- a/mcweb/backend/search/providers/reddit.py
+++ b/mcweb/backend/search/providers/reddit.py
@@ -7,6 +7,7 @@ import logging
 from .provider import ContentProvider, MC_DATE_FORMAT
 from .exceptions import UnsupportedOperationException
 from util.cache import cache_by_kwargs
+from .language import top_detected
 
 logger = logging.getLogger(__file__)
 
@@ -120,7 +121,7 @@ class RedditPushshiftProvider(ContentProvider):
             'last_updated': RedditPushshiftProvider._to_date(item['updated_utc']).strftime(MC_DATE_FORMAT) if 'updated_utc' in item else None,
             'author': item['author'],
             'subreddit': item['subreddit'],
-            'language': None  # Reddit doesn't tell us the language, TODO: use langauge detection to guess?
+            'language': top_detected(item['title'])  # Reddit doesn't tell us the language, so guess it
         }
 
     @classmethod

--- a/mcweb/backend/search/providers/test/test_reddit.py
+++ b/mcweb/backend/search/providers/test/test_reddit.py
@@ -13,7 +13,7 @@ class RedditPushshiftProviderTest(TestCase):
         results = self._provider.count("Trump", dt.datetime.strptime("2019-01-01", "%Y-%m-%d"),
                                         dt.datetime.strptime("2019-02-01", "%Y-%m-%d"))
         assert results > 0
-    """
+
     def test_sample(self):
         results = self._provider.sample("Trump", dt.datetime.strptime("2019-01-01", "%Y-%m-%d"),
                                         dt.datetime.strptime("2019-02-01", "%Y-%m-%d"))
@@ -21,7 +21,10 @@ class RedditPushshiftProviderTest(TestCase):
         for post in results:
             assert last_score >= post['score']
             last_score = post['score']
+            assert 'language' in post
+            assert len(post['language']) == 2
 
+    """
     def test_count_over_time(self):
         results = self._provider.count_over_time("Trump", dt.datetime.strptime("2019-01-01", "%Y-%m-%d"),
                                                  dt.datetime.strptime("2019-02-01", "%Y-%m-%d"))

--- a/mcweb/backend/search/providers/test/test_twitter.py
+++ b/mcweb/backend/search/providers/test/test_twitter.py
@@ -20,6 +20,8 @@ class TwitterTwitterProviderTest(TestCase):
         for tweet in results:
             assert 'content' in tweet
             assert len(tweet['content']) > 0
+            assert 'language' in tweet
+            assert len(tweet['language']) == 2
 
     def test_count(self):
         results = self._provider.count(TERM, start_date=self._5_days_ago, end_date=self._now)

--- a/mcweb/backend/search/providers/twitter.py
+++ b/mcweb/backend/search/providers/twitter.py
@@ -7,7 +7,7 @@ import logging
 from .provider import ContentProvider
 from .exceptions import UnsupportedOperationException
 from util.cache import cache_by_kwargs
-
+from .language import top_detected
 
 TWITTER_API_URL = 'https://api.twitter.com/2/'
 
@@ -148,7 +148,7 @@ class TwitterTwitterProvider(ContentProvider):
             'url': link,
             'last_updated': dateparser.parse(item['created_at']),
             'author': item['author']['name'],
-            'language': None,
+            'language': top_detected(item['text']),  # guess the language cause Twitter oddly doesn't
             'retweet_count': item['public_metrics']['retweet_count'],
             'reply_count': item['public_metrics']['reply_count'],
             'like_count': item['public_metrics']['like_count'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ whitenoise==6.2.*
 sentry-sdk==1.11.*
 requests  # let the other dependencies sort out which is the right version
 wayback-news-search==1.0.*
+fasttext==0.9.*


### PR DESCRIPTION
This uses the `fasttext` library to very quickly guess the language of content from Twitter and Reddit. Neither tells us the language they have guessed. We need this for useful analysis, and to support later stop-word removal if we can do top terms lists.

Note: this required downloading a language model - I have added that step to the install.sh script so make sure to run that locally to get the model saved properly.