### PR TITLE
Rearrange start script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+curl -SL https://dl.fbaipublicfiles.com/fasttext/supervised-models/lid.176.bin -o lid.176.bin
+mv lid.176.bin mcweb/backend/search/providers/language/
 python mcweb/manage.py migrate
 npm run build
 python mcweb/manage.py collectstatic --noinput
 
-curl -SL https://dl.fbaipublicfiles.com/fasttext/supervised-models/lid.176.bin -o lid.176.bin
-mv lid.176.bin mcweb/backend/search/providers/language/
+


### PR DESCRIPTION
- rearrange install.sh script to run fasttext before python commands.