### PR TITLE
Changes to info button for WM sample stories

### DIFF
--- a/mcweb/frontend/src/features/search/results/SampleStories.jsx
+++ b/mcweb/frontend/src/features/search/results/SampleStories.jsx
@@ -62,13 +62,6 @@ export default function SampleStories() {
     return parts[(parts.length - 1)];
   };
 
-  const sampleStoryLink = (provider, url) => {
-    if (provider === PROVIDER_NEWS_WAYBACK_MACHINE && url) {
-      return `/story/${provider}/${getStoryId(url)}`;
-    }
-    return null;
-  };
-
   useEffect(() => {
     if ((queryList[0].length !== 0 || (advanced && queryString !== 0))) {
       query({
@@ -156,7 +149,7 @@ export default function SampleStories() {
                       </MenuItem>
                       <MenuItem>
                         <Link
-                          to={sampleStoryLink(platform, sampleStory.article_url)}
+                          to={`/story/${platform}/${getStoryId(sampleStory.article_url)}`}
                           target="_blank"
                           rel="noreferrer"
                         >

--- a/mcweb/frontend/src/features/stories/StoryShow.jsx
+++ b/mcweb/frontend/src/features/stories/StoryShow.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import CircularProgress from '@mui/material/CircularProgress';
+import Alert from '@mui/material/Alert';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { useGetStoryDetailsQuery } from '../../app/services/searchApi';
 
@@ -18,29 +19,20 @@ export default function StoryShow() {
   const { story } = data;
   return (
     <div className="container" style={{ paddingTop: 50 }}>
+      <Alert severity="info" sx={{ width: '40%', marginBottom: 2 }}>
+        Extracted story information provided by Wayback Machine
+      </Alert>
       <h1 className="row">{story.title}</h1>
       <div className="row">
         <h5>
-          Originally published on
-          {' '}
-          {story.publication_date}
-          {' '}
-          in
-          {' '}
-          <b>
-            {story.domain}
-          </b>
-          . Collected on
-          {' '}
-          {story.capture_time}
-          .
+          {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
+          Originally published on {story.publication_date} in <b>{story.domain}</b>. Collected on {story.capture_time}.
         </h5>
       </div>
 
       <div className="clearfix">
         <h3 className="float-start">Story Text</h3>
         <h6 className="float-end">
-          {' '}
           <a target="_blank" href={story.archive_playback_url} rel="noreferrer">
             <OpenInNewIcon />
           </a>

--- a/mcweb/frontend/src/features/stories/StoryShow.jsx
+++ b/mcweb/frontend/src/features/stories/StoryShow.jsx
@@ -19,10 +19,15 @@ export default function StoryShow() {
   const { story } = data;
   return (
     <div className="container" style={{ paddingTop: 50 }}>
-      <Alert severity="info" sx={{ width: '40%', marginBottom: 2 }}>
-        Extracted story information provided by Wayback Machine
-      </Alert>
-      <h1 className="row">{story.title}</h1>
+      <div className="row">
+        <h1>{story.title}</h1>
+      </div>
+      <div className="row" style={{ marginLeft: 1 }}>
+        <Alert severity="info" sx={{ width: '40%', marginBottom: 2 }}>
+          Extracted story information provided by Wayback Machine
+        </Alert>
+      </div>
+
       <div className="row">
         <h5>
           {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
@@ -39,7 +44,9 @@ export default function StoryShow() {
         </h6>
 
       </div>
-      <p className="row">{story.snippet}</p>
+      <div className="row">
+        <p>{story.snippet}</p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
- Add credit for Wayback Machine on link in info menu, as well as on the story show page
![Screen Shot 2023-01-26 at 4 22 42 PM](https://user-images.githubusercontent.com/78226696/214953605-c3efb2f9-c814-42ba-b63e-892cec716423.png)
![Screen Shot 2023-01-26 at 4 16 08 PM](https://user-images.githubusercontent.com/78226696/214953624-208e9215-b9bb-4c93-b914-9f1272a7207d.png)

-Fix for info menu showing up when switching platforms
-Add dropdown menu icon
![Screen Shot 2023-01-26 at 4 24 11 PM](https://user-images.githubusercontent.com/78226696/214953850-06de100b-d9a4-4e20-8e66-34ff277c4ea6.png)
