### PR TITLE
Tweaks for rss-fetcher feed sync

### DIFF
--- a/mcweb/backend/version.py
+++ b/mcweb/backend/version.py
@@ -1,0 +1,29 @@
+# three groups of imports, each alphabetized:
+
+# standard:
+import json
+import os
+import time
+
+# PyPI:
+from django.http import HttpResponse
+from django.views.decorators.http import require_http_methods
+
+# web-search/mcweb:
+from settings import VERSION
+
+
+@require_http_methods(["GET"])
+def version(request):
+    """
+    /api/version
+    simplest possible endpoint I could get working -phil
+    maybe require authentication?
+    """
+    # could include "uptime" (now - start_time)?
+    data = json.dumps({
+        'GIT_REV': os.environ.get('GIT_REV'),  # supplied by Dokku
+        'now': time.time(),                    # float: used by rss-fetcher
+        'version': VERSION,
+    })
+    return HttpResponse(data, content_type='application/json', status=200)

--- a/mcweb/settings.py
+++ b/mcweb/settings.py
@@ -37,7 +37,8 @@ SECRET_KEY = env("SECRET_KEY")
 
 DEBUG = environ.Env(DEBUG=(bool, False))
 
-ALLOWED_HOSTS = ['search.mediacloud.org', 'localhost']
+# app.process for access from rss-fetcher
+ALLOWED_HOSTS = ['search.mediacloud.org', 'localhost', 'mcweb.web']
 
 # Application definition
 

--- a/mcweb/urls.py
+++ b/mcweb/urls.py
@@ -1,11 +1,15 @@
 from django.urls import path, include, re_path
 from django.contrib import admin
 
+from backend.version import version
+
 urlpatterns = [
     path('', include('frontend.urls')), 
     path('admin', admin.site.urls),
     path('api/auth/', include('backend.users.urls')),
     path('api/search/', include('backend.search.urls')),
     path('api/sources/', include('backend.sources.urls')),
+    path('api/version', version),
     re_path(r'^(?:.*)/?', include('frontend.urls')),
 ]
+


### PR DESCRIPTION
mcweb/backend/sources/api.py: add modified_before filter to FeedViewSet

mcweb/urls.py: add /api/version (returns versions *AND* current system epoch time)
mcweb/backend/version.py: new; returns version and current time for use with modified_before

mcweb/settings.py: add mcweb.web as an ALLOWED_HOST (for access from rss-fetcher container)