### PR TITLE
Scroll to results

### DIFF
--- a/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
+++ b/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
@@ -87,10 +87,10 @@ export default function CountOverTimeResults() {
   }, [lastSearchTime]);
 
   useEffect(() => {
-    if (data) {
+    if (data || error) {
       executeScroll();
     }
-  }, [data]);
+  }, [data, error]);
 
   if (isLoading) {
     return (<div><CircularProgress size="75px" /></div>);


### PR DESCRIPTION
After data(or error) returns for count over time the page scrolls to the Count Over Time chart. 