### PR TITLE
RE: Hide Stories on a source page if it is not online_news 

### DIFF
--- a/mcweb/frontend/src/features/sources/SourceShow.jsx
+++ b/mcweb/frontend/src/features/sources/SourceShow.jsx
@@ -56,9 +56,11 @@ export default function SourceShow() {
         <div className="col-6">
           <CollectionList sourceId={sourceId} />
         </div>
-        <div className="col-6">
-          <FeedStories feed={false} sourceId={sourceId} />
-        </div>
+        {source.platform === 'online_news' && (
+          <div className="col-6">
+            <FeedStories feed={false} sourceId={sourceId} />
+          </div>
+        )}
       </div>
 
     </div>


### PR DESCRIPTION
In `SourceShow.jsx` added a line that if the source's platform is `online_news` then `FeedStories` is displayed. If not the stories would be hidden. Currently, there are no sources in the collection that are not `online_news`
