### PR TITLE
Hooks error fixes

### DIFF
--- a/mcweb/frontend/src/App.jsx
+++ b/mcweb/frontend/src/App.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import {
   Route, Navigate, useLocation, Routes, useSearchParams,
 } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import Homepage from './features/homepage/Homepage';
 
 import Header from './features/header/Header';
@@ -32,17 +32,16 @@ import setSearchQuery from './features/search/util/setSearchQuery';
 function App() {
   const { lastSearchTime } = useSelector((state) => state.query);
   const [searchParams] = useSearchParams();
-  const [trigger, setTrigger] = useState(false);
+  const [trigger, setTrigger] = useState(true);
+
+  const dispatch = useDispatch();
+
   useEffect(() => {
-    if (searchParams.get('start')) {
-      setTrigger(true);
+    if (trigger && searchParams.get('start')) {
+      setSearchQuery(searchParams, dispatch);
+      setTrigger(false);
     }
   }, [lastSearchTime]);
-
-  if (trigger && searchParams.get('start')) {
-    setSearchQuery(searchParams);
-    setTrigger(false);
-  }
 
   return (
     <>

--- a/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
+++ b/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useEffect } from 'react';
 import TextField from '@mui/material/TextField';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
@@ -21,10 +21,12 @@ export default function SearchDatePicker() {
     dispatch(setEndDate(dayjs(newValue).format('MM/DD/YYYY')));
   };
 
-  if (dayjs(endDate) > latestAllowedEndDate(platform)) {
-    handleChangeToDate(latestAllowedEndDate(platform));
-    enqueueSnackbar('Changed your end date to match this platform limit', { variant: 'warning' });
-  }
+  useEffect(() => {
+    if (dayjs(endDate) > latestAllowedEndDate(platform)) {
+      handleChangeToDate(latestAllowedEndDate(platform));
+      enqueueSnackbar('Changed your end date to match this platform limit', { variant: 'warning' });
+    }
+  }, [platform]);
 
   return (
     <>

--- a/mcweb/frontend/src/features/search/util/setSearchQuery.js
+++ b/mcweb/frontend/src/features/search/util/setSearchQuery.js
@@ -42,13 +42,13 @@ const sizeQuery = (query) => {
 };
 
 const formatCollections = (collections) => collections.map((collection) => {
-  const [id, name] = collection.split('>');
+  let [id, name] = collection.split('>');
+  id = Number(id);
   return { id, name };
 });
 
-const setSearchQuery = (searchParams) => {
+const setSearchQuery = (searchParams, dispatch) => {
   dayjs.extend(customParseFormat);
-  const dispatch = useDispatch();
   // param keys are set in ./urlSerializer.js
   let query = searchParams.get('q');
   let negatedQuery = searchParams.get('nq');


### PR DESCRIPTION
- Fix hooks warnings:
  - "Warning: React has detected a change in the order of Hooks called by App. This will lead to bugs and errors if not fixed. 
      For more information, read the Rules of Hooks: https://reactjs.org/link/rules-of-hooks"
    - This warning was fixed by passing dispatch as a param to setSearchQuery
   - "Warning: Cannot update a component (PlatformPicker) while rendering a different component (App). To locate the bad 
      setState() call inside App, follow the stack trace as described in https://reactjs.org/link/setstate-in-render"
    - this warning was fixed by sending setSearchQuery in a useEffect in App
  - Fixed warning when switching to wayback platform
    - put useEffect in date picker to update whenever platform changes