### PR TITLE
YouTube support tweaks

### DIFF
--- a/mcweb/backend/search/providers/test/test_youtube.py
+++ b/mcweb/backend/search/providers/test/test_youtube.py
@@ -25,16 +25,18 @@ class YouTubeYouTubeProviderTest(TestCase):
         assert isinstance(results, dict) is True
 
     def test_count(self):
-        results = self._provider.count(
-            TERM,
-            start_date=dt.datetime.now() - dt.timedelta(days=2),
-            end_date=dt.datetime.now()
-        )
-        assert results > 0
+        try:
+            _ = self._provider.count(
+                TERM,
+                start_date=dt.datetime.now() - dt.timedelta(days=2),
+                end_date=dt.datetime.now()
+            )
+        except UnsupportedOperationException:
+            assert True
 
     def test_count_too_big(self):
         try:
-            results = self._provider.count(
+            _ = self._provider.count(
                 TERM,
                 start_date=dt.datetime.now() - dt.timedelta(days=DAY_WINDOW),
                 end_date=dt.datetime.now()
@@ -49,3 +51,23 @@ class YouTubeYouTubeProviderTest(TestCase):
             end_date=dt.datetime.now()
         )
         assert isinstance(results, list) is True
+
+    def test_all_items(self):
+        page_count = 0
+        total_items = 0
+        for page in self._provider.all_items("cultural marxism", start_date=dt.datetime(2023, 1, 1),
+                                             end_date=dt.datetime(2023, 1, 5)):
+            assert len(page) > 0
+            total_items += len(page)
+            page_count += 1
+        assert page_count == 1
+        assert total_items == 2
+        page_count = 0
+        total_items = 0
+        for page in self._provider.all_items(TERM, start_date=dt.datetime(2023, 1, 1),
+                                             end_date=dt.datetime(2023, 1, 5)):
+            assert len(page) > 0
+            total_items += len(page)
+            page_count += 1
+        assert page_count == 6
+        assert total_items == 297

--- a/mcweb/backend/search/providers/youtube.py
+++ b/mcweb/backend/search/providers/youtube.py
@@ -48,7 +48,7 @@ class YouTubeYouTubeProvider(ContentProvider):
         """
         # results['pageInfo']['totalResults'] _looks_ like the right thing, but doesn't limit to the
         # publishedBefore nad publishedAfter values :-(
-        raise UnsupportedOperationException("The YouTube API provide matching video counts")
+        raise UnsupportedOperationException("The YouTube API doesn't provide matching video counts")
 
     def sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 20,
                **kwargs) -> List[Dict]:

--- a/mcweb/frontend/src/features/search/results/SampleStories.jsx
+++ b/mcweb/frontend/src/features/search/results/SampleStories.jsx
@@ -16,9 +16,6 @@ import {
 } from '../util/platforms';
 import { googleFaviconUrl } from '../../ui/uiUtil';
 
-const supportsDownload = (platform) => [PROVIDER_NEWS_WAYBACK_MACHINE,
-  PROVIDER_REDDIT_PUSHSHIFT, PROVIDER_TWITTER_TWITTER].includes(platform);
-
 export default function SampleStories() {
   const {
     queryList,
@@ -160,28 +157,26 @@ export default function SampleStories() {
             ))}
           </tbody>
         </table>
-        {(supportsDownload(platform)) && (
-          <div className="clearfix">
-            <div className="float-end">
-              <Button
-                variant="text"
-                endIcon={<DownloadIcon titleAccess="download a CSV of all matching content" />}
-                onClick={() => {
-                  handleDownloadRequest({
-                    query: fullQuery,
-                    startDate,
-                    endDate,
-                    collections: collectionIds,
-                    sources: sourceIds,
-                    platform,
-                  });
-                }}
-              >
-                Download CSV of All Content
-              </Button>
-            </div>
+        <div className="clearfix">
+          <div className="float-end">
+            <Button
+              variant="text"
+              endIcon={<DownloadIcon titleAccess="download a CSV of all matching content" />}
+              onClick={() => {
+                handleDownloadRequest({
+                  query: fullQuery,
+                  startDate,
+                  endDate,
+                  collections: collectionIds,
+                  sources: sourceIds,
+                  platform,
+                });
+              }}
+            >
+              Download CSV of All Content
+            </Button>
           </div>
-        )}
+        </div>
       </>
     );
   }


### PR DESCRIPTION
Two main changes here:

### Download

Turns out we can page through search results via the YT api, so this adds support for downloading that CSV. I also included the `description` and `thumbnail` url fields, which weren't in there before and might be useful for something. 

### Count

Turns out the count we were getting is the count of matching videos across all of YT, and does _not_ respect the date window we pass in. So I removed that.

I updated all unit tests accordingly.