### PR TITLE
Get/use RSS_FETCHER_{USER,PASS,URL} vars from environment

### DIFF
--- a/mcweb/backend/sources/api.py
+++ b/mcweb/backend/sources/api.py
@@ -2,6 +2,7 @@ import time
 import json
 import os
 import requests
+import requests.auth
 from django.db.models import Count
 from django.shortcuts import get_object_or_404
 from rest_framework.response import Response
@@ -16,6 +17,13 @@ from .serializer import CollectionSerializer, FeedsSerializer, SourcesSerializer
 from backend.util import csv_stream
 from util.cache import cache_by_kwargs
 from .models import Collection, Feed, Source
+
+
+# Same env var names as rss-fetcher config:
+RSS_FETCHER_USER = os.getenv('RSS_FETCHER_USER', None)
+RSS_FETCHER_PASS = os.getenv('RSS_FETCHER_PASS', None)
+# Allows testing against alternate (eg; dev, staging) instances of rss-fetcher:
+RSS_FETCHER_URL  = os.getenv('RSS_FETCHER_URL', 'https://rss-fetcher.tarbell.mediacloud.org')
 
 
 def _featured_collection_ids() -> List:
@@ -83,7 +91,11 @@ class FeedsViewSet(viewsets.ModelViewSet):
     @action(methods=['post'], detail=False)
     def sources_feeds(self, request):
         source_id = request.data["source_id"]
-        response = requests.get(f'https://rss-fetcher.tarbell.mediacloud.org/api/sources/{source_id}/feeds')
+        if RSS_FETCHER_USER and RSS_FETCHER_PASS:
+            auth = requests.auth.HTTPBasicAuth(RSS_FETCHER_USER, RSS_FETCHER_PASS)
+        else:
+            auth = None
+        response = requests.get(f'{RSS_FETCHER_URL}/api/sources/{source_id}/feeds', auth=auth)
         feeds = response.json()
         feeds = feeds["results"]
         return Response({"feeds": feeds})


### PR DESCRIPTION
Implement sending basic auth to rss-fetcher API.

Gets user/password via  RSS_FETCHER_{USER,PASS} environment variables (send no auth unless both set). Also adds RSS_FETCHER_URL (with default), so development/test web-search instance can refer to a development/test rss-fetcher instance!