### PR TITLE
Feature rescrape UI Additions

### DIFF
--- a/mcweb/backend/sources/api.py
+++ b/mcweb/backend/sources/api.py
@@ -246,7 +246,7 @@ class SourcesViewSet(viewsets.ModelViewSet):
 
     def create(self, request):
         cleaned_data = Source._clean_source(request.data)
-        serializer = SourceSerializer(data=cleaned_data)
+        serializer = SourceSerializer(data=cleaned_data, context={'request': request})
         if serializer.is_valid():
             serializer.save()
             return Response({"source": serializer.data})
@@ -356,7 +356,7 @@ class SourcesViewSet(viewsets.ModelViewSet):
     @action(methods=['post'], detail=False, url_path='rescrape-feeds')
     def rescrape_feeds(self, request):
         # maybe take multiple ids?  Or just add a method to rescrape a source
-        source_id = int(self.request.query_params.get("source_id"))
+        source_id = int(request.data["source_id"])
         return Response(schedule_scrape_source(source_id, request.user))
 
     # NOTE!!!! {completed,pending}-tasks are ***NOT***

--- a/mcweb/backend/sources/serializer.py
+++ b/mcweb/backend/sources/serializer.py
@@ -124,12 +124,12 @@ class SourceSerializer(serializers.ModelSerializer):
     
     def create(self, validated_data):
         new_source = Source.objects.create(**validated_data)
-        user = None
-        request = self.context.get("request")
-        if request and hasattr(request, "user"):
-            user = request.user
-        if new_source:
-            schedule_scrape_source(new_source.id, user)
+        # user = None
+        # request = self.context.get("request")
+        # if request and hasattr(request, "user"):
+        #     user = request.user
+        # if new_source:
+        #     schedule_scrape_source(new_source.id, user)
         return new_source
 
   

--- a/mcweb/frontend/src/app/services/sourceApi.js
+++ b/mcweb/frontend/src/app/services/sourceApi.js
@@ -54,11 +54,14 @@ export const sourceApi = managerApi.injectEndpoints({
       invalidatesTags: ['Source'],
     }),
     rescrapeForFeeds: builder.mutation({
-      query: (sourceId) => ({
-        url: 'rescrape-feeds',
-        method: 'POST',
-        body: sourceId,
-      }),
+      query: (sourceId) => {
+        console.log(sourceId);
+        return {
+          url: 'sources/rescrape-feeds/',
+          method: 'POST',
+          body: { source_id: sourceId },
+        };
+      },
     }),
   }),
 });
@@ -71,4 +74,5 @@ export const {
   useUpdateSourceMutation,
   useDeleteSourceMutation,
   useUploadSourcesMutation,
+  useRescrapeForFeedsMutation,
 } = sourceApi;

--- a/mcweb/frontend/src/app/services/sourceApi.js
+++ b/mcweb/frontend/src/app/services/sourceApi.js
@@ -53,6 +53,13 @@ export const sourceApi = managerApi.injectEndpoints({
       }),
       invalidatesTags: ['Source'],
     }),
+    rescrapeForFeeds: builder.mutation({
+      query: (sourceId) => ({
+        url: 'rescrape-feeds',
+        method: 'POST',
+        body: sourceId,
+      }),
+    }),
   }),
 });
 

--- a/mcweb/frontend/src/app/services/sourceApi.js
+++ b/mcweb/frontend/src/app/services/sourceApi.js
@@ -54,14 +54,11 @@ export const sourceApi = managerApi.injectEndpoints({
       invalidatesTags: ['Source'],
     }),
     rescrapeForFeeds: builder.mutation({
-      query: (sourceId) => {
-        console.log(sourceId);
-        return {
-          url: 'sources/rescrape-feeds/',
-          method: 'POST',
-          body: { source_id: sourceId },
-        };
-      },
+      query: (sourceId) => ({
+        url: 'sources/rescrape-feeds/',
+        method: 'POST',
+        body: { source_id: sourceId },
+      }),
     }),
   }),
 });

--- a/mcweb/frontend/src/features/sources/SourceHeader.jsx
+++ b/mcweb/frontend/src/features/sources/SourceHeader.jsx
@@ -7,7 +7,7 @@ import { CircularProgress } from '@mui/material';
 import { useParams, Link, Outlet } from 'react-router-dom';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
 import ListAltIcon from '@mui/icons-material/ListAlt';
-import { useGetSourceQuery, useDeleteSourceMutation } from '../../app/services/sourceApi';
+import { useGetSourceQuery, useDeleteSourceMutation, useRescrapeForFeedsMutation } from '../../app/services/sourceApi';
 import { useLazyFetchFeedQuery } from '../../app/services/feedsApi';
 import Permissioned, { ROLE_STAFF } from '../auth/Permissioned';
 import urlSerializer from '../search/util/urlSerializer';
@@ -22,6 +22,7 @@ export default function SourceHeader() {
   const sourceId = Number(params.sourceId);
   const [openRefetch, setOpenRefetch] = useState(false);
   const [openDelete, setOpenDelete] = useState(false);
+  const [openRescrape, setOpenRescrape] = useState(false);
   const {
     data: source,
     isLoading,
@@ -29,9 +30,14 @@ export default function SourceHeader() {
 
   const [fetchFeedTrigger] = useLazyFetchFeedQuery();
   const [deleteSource] = useDeleteSourceMutation();
+  const [scrapeForFeeds, { error }] = useRescrapeForFeedsMutation();
 
   if (isLoading) {
     return <CircularProgress size="75px" />;
+  }
+
+  if (error) {
+    console.log(error);
   }
 
   const PlatformIcon = platformIcon(source.platform);
@@ -128,6 +134,25 @@ export default function SourceHeader() {
             endIcon={<LockOpenIcon titleAccess="admin-delete" />}
             secondAction={false}
             confirmButtonText="delete"
+          />
+
+          <AlertDialog
+            outsideTitle="Rescrape Source"
+            title={`Rescrape Source ${source.name} for new Feeds`}
+            content={`Are you sure you would like to rescrape ${source.name} for new feeds?
+             Confirming will place this source in a queue to be rescraped for new feeds`}
+            dispatchNeeded={false}
+            action={scrapeForFeeds}
+            actionTarget={sourceId}
+            snackbar
+            snackbarText="Source Queued for Rescraping"
+            onClick={() => setOpenRescrape(true)}
+            openDialog={openRescrape}
+            variant="outlined"
+            navigateNeeded={false}
+            endIcon={<LockOpenIcon titleAccess="admin-delete" />}
+            secondAction={false}
+            confirmButtonText="Rescrape"
           />
 
         </Permissioned>

--- a/mcweb/frontend/src/features/sources/SourceHeader.jsx
+++ b/mcweb/frontend/src/features/sources/SourceHeader.jsx
@@ -30,14 +30,10 @@ export default function SourceHeader() {
 
   const [fetchFeedTrigger] = useLazyFetchFeedQuery();
   const [deleteSource] = useDeleteSourceMutation();
-  const [scrapeForFeeds, { error }] = useRescrapeForFeedsMutation();
+  const [scrapeForFeeds] = useRescrapeForFeedsMutation();
 
   if (isLoading) {
     return <CircularProgress size="75px" />;
-  }
-
-  if (error) {
-    console.log(error);
   }
 
   const PlatformIcon = platformIcon(source.platform);


### PR DESCRIPTION
- Add 'rescrape source' button to SourceHeader
![Screen Shot 2023-03-13 at 11 35 15 AM](https://user-images.githubusercontent.com/78226696/224750981-5d7eda65-4500-4049-8cb8-b0bfefa91ed7.png)
  - Additional confirmation dialogue
![Screen Shot 2023-03-13 at 11 34 21 AM](https://user-images.githubusercontent.com/78226696/224751133-6ae58dc0-ef59-4b4c-b80a-7c90f9aebc4c.png)

-It was requested that when a source is created, we schedule it to scrape for feeds, this behavior has also been implemented
  - add method call to serializer 'Create' method (context added to serializer for user)