### PR TITLE
Refactored authSlice.js

### DIFF
--- a/mcweb/frontend/src/features/auth/authSlice.js
+++ b/mcweb/frontend/src/features/auth/authSlice.js
@@ -4,11 +4,11 @@ const slice = createSlice({
   name: 'auth',
   initialState: { user: null, isLoggedIn: false },
   reducers: {
-    setCredentials: (state, { payload }) => {
-      state.user = payload;
-      state.isLoggedIn = state.user && state.user.isActive;
-    },
-
+    setCredentials: (state, { payload }) => ({
+      ...state,
+      user: payload,
+      isLoggedIn: payload && payload.isActive,
+    }),
   },
 });
 

--- a/mcweb/frontend/src/features/search/query/SelectedMedia.jsx
+++ b/mcweb/frontend/src/features/search/query/SelectedMedia.jsx
@@ -7,13 +7,22 @@ import IconButton from '@mui/material/IconButton';
 
 export default function SelectedMedia({ onRemove, collections, sources }) {
   const dispatch = useDispatch();
-  // note: this only supports collectinos right now, but needs to support sources too
+  // note: this only supports collections right now, but needs to support sources too
   return (
     <div className="selected-media-container">
       <div className="selected-media-item-list">
         {sources.map((source) => (
           <div className="selected-media-item" key={`selected-media-${source.id}`}>
-            <Link target="_blank" to={`/sources/${source.id}`}>
+            <Link
+              target="_blank"
+              to={`/sources/${source.id}`}
+              style={{
+                display: 'block',
+                whiteSpace: 'normal',
+                overflow: 'hidden',
+                width: '100%',
+              }}
+            >
               {source.label || source.name}
             </Link>
             <IconButton size="small" aria-label="remove" onClick={() => dispatch(onRemove({ type: 'source', id: source.id }))}>
@@ -23,9 +32,19 @@ export default function SelectedMedia({ onRemove, collections, sources }) {
         ))}
         {collections.map((collection) => (
           <div className="selected-media-item" key={`selected-media-${collection.id}`}>
-            <Link target="_blank" to={`/collections/${collection.id}`}>
+            <Link
+              target="_blank"
+              to={`/collections/${collection.id}`}
+              style={{
+                display: 'block',
+                whiteSpace: 'normal',
+                overflow: 'hidden',
+                width: '100%',
+              }}
+            >
               {collection.name}
             </Link>
+
             <IconButton
               size="small"
               aria-label="remove"


### PR DESCRIPTION
- made a copy of the `state` object, modified the copy, and returned the modified copy instead of modifying the original `state` directly in `authSlice.js`
- removed the lining error 