### PR TITLE
Remove last year option from quick dates option in search

### DIFF
--- a/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
+++ b/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
@@ -74,8 +74,6 @@ export default function SearchDatePicker() {
 
       <DefaultDates platform={platform} amountOfTime="3" typeOfTime="month" message="Last 3 Months" />
 
-      <DefaultDates platform={platform} amountOfTime="1" typeOfTime="year" message="Last Year" />
-
     </>
   );
 }


### PR DESCRIPTION
- We have turned off search of media cloud pre-8/22, now need to remove quick date default option of one year (because that does not work)