### PR TITLE
Date format fix

### DIFF
--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -29,9 +29,7 @@ def parse_query(request, http_method: str = 'POST') -> tuple:
     collections = payload["collections"]
     sources = payload["sources"]
     start_date = payload["startDate"]
-    print("parse", str(start_date))
     start_date = dt.datetime.strptime(start_date, '%m/%d/%Y')
     end_date = payload["endDate"]
-    # print(end_date)
     end_date = dt.datetime.strptime(end_date, '%m/%d/%Y')
     return start_date, end_date, query_str, collections, provider_name

--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -29,7 +29,9 @@ def parse_query(request, http_method: str = 'POST') -> tuple:
     collections = payload["collections"]
     sources = payload["sources"]
     start_date = payload["startDate"]
+    print("parse", str(start_date))
     start_date = dt.datetime.strptime(start_date, '%m/%d/%Y')
     end_date = payload["endDate"]
+    # print(end_date)
     end_date = dt.datetime.strptime(end_date, '%m/%d/%Y')
     return start_date, end_date, query_str, collections, provider_name

--- a/mcweb/frontend/src/features/search/Search.jsx
+++ b/mcweb/frontend/src/features/search/Search.jsx
@@ -130,7 +130,7 @@ export default function Search() {
                     { options: { replace: true } },
                   );
                   dispatch(searchApi.util.resetApiState());
-                  dispatch(setSearchTime(dayjs().format()));
+                  dispatch(setSearchTime(dayjs().unix()));
                 }}
               >
                 Search

--- a/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
+++ b/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
@@ -13,7 +13,6 @@ export default function SearchDatePicker() {
   const dispatch = useDispatch();
   const { enqueueSnackbar } = useSnackbar();
   const { platform, startDate, endDate } = useSelector((state) => state.query);
-
   const handleChangeFromDate = (newValue) => {
     dispatch(setStartDate(dayjs(newValue).format('MM/DD/YYYY')));
   };

--- a/mcweb/frontend/src/features/search/query/querySlice.js
+++ b/mcweb/frontend/src/features/search/query/querySlice.js
@@ -19,7 +19,7 @@ const querySlice = createSlice({
     collections: DEFAULT_COLLECTIONS,
     previewCollections: DEFAULT_COLLECTIONS,
     sources: [],
-    lastSearchTime: 0,
+    lastSearchTime: dayjs().unix(),
     anyAll: 'any',
     advanced: false,
   },

--- a/mcweb/frontend/src/features/search/util/setSearchQuery.js
+++ b/mcweb/frontend/src/features/search/util/setSearchQuery.js
@@ -15,6 +15,8 @@ import {
   setSearchTime,
 } from '../query/querySlice';
 
+const customParseFormat = require('dayjs/plugin/customParseFormat');
+
 const formatQuery = (query) => {
   if (query === null) return null;
   const finalQuery = new Array(query.length);
@@ -45,6 +47,7 @@ const formatCollections = (collections) => collections.map((collection) => {
 });
 
 const setSearchQuery = (searchParams) => {
+  dayjs.extend(customParseFormat);
   const dispatch = useDispatch();
   // param keys are set in ./urlSerializer.js
   let query = searchParams.get('q');
@@ -66,9 +69,8 @@ const setSearchQuery = (searchParams) => {
 
   queryString = queryString ? decode(queryString) : null;
 
-  startDate = startDate ? dayjs(startDate).format('MM/DD/YYYY') : null;
-  endDate = endDate ? dayjs(endDate).format('MM/DD/YYYY') : null;
-
+  startDate = startDate ? dayjs(startDate, 'MM/DD/YYYY').format('MM/DD/YYYY') : null;
+  endDate = endDate ? dayjs(endDate, 'MM/DD/YYYY').format('MM/DD/YYYY') : null;
   collections = collections ? decode(collections).split(',') : null;
   collections = formatCollections(collections);
 

--- a/mcweb/frontend/src/features/search/util/urlSerializer.js
+++ b/mcweb/frontend/src/features/search/util/urlSerializer.js
@@ -35,7 +35,6 @@ const urlSerializer = (queryObject) => {
 
   const start = dayjs(startDate).format('MM-DD-YYYY');
   const end = dayjs(endDate).format('MM-DD-YYYY');
-  console.log(start, end);
   let collectionsFormatted = formatCollections(collections).join(',');
   collectionsFormatted = encode(collectionsFormatted);
 

--- a/mcweb/frontend/src/features/search/util/urlSerializer.js
+++ b/mcweb/frontend/src/features/search/util/urlSerializer.js
@@ -35,7 +35,7 @@ const urlSerializer = (queryObject) => {
 
   const start = dayjs(startDate).format('MM-DD-YYYY');
   const end = dayjs(endDate).format('MM-DD-YYYY');
-
+  console.log(start, end);
   let collectionsFormatted = formatCollections(collections).join(',');
   collectionsFormatted = encode(collectionsFormatted);
 


### PR DESCRIPTION
- fix date format error for safari and firefox browsers
  - date could not be parsed from the url properly in setSearchQuery.js, adding dayjs extenstion allowed the date to be parsed in these browsers.