### PR TITLE
Re: Add Icons to more Buttons #147

### DIFF
--- a/mcweb/frontend/src/features/collections/CollectionHeader.jsx
+++ b/mcweb/frontend/src/features/collections/CollectionHeader.jsx
@@ -3,7 +3,7 @@ import { CircularProgress, Button } from '@mui/material';
 import * as React from 'react';
 import dayjs from 'dayjs';
 import ShieldIcon from '@mui/icons-material/Shield';
-import SearchIcon from '@mui/icons-material/Search';
+import SearchIcon from '@mui/icons-material/Search'; 
 import LockOpenIcon from '@mui/icons-material/LockOpen';
 import { Outlet, Link, useParams } from 'react-router-dom';
 import { useGetCollectionQuery } from '../../app/services/collectionsApi';
@@ -55,7 +55,7 @@ export default function CollectionHeader() {
         <div className="container">
           <div className="row">
             <div className="col-12">
-              <Button variant="outlined" endIcon={<SearchIcon />}>
+              <Button variant="outlined" endIcon={<SearchIcon />}> 
                 <a
                   href={`/search/${urlSerializer({
                     queryList: defaultPlatformQuery(collection.platform),

--- a/mcweb/frontend/src/features/collections/CollectionHeader.jsx
+++ b/mcweb/frontend/src/features/collections/CollectionHeader.jsx
@@ -3,6 +3,7 @@ import { CircularProgress, Button } from '@mui/material';
 import * as React from 'react';
 import dayjs from 'dayjs';
 import ShieldIcon from '@mui/icons-material/Shield';
+import SearchIcon from '@mui/icons-material/Search';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
 import { Outlet, Link, useParams } from 'react-router-dom';
 import { useGetCollectionQuery } from '../../app/services/collectionsApi';
@@ -54,7 +55,7 @@ export default function CollectionHeader() {
         <div className="container">
           <div className="row">
             <div className="col-12">
-              <Button variant="outlined">
+              <Button variant="outlined" endIcon={<SearchIcon />}>
                 <a
                   href={`/search/${urlSerializer({
                     queryList: defaultPlatformQuery(collection.platform),

--- a/mcweb/frontend/src/features/collections/util/DownloadSourcesCsv.jsx
+++ b/mcweb/frontend/src/features/collections/util/DownloadSourcesCsv.jsx
@@ -9,7 +9,7 @@ function DownloadSourcesCsv({ collectionId }) {
   };
   return (
 
-    <Button variant="outlined" endIcon={<DownloadIcon />} onClick={() => handleDownloadRequest()}>
+    <Button variant="outlined" endIcon={<DownloadIcon />} onClick={() => handleDownloadRequest()}> 
       Download Source CSV
     </Button>
   );

--- a/mcweb/frontend/src/features/collections/util/DownloadSourcesCsv.jsx
+++ b/mcweb/frontend/src/features/collections/util/DownloadSourcesCsv.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '@mui/material/Button';
+import DownloadIcon from '@mui/icons-material/Download';
 
 function DownloadSourcesCsv({ collectionId }) {
   const handleDownloadRequest = () => {
@@ -8,7 +9,7 @@ function DownloadSourcesCsv({ collectionId }) {
   };
   return (
 
-    <Button variant="outlined" onClick={() => handleDownloadRequest()}>
+    <Button variant="outlined" endIcon={<DownloadIcon />} onClick={() => handleDownloadRequest()}>
       Download Source CSV
     </Button>
   );

--- a/mcweb/frontend/src/features/header/Header.jsx
+++ b/mcweb/frontend/src/features/header/Header.jsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import Button from '@mui/material/Button';
 import { NavLink, Link } from 'react-router-dom';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
+// import BookmarkIcon from '@mui/icons-material/Bookmark';
+// endIcon={<BookmarkIcon />}
 import UserMenu from './UserMenu';
 import { assetUrl } from '../ui/uiUtil';
 import Permissioned, { ROLE_STAFF } from '../auth/Permissioned';
@@ -25,7 +27,7 @@ function Header() {
                 {pages.map((page) => (
                   <li key={page}>
                     <NavLink to={page} key={page} className={({ isActive }) => (isActive ? 'active' : undefined)}>
-                      <Button variant="text">{page}</Button>
+                      <Button variant="text" >{page}</Button>
                     </NavLink>
                   </li>
                 ))}

--- a/mcweb/frontend/src/features/header/Header.jsx
+++ b/mcweb/frontend/src/features/header/Header.jsx
@@ -3,7 +3,7 @@ import Button from '@mui/material/Button';
 import { NavLink, Link } from 'react-router-dom';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
 // import BookmarkIcon from '@mui/icons-material/Bookmark';
-// endIcon={<BookmarkIcon />}
+// endIcon={<BookmarkIcon />} 
 import UserMenu from './UserMenu';
 import { assetUrl } from '../ui/uiUtil';
 import Permissioned, { ROLE_STAFF } from '../auth/Permissioned';

--- a/mcweb/frontend/src/features/homepage/Homepage.jsx
+++ b/mcweb/frontend/src/features/homepage/Homepage.jsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import Button from '@mui/material/Button';
 import { Link } from 'react-router-dom';
 import { assetUrl } from '../ui/uiUtil';
+import SearchIcon from '@mui/icons-material/Search';
 
 export default function Homepage() {
   return (
@@ -16,7 +17,7 @@ export default function Homepage() {
                 <br />
                 for media analysis.
               </h1>
-              <Link to="/search"><Button variant="contained">Search Now</Button></Link>
+              <Link to="/search"><Button variant="contained" endIcon={<SearchIcon />}>Search Now</Button></Link>
             </div>
           </div>
         </div>

--- a/mcweb/frontend/src/features/search/Search.jsx
+++ b/mcweb/frontend/src/features/search/Search.jsx
@@ -22,6 +22,8 @@ import AdvancedSearch from './query/AdvancedSearch';
 import MediaPicker from './query/media-picker/MediaPicker';
 import urlSerializer from './util/urlSerializer';
 import deactivateButton from './util/deactivateButton'; 
+import SearchIcon from '@mui/icons-material/Search';
+
 
 export default function Search() {
   const dispatch = useDispatch();
@@ -186,6 +188,7 @@ export default function Search() {
                 className="float-end"
                 variant="contained"
                 disabled={!show}
+                endIcon={<SearchIcon />}
                 onClick={() => {
                   navigate(
                     `/search${urlSerializer(queryObject)}`,

--- a/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
+++ b/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
@@ -15,6 +15,8 @@ import {
   PROVIDER_NEWS_WAYBACK_MACHINE,
 } from '../util/platforms';
 import { supportsNormalizedCount } from './TotalAttentionResults';
+import { Settings } from '@mui/icons-material';
+import DownloadIcon from '@mui/icons-material/Download';
 
 export default function CountOverTimeResults() {
   const {
@@ -123,7 +125,7 @@ export default function CountOverTimeResults() {
             <div className="float-start">
               {normalized && (
                 <div>
-                  <Button onClick={handleClick}>
+                  <Button onClick={handleClick}  endIcon={<Settings />}>
                     View Options
                   </Button>
                   <Menu
@@ -175,6 +177,7 @@ export default function CountOverTimeResults() {
           <div className="float-end">
             <Button
               variant="text"
+              endIcon={<DownloadIcon />}
               onClick={() => {
                 handleDownloadRequest({
                   query: fullQuery(),

--- a/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
+++ b/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
@@ -16,7 +16,7 @@ import {
 } from '../util/platforms';
 import { supportsNormalizedCount } from './TotalAttentionResults';
 import { Settings } from '@mui/icons-material';
-import DownloadIcon from '@mui/icons-material/Download';
+import DownloadIcon from '@mui/icons-material/Download'; 
 
 export default function CountOverTimeResults() {
   const {
@@ -125,7 +125,7 @@ export default function CountOverTimeResults() {
             <div className="float-start">
               {normalized && (
                 <div>
-                  <Button onClick={handleClick}  endIcon={<Settings />}>
+                  <Button onClick={handleClick}  endIcon={<Settings />}> 
                     View Options
                   </Button>
                   <Menu

--- a/mcweb/frontend/src/features/search/results/SampleStories.jsx
+++ b/mcweb/frontend/src/features/search/results/SampleStories.jsx
@@ -139,7 +139,7 @@ export default function SampleStories() {
         <div className="float-end">
           <Button
             variant="text"
-            endIcon={<DownloadIcon />}
+            endIcon={<DownloadIcon />} 
             onClick={() => {
               handleDownloadRequest({
                 query: fullQuery,

--- a/mcweb/frontend/src/features/search/results/SampleStories.jsx
+++ b/mcweb/frontend/src/features/search/results/SampleStories.jsx
@@ -4,6 +4,8 @@ import { useSelector } from 'react-redux';
 import dayjs from 'dayjs';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
+import DownloadIcon from '@mui/icons-material/Download';
+
 
 import { useGetSampleStoriesMutation } from '../../../app/services/searchApi';
 import queryGenerator from '../util/queryGenerator';
@@ -137,6 +139,7 @@ export default function SampleStories() {
         <div className="float-end">
           <Button
             variant="text"
+            endIcon={<DownloadIcon />}
             onClick={() => {
               handleDownloadRequest({
                 query: fullQuery,

--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -111,7 +111,7 @@ function TotalAttentionResults() {
               <div className="float-start">
                 {normalized && (
                   <div>
-                    <Button onClick={handleClick} endIcon={<Settings />}>
+                    <Button onClick={handleClick} endIcon={<Settings />}> 
                       View Options
                     </Button>
                     <Menu

--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -11,6 +11,7 @@ import { useGetTotalCountMutation } from '../../../app/services/searchApi';
 import {
   PROVIDER_REDDIT_PUSHSHIFT, PROVIDER_NEWS_MEDIA_CLOUD, PROVIDER_NEWS_WAYBACK_MACHINE,
 } from '../util/platforms';
+import { Settings } from '@mui/icons-material';
 
 export const supportsNormalizedCount = (platform) => [PROVIDER_NEWS_MEDIA_CLOUD,
   PROVIDER_NEWS_WAYBACK_MACHINE, PROVIDER_REDDIT_PUSHSHIFT].includes(platform);
@@ -110,7 +111,7 @@ function TotalAttentionResults() {
               <div className="float-start">
                 {normalized && (
                   <div>
-                    <Button onClick={handleClick}>
+                    <Button onClick={handleClick} endIcon={<Settings />}>
                       View Options
                     </Button>
                     <Menu

--- a/mcweb/frontend/src/features/sources/SourceHeader.jsx
+++ b/mcweb/frontend/src/features/sources/SourceHeader.jsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import dayjs from 'dayjs';
 import Button from '@mui/material/Button';
+import SearchIcon from '@mui/icons-material/Search';
+import HomeIcon from '@mui/icons-material/Home';
 import { CircularProgress } from '@mui/material';
 import { useParams, Link, Outlet } from 'react-router-dom';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
@@ -49,7 +51,7 @@ export default function SourceHeader() {
         <div className="container">
           <div className="row">
             <div className="col-12">
-              <Button variant="outlined">
+              <Button variant="outlined" endIcon={<SearchIcon />}>
                 <a
                   href={`/search/${urlSerializer({
                     queryList: defaultPlatformQuery(source.platform),
@@ -69,7 +71,7 @@ export default function SourceHeader() {
 
                 </a>
               </Button>
-              <Button variant="outlined">
+              <Button variant="outlined" endIcon={<HomeIcon />}>
                 <a href={source.homepage} target="_blank" rel="noreferrer">Visit Homepage</a>
               </Button>
               <Button variant="outlined">

--- a/mcweb/frontend/src/features/sources/SourceHeader.jsx
+++ b/mcweb/frontend/src/features/sources/SourceHeader.jsx
@@ -51,7 +51,7 @@ export default function SourceHeader() {
         <div className="container">
           <div className="row">
             <div className="col-12">
-              <Button variant="outlined" endIcon={<SearchIcon />}>
+              <Button variant="outlined" endIcon={<SearchIcon />}> 
                 <a
                   href={`/search/${urlSerializer({
                     queryList: defaultPlatformQuery(source.platform),


### PR DESCRIPTION
icons added 
- Homepage.jsx `SearchIcon` “Search Now”
- Search.jsx  `SearchIcon`  “Search” 
- DownloadSourcesCsv.jsx `DownloadIcon` “Download Source CSV”
- CollectionHeader.jsx `SearchIcon` “Search Icon”
- SourceHeader.jsx `SearchIcon` “Search Content”
- SourceHeader.jsx `HomeIcon`  “Visit Homepage”
- CountOverTimeResults.jsx `Settings`  “View Options” 
- CountOverTimeResults.jsx  `DownloadIcon` “Download CSV” 
- TotalAttentionResults.jsx `Settings`“View Options” 
- SampleStories.jsx  `DownloadIcon` “Download CSV of All Content” 

Having trouble adding icons to the headers since when you go to add the `BookmarkIcon` to the "Directory" header it is applied to both headers, "Search" included. Any suggestions around this without having to identically create two separate header buttons for search and directory? 