### PR TITLE
RE: Add message when total attention returns 0 or 100% 

### DIFF
--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import { Settings } from '@mui/icons-material';
@@ -10,11 +11,13 @@ import BarChart from './BarChart';
 import queryGenerator from '../util/queryGenerator';
 import { useGetTotalCountMutation } from '../../../app/services/searchApi';
 import {
-  PROVIDER_REDDIT_PUSHSHIFT, PROVIDER_NEWS_WAYBACK_MACHINE,
+  PROVIDER_REDDIT_PUSHSHIFT,
+  PROVIDER_NEWS_WAYBACK_MACHINE,
 } from '../util/platforms';
 
-export const supportsNormalizedCount = (platform) => [
-  PROVIDER_NEWS_WAYBACK_MACHINE, PROVIDER_REDDIT_PUSHSHIFT].includes(platform);
+export const supportsNormalizedCount = (platform) =>
+  // eslint-disable-next-line implicit-arrow-linebreak
+  [PROVIDER_NEWS_WAYBACK_MACHINE, PROVIDER_REDDIT_PUSHSHIFT].includes(platform);
 
 function TotalAttentionResults() {
   const {
@@ -50,11 +53,10 @@ function TotalAttentionResults() {
 
   // using EPSILON in the denominator here prevents against div by zero errors
   // (which returns infinity in JS)
-  const normalizeData = (oldData) => 100 * (oldData.count.relevant
-    / (oldData.count.total + Number.EPSILON));
+  const normalizeData = (oldData) => 100 * (oldData.count.relevant / (oldData.count.total + Number.EPSILON));
 
   useEffect(() => {
-    if ((queryList[0].length !== 0) || (advanced && queryString !== 0)) {
+    if (queryList[0].length !== 0 || (advanced && queryString !== 0)) {
       query({
         query: fullQuery,
         startDate,
@@ -86,37 +88,58 @@ function TotalAttentionResults() {
           <h2>Total Attention</h2>
           <p>
             Compare the total number of items that matched your queries.
-            your queries. Use the &quot;view options&quot; menu to switch between story counts
-            and a percentage (if supported).
+            Use the &quot;view options&quot; menu to switch between
+            story counts and a percentage (if supported).
           </p>
         </div>
         <div className="col-8">
-          {(error) && (
+          {error && (
             <Alert severity="warning">
-              Sorry, but something went wrong.
-              (
+              Sorry, but something went wrong. (
               {error.data.note}
               )
             </Alert>
           )}
-          {(error === undefined) && (
-            <BarChart
-              series={[{
-                data: [{ key: fullQuery, value: (normalized) ? normalizeData(data) : data.count.relevant }],
-                name: 'Matching Content',
-                color: '#2f2d2b',
-              }]}
-              normalized={normalized}
-              title="Total Stories Count"
-              height={200}
-            />
+          {error === undefined && (
+            <div>
+              {normalizeData(data) === 0 && (
+                <Alert severity="warning">No content has matched this query</Alert>
+              )}
+              {normalizeData(data) === 100 && (
+                <Alert severity="warning"> You searched &apos;*&apos; and received 100% results </Alert>
+              )}
+              <BarChart
+                series={[
+                  {
+                    data: [
+                      {
+                        key: fullQuery,
+                        value: normalized
+                          ? normalizeData(data)
+                          : data.count.relevant,
+                      },
+                    ],
+                    name: 'Matching Content',
+                    color: '#2f2d2b',
+                  },
+                ]}
+                normalized={normalized}
+                title="Total Stories Count"
+                height={200}
+              />
+            </div>
           )}
           <div className="clearfix">
             {supportsNormalizedCount(platform) && (
               <div className="float-start">
                 {normalized && (
                   <div>
-                    <Button onClick={handleClick} endIcon={<Settings titleAccess="view other chart viewing options" />}>
+                    <Button
+                      onClick={handleClick}
+                      endIcon={
+                        <Settings titleAccess="view other chart viewing options" />
+                      }
+                    >
                       View Options
                     </Button>
                     <Menu
@@ -128,22 +151,20 @@ function TotalAttentionResults() {
                         'aria-labelledby': 'basic-button',
                       }}
                     >
-                      <MenuItem onClick={() => {
-                        setNormalized(false);
-                        handleClose();
-                      }}
+                      <MenuItem
+                        onClick={() => {
+                          setNormalized(false);
+                          handleClose();
+                        }}
                       >
                         View Story Count
-
                       </MenuItem>
                     </Menu>
                   </div>
                 )}
                 {!normalized && (
                   <div>
-                    <Button onClick={handleClick}>
-                      View Options
-                    </Button>
+                    <Button onClick={handleClick}>View Options</Button>
                     <Menu
                       id="basic-menu"
                       anchorEl={anchorEl}
@@ -153,10 +174,11 @@ function TotalAttentionResults() {
                         'aria-labelledby': 'basic-button',
                       }}
                     >
-                      <MenuItem onClick={() => {
-                        setNormalized(true);
-                        handleClose();
-                      }}
+                      <MenuItem
+                        onClick={() => {
+                          setNormalized(true);
+                          handleClose();
+                        }}
                       >
                         View Normalized Story Percentage (default)
                       </MenuItem>

--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
-import Typography from '@mui/material/Typography';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import { Settings } from '@mui/icons-material';
@@ -106,7 +105,7 @@ function TotalAttentionResults() {
                 <Alert severity="warning">No content has matched this query</Alert>
               )}
               {normalizeData(data) === 100 && (
-                <Alert severity="warning"> You searched &apos;*&apos; and received 100% results </Alert>
+                <Alert severity="warning"> This query has returned 100% attention </Alert>
               )}
               <BarChart
                 series={[

--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -33,7 +33,8 @@ function TotalAttentionResults() {
     advanced,
   } = useSelector((state) => state.query);
 
-  const fullQuery = queryString || queryGenerator(queryList, negatedQueryList, platform, anyAll);
+  const fullQuery = queryString
+    || queryGenerator(queryList, negatedQueryList, platform, anyAll);
 
   const [normalized, setNormalized] = useState(true);
 
@@ -86,9 +87,9 @@ function TotalAttentionResults() {
         <div className="col-4">
           <h2>Total Attention</h2>
           <p>
-            Compare the total number of items that matched your queries.
-            Use the &quot;view options&quot; menu to switch between
-            story counts and a percentage (if supported).
+            Compare the total number of items that matched your queries. Use the
+            &quot;view options&quot; menu to switch between story counts and a
+            percentage (if supported).
           </p>
         </div>
         <div className="col-8">
@@ -102,10 +103,16 @@ function TotalAttentionResults() {
           {error === undefined && (
             <div>
               {normalizeData(data) === 0 && (
-                <Alert severity="warning">No content has matched this query</Alert>
+                <Alert severity="warning">
+                  No content has matched this query
+                </Alert>
               )}
               {normalizeData(data) === 100 && (
-                <Alert severity="warning"> This query has returned 100% attention </Alert>
+                <Alert severity="warning">
+                  {' '}
+                  This query has returned 100% attention
+                  {' '}
+                </Alert>
               )}
               <BarChart
                 series={[
@@ -113,16 +120,17 @@ function TotalAttentionResults() {
                     data: [
                       {
                         key: fullQuery,
-                        value: normalized
-                          ? normalizeData(data)
-                          : data.count.relevant,
+                        value: normalizeData(data) === 100
+                          ? data.count.relevant
+                          : (normalized && normalizeData(data))
+                          || data.count.relevant,
                       },
                     ],
                     name: 'Matching Content',
                     color: '#2f2d2b',
                   },
                 ]}
-                normalized={normalized}
+                normalized={normalized && normalizeData(data) !== 100}
                 title="Total Stories Count"
                 height={200}
               />
@@ -131,7 +139,7 @@ function TotalAttentionResults() {
           <div className="clearfix">
             {supportsNormalizedCount(platform) && (
               <div className="float-start">
-                {normalized && (
+                {normalized && normalizeData(data) !== 100 && (
                   <div>
                     <Button
                       onClick={handleClick}
@@ -161,7 +169,7 @@ function TotalAttentionResults() {
                     </Menu>
                   </div>
                 )}
-                {!normalized && (
+                {!normalized && normalizeData(data) !== 100 && (
                   <div>
                     <Button onClick={handleClick}>View Options</Button>
                     <Menu


### PR DESCRIPTION
- Alert Banner created when the query returns 0% or 100% attention. Determined by the`normalizeData(data)` value.
- Additional style linting done in `TotalAttentionResults.jsx`
<img width="987" alt="Screen Shot 2023-02-28 at 4 41 57 PM" src="https://user-images.githubusercontent.com/91026581/221987739-857c748f-6507-4076-b4a9-87f6b0e21240.png">
<img width="988" alt="Screen Shot 2023-02-28 at 4 42 26 PM" src="https://user-images.githubusercontent.com/91026581/221987743-a3614773-81fc-465d-baed-0e2da17ec91f.png">
