### PR TITLE
Fix column titles for download sources, quick fix for upload sources

### DIFF
--- a/mcweb/backend/sources/api.py
+++ b/mcweb/backend/sources/api.py
@@ -253,7 +253,7 @@ class SourcesViewSet(viewsets.ModelViewSet):
             if len(row.keys()) <= 1:
                 continue
             # check if this is an update
-            if row.get('id', None) and (row['id'] > 0) and (row['id'] != 'null'):
+            if row.get('id', None) and (int(row['id']) > 0) and (row['id'] != 'null'):
                 existing_source = queryset.filter(pk=row['id'])
             else:
                 # if online news, need to make check if canonical domain exists
@@ -296,8 +296,8 @@ class SourcesViewSet(viewsets.ModelViewSet):
             for source in source_associations:
                 if first_page:  # send back columun names, which differ by platform
                     yield (['id', 'name', 'url_search_string', 'label', 'homepage', 'notes', 'platform',
-                'stories_per_week', 'first_story', 'publication_country', 'publication_state',
-                'primary_langauge', 'media_type'])
+                'stories_per_week', 'first_story', 'pub_country', 'pub_state',
+                'primary_language', 'media_type'])
                 yield ([source.id, source.name, source.url_search_string, source.label,
                              source.homepage, source.notes, source.platform, source.stories_per_week,
                              source.first_story, source.pub_country, source.pub_state, source.primary_language,

--- a/mcweb/backend/sources/models.py
+++ b/mcweb/backend/sources/models.py
@@ -81,22 +81,45 @@ class Source(models.Model):
         Source._set_from_dict(self, source_info)
         self.save()
         return self
-
+    
     @classmethod
     def _set_from_dict(cls, obj, source: Dict):
-        obj.name = source.get("name", None)
-        obj.platform = source.get("platform", None)
-        obj.url_search_string = source.get("url_search_string", None)
-        obj.label = source.get("label", None)
-        obj.homepage = source.get("homepage", None)
-        obj.notes = source.get("notes", None)
-        obj.service = source.get("service", None)
-        obj.stories_per_week = source.get("stories_per_week", None)
-        obj.pub_country = source.get("pub_country", None)
-        obj.pub_state = source.get("pub_state", None)
-        obj.primary_language = source.get("primary_language", None)
-        obj.media_type = source.get("media_type", None)
-
+        name = source.get("name", None)
+        if name is not None and len(name) > 0:
+            obj.name = name
+        platform = source.get("platform", None)
+        if platform is not None and len(platform) > 0:
+            obj.platform = platform
+        url_search_string = source.get("url_search_string", None)
+        if url_search_string is not None and len(url_search_string) > 0:
+            obj.url_search_string = url_search_string
+        label = source.get("label", None)
+        if label is not None and len(label) > 0:
+            obj.label = label
+        homepage = source.get("homepage", None)
+        if homepage is not None and len(homepage) > 0:
+            obj.homepage = homepage
+        notes = source.get("notes", None)
+        if notes is not None and len(notes) > 0:
+            obj.notes = notes
+        service = source.get("service", None)
+        if service is not None and len(service) > 0:
+            obj.service = service
+        stories_per_week = source.get("stories_per_week", None)
+        if stories_per_week is not None and len(stories_per_week) > 0:
+            obj.stories_per_week = stories_per_week
+        pub_country = source.get("pub_country", None)
+        if pub_country is not None and len(pub_country) > 0:
+            obj.pub_country = pub_country
+        pub_state = source.get("pub_state", None)
+        if pub_state is not None and len(pub_state) > 0:
+            obj.pub_state = pub_state
+        primary_language = source.get("primary_language", None)
+        if primary_language is not None and len(primary_language) > 0:
+            obj.primary_language = primary_language
+        media_type = source.get("media_type", None)
+        if media_type is not None and len(media_type) > 0:
+            obj.media_type = media_type
 
 class Feed(models.Model):
     url = models.TextField(null=False, blank=False, unique=True)

--- a/mcweb/frontend/src/app/services/sourcesCollectionsApi.js
+++ b/mcweb/frontend/src/app/services/sourcesCollectionsApi.js
@@ -15,7 +15,7 @@ export const sourcesCollectionsApi = managerApi.injectEndpoints({
         url: `sources-collections/${ids.source_id}/?collection_id=${ids.collection_id}`,
         method: 'DELETE',
       }),
-      invalidatesTags: (result, error, ids) => [{ type: 'Collection', id: ids.collection_id }, { type: 'Source', id: ids.source_id }],
+      invalidatesTags: ['Collection', 'Source'],
     }),
   }),
 });


### PR DESCRIPTION
- When uploading a csv of sources to a collection:
  - if there were empty values in a column they would overwrite the previous values on existing objects to be blank
- Fix column names in download source csv 

Quick fix for issue #248 

Future Additions Needed:

- This is a quick fix and upload source csv should be refactored in the future (will open issue with details)