### PR TITLE
Fix for not allowing edit or creating source with url search string

### DIFF
--- a/mcweb/backend/sources/serializer.py
+++ b/mcweb/backend/sources/serializer.py
@@ -83,13 +83,15 @@ class SourceSerializer(serializers.ModelSerializer):
         homepage = self.initial_data["homepage"]
         canonical_domain = urls.canonical_domain(homepage)
         platform = self.initial_data["platform"]
+        url_search_string = self.initial_data.get("url_search_string", None)
         existing_sources = Source.objects.filter(name__exact=value)
-        if existing_sources.exists():
-             if existing_sources[0].id != self_id and self_id is not None:
-                raise serializers.ValidationError(f"name: {value} already exists")
-        if platform == "online_news":
-            if canonical_domain != value:
-                raise serializers.ValidationError(f"name: {value} does not match the canonicalized version of homepage: {homepage}")
+        if url_search_string is None or len(url_search_string) == 0:
+            if existing_sources.exists():
+                if existing_sources[0].id != self_id and self_id is not None:
+                    raise serializers.ValidationError(f"name: {value} already exists")
+            if platform == "online_news":
+                if canonical_domain != value:
+                    raise serializers.ValidationError(f"name: {value} does not match the canonicalized version of homepage: {homepage}")
         return value
     
     def validate_pub_country(self, value):

--- a/mcweb/frontend/src/features/sources/ModifySource.jsx
+++ b/mcweb/frontend/src/features/sources/ModifySource.jsx
@@ -50,6 +50,7 @@ export default function ModifySource() {
         homepage: data.homepage,
         label: data.label,
         platform: data.platform,
+        url_search_string: data.url_search_string,
       };
       setFormState(formData);
     }

--- a/mcweb/frontend/src/features/sources/SourceShow.jsx
+++ b/mcweb/frontend/src/features/sources/SourceShow.jsx
@@ -38,11 +38,15 @@ export default function SourceShow() {
       <div className="row">
         <div className="col-6">
           <p>
-            <b>Homepage</b>
-            :
-            {' '}
-            <a href={source.homepage} target="_blank" rel="noreferrer">{source.homepage}</a>
+            {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
+            <b>Homepage</b>: <a href={source.homepage} target="_blank" rel="noreferrer">{source.homepage}</a>
           </p>
+          {source.url_search_string && (
+          <p>
+            {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
+            <b>URL Search String</b>: {source.url_search_string}
+          </p>
+          )}
           {source.notes && (
             <p>
               <b>Notes</b>


### PR DESCRIPTION
- Change to `name` validation to allow the same names if they have a url_search_string
- Fix to ui to show url_search_string in edit screen and show page