### PR TITLE
Fixed text overflows in MediaPicker

### DIFF
--- a/mcweb/frontend/src/features/auth/authSlice.js
+++ b/mcweb/frontend/src/features/auth/authSlice.js
@@ -4,11 +4,11 @@ const slice = createSlice({
   name: 'auth',
   initialState: { user: null, isLoggedIn: false },
   reducers: {
-    setCredentials: (state, { payload }) => {
-      state.user = payload;
-      state.isLoggedIn = state.user && state.user.isActive;
-    },
-
+    setCredentials: (state, { payload }) => ({
+      ...state,
+      user: payload,
+      isLoggedIn: payload && payload.isActive,
+    }),
   },
 });
 

--- a/mcweb/frontend/src/features/search/query/SelectedMedia.jsx
+++ b/mcweb/frontend/src/features/search/query/SelectedMedia.jsx
@@ -7,13 +7,22 @@ import IconButton from '@mui/material/IconButton';
 
 export default function SelectedMedia({ onRemove, collections, sources }) {
   const dispatch = useDispatch();
-  // note: this only supports collectinos right now, but needs to support sources too
+  // note: this only supports collections right now, but needs to support sources too
   return (
     <div className="selected-media-container">
       <div className="selected-media-item-list">
         {sources.map((source) => (
           <div className="selected-media-item" key={`selected-media-${source.id}`}>
-            <Link target="_blank" to={`/sources/${source.id}`}>
+            <Link
+              target="_blank"
+              to={`/sources/${source.id}`}
+              style={{
+                display: 'block',
+                whiteSpace: 'normal',
+                overflow: 'hidden',
+                width: '100%',
+              }}
+            >
               {source.label || source.name}
             </Link>
             <IconButton size="small" aria-label="remove" onClick={() => dispatch(onRemove({ type: 'source', id: source.id }))}>
@@ -23,9 +32,19 @@ export default function SelectedMedia({ onRemove, collections, sources }) {
         ))}
         {collections.map((collection) => (
           <div className="selected-media-item" key={`selected-media-${collection.id}`}>
-            <Link target="_blank" to={`/collections/${collection.id}`}>
+            <Link
+              target="_blank"
+              to={`/collections/${collection.id}`}
+              style={{
+                display: 'block',
+                whiteSpace: 'normal',
+                overflow: 'hidden',
+                width: '100%',
+              }}
+            >
               {collection.name}
             </Link>
+
             <IconButton
               size="small"
               aria-label="remove"

--- a/mcweb/frontend/src/features/search/query/SelectedMedia.jsx
+++ b/mcweb/frontend/src/features/search/query/SelectedMedia.jsx
@@ -19,7 +19,6 @@ export default function SelectedMedia({ onRemove, collections, sources }) {
               style={{
                 display: 'block',
                 whiteSpace: 'normal',
-                overflow: 'hidden',
                 width: '100%',
               }}
             >
@@ -38,7 +37,6 @@ export default function SelectedMedia({ onRemove, collections, sources }) {
               style={{
                 display: 'block',
                 whiteSpace: 'normal',
-                overflow: 'hidden',
                 width: '100%',
               }}
             >


### PR DESCRIPTION
- updated `SelectedMedia.jsx` to remove the text overflow for longer named sources/collections so that the title flows to the next line.
<img width="453" alt="Screen Shot 2023-02-07 at 2 28 09 PM" src="https://user-images.githubusercontent.com/91026581/217345733-506d3a33-9999-4388-aed6-51cff7ad8d22.png">
