### PR TITLE
Disable WB online news search for dates before 8/1/22

### DIFF
--- a/mcweb/frontend/src/features/search/Search.jsx
+++ b/mcweb/frontend/src/features/search/Search.jsx
@@ -22,7 +22,7 @@ import urlSerializer from './util/urlSerializer';
 import deactivateButton from './util/deactivateButton';
 import TopWords from './results/TopWords';
 import AlertDialog from '../ui/AlertDialog';
-import { PROVIDER_NEWS_WAYBACK_MACHINE } from './util/platforms';
+import { PROVIDER_NEWS_WAYBACK_MACHINE, PROVIDER_REDDIT_PUSHSHIFT } from './util/platforms';
 
 export default function Search() {
   const dispatch = useDispatch();
@@ -98,8 +98,13 @@ export default function Search() {
               </h3>
               {platform === PROVIDER_NEWS_WAYBACK_MACHINE && (
                 <Alert severity="warning">
-                  Search dates limited to currently available data.
-                  Backfill of historical data in progress.
+                  Your dates have been limited to the range of available data.
+                  We are still working with the Wayback Machine to ingest the historical data.
+                </Alert>
+              )}
+              {platform === PROVIDER_REDDIT_PUSHSHIFT && (
+                <Alert severity="warning">
+                  PushShift.io moved to a new server; data before 11/1/22 unavailable.
                 </Alert>
               )}
               <SearchDatePicker />

--- a/mcweb/frontend/src/features/search/Search.jsx
+++ b/mcweb/frontend/src/features/search/Search.jsx
@@ -2,9 +2,10 @@ import React, { useEffect, useState } from 'react';
 import Button from '@mui/material/Button';
 import { useDispatch, useSelector } from 'react-redux';
 import dayjs from 'dayjs';
-import { ContentCopy } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
+import ContentCopy from '@mui/icons-material/ContentCopy';
 import SearchIcon from '@mui/icons-material/Search';
+import Alert from '@mui/material/Alert';
 import { searchApi } from '../../app/services/searchApi';
 import PlatformPicker from './query/PlatformPicker';
 import SelectedMedia from './query/SelectedMedia';
@@ -21,6 +22,7 @@ import urlSerializer from './util/urlSerializer';
 import deactivateButton from './util/deactivateButton';
 import TopWords from './results/TopWords';
 import AlertDialog from '../ui/AlertDialog';
+import { PROVIDER_NEWS_WAYBACK_MACHINE } from './util/platforms';
 
 export default function Search() {
   const dispatch = useDispatch();
@@ -37,6 +39,7 @@ export default function Search() {
     collections,
     sources,
     advanced,
+    platform,
   } = queryState;
 
   const handleShare = () => {
@@ -93,6 +96,12 @@ export default function Search() {
                 <em>3</em>
                 Pick dates
               </h3>
+              {platform === PROVIDER_NEWS_WAYBACK_MACHINE && (
+                <Alert severity="warning">
+                  Search dates limited to currently available data.
+                  Backfill of historical data in progress.
+                </Alert>
+              )}
               <SearchDatePicker />
             </div>
           </div>

--- a/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
+++ b/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
@@ -8,13 +8,14 @@ import { useDispatch, useSelector } from 'react-redux';
 import dayjs from 'dayjs';
 import { useSnackbar } from 'notistack';
 import { setQueryProperty } from './querySlice';
-import { latestAllowedEndDate } from '../util/platforms';
+import { earliestAllowedStartDate, latestAllowedEndDate } from '../util/platforms';
 import DefaultDates from './DefaultDates';
 
 export default function SearchDatePicker() {
   const dispatch = useDispatch();
   const { enqueueSnackbar } = useSnackbar();
   const { platform, startDate, endDate } = useSelector((state) => state.query);
+
   const handleChangeFromDate = (newValue) => {
     dispatch(setQueryProperty({ startDate: dayjs(newValue).format('MM/DD/YYYY') }));
   };
@@ -29,11 +30,15 @@ export default function SearchDatePicker() {
       handleChangeToDate(latestAllowedEndDate(platform));
       enqueueSnackbar('Changed your end date to match this platform limit', { variant: 'warning' });
     }
+    if (dayjs(startDate) < earliestAllowedStartDate(platform)) {
+      handleChangeFromDate(earliestAllowedStartDate(platform));
+      enqueueSnackbar('Changed your start date to match this platform limit', { variant: 'warning' });
+    }
   }, [platform]);
 
   return (
     <>
-      <div className="date-picker-wrapper">
+      <div className="date-picker-wrapper local-provider">
         <LocalizationProvider dateAdapter={AdapterDateFns}>
           <DatePicker
             required
@@ -44,6 +49,7 @@ export default function SearchDatePicker() {
             disableFuture
             disableHighlightToday
             maxDate={endDate}
+            minDate={dayjs(earliestAllowedStartDate(platform).format('MM/DD/YYYY'))}
             renderInput={(params) => <TextField {...params} />}
           />
           <DatePicker
@@ -53,6 +59,7 @@ export default function SearchDatePicker() {
             onChange={handleChangeToDate}
             disableFuture
             disableHighlightToday
+            minDate={dayjs(earliestAllowedStartDate(platform).format('MM/DD/YYYY')).add('1', 'day')}
             maxDate={dayjs(latestAllowedEndDate(platform).format('MM/DD/YYYY'))}
             renderInput={(params) => <TextField {...params} />}
           />

--- a/mcweb/frontend/src/features/search/query/style/_date-picker.scss
+++ b/mcweb/frontend/src/features/search/query/style/_date-picker.scss
@@ -1,3 +1,8 @@
 .date-picker-wrapper {
   margin-top: $padding-s;
 }
+
+.local-provider {
+  display: flex;
+  justify-content: space-between;
+}

--- a/mcweb/frontend/src/features/search/util/platforms.js
+++ b/mcweb/frontend/src/features/search/util/platforms.js
@@ -31,6 +31,7 @@ export const latestAllowedEndDate = (provider) => {
 
 export const earliestAllowedStartDate = (provider) => {
   if (provider === PROVIDER_NEWS_WAYBACK_MACHINE) return dayjs('2022-08-01');
+  if (provider === PROVIDER_REDDIT_PUSHSHIFT) return dayjs('2022-11-1');
   return dayjs('2010-01-01');
 };
 

--- a/mcweb/frontend/src/features/search/util/platforms.js
+++ b/mcweb/frontend/src/features/search/util/platforms.js
@@ -29,6 +29,11 @@ export const latestAllowedEndDate = (provider) => {
   return today;
 };
 
+export const earliestAllowedStartDate = (provider) => {
+  if (provider === PROVIDER_NEWS_WAYBACK_MACHINE) return dayjs('2022-08-01');
+  return dayjs('2010-01-01');
+};
+
 export const defaultPlatformProvider = (platform) => {
   if (platform == PLATFORM_TWITTER) return PROVIDER_TWITTER_TWITTER;
   if (platform == PLATFORM_REDDIT) return PROVIDER_REDDIT_PUSHSHIFT;


### PR DESCRIPTION
Due to unreliable information (currently working on backfilling data) we have disabled searching before 8/1/22. #260 
- Add minDate to Datepicker
- Add warning to online_news search about disabled dates

![Screen Shot 2023-01-20 at 2 44 01 PM](https://user-images.githubusercontent.com/78226696/213792701-2c17852f-0e9b-44a4-85a0-5d094c06e700.png)
