### PR TITLE
Temporarily shut off source name validations

### DIFF
--- a/mcweb/backend/sources/serializer.py
+++ b/mcweb/backend/sources/serializer.py
@@ -79,19 +79,19 @@ class SourceSerializer(serializers.ModelSerializer):
         Check that name is normalized version of homepage, ensure name is unique in db
         """
         
-        self_id = self.initial_data.get('id', None) 
-        homepage = self.initial_data["homepage"]
-        canonical_domain = urls.canonical_domain(homepage)
-        platform = self.initial_data["platform"]
-        url_search_string = self.initial_data.get("url_search_string", None)
-        existing_sources = Source.objects.filter(name__exact=value)
-        if url_search_string is None or len(url_search_string) == 0:
-            if existing_sources.exists():
-                if existing_sources[0].id != self_id and self_id is not None:
-                    raise serializers.ValidationError(f"name: {value} already exists")
-            if platform == "online_news":
-                if canonical_domain != value:
-                    raise serializers.ValidationError(f"name: {value} does not match the canonicalized version of homepage: {homepage}")
+        # self_id = self.initial_data.get('id', None) 
+        # homepage = self.initial_data["homepage"]
+        # canonical_domain = urls.canonical_domain(homepage)
+        # platform = self.initial_data["platform"]
+        # url_search_string = self.initial_data.get("url_search_string", None)
+        # existing_sources = Source.objects.filter(name__exact=value)
+        # if url_search_string is None or len(url_search_string) == 0:
+        #     if existing_sources.exists():
+        #         if existing_sources[0].id != self_id and self_id is not None:
+        #             raise serializers.ValidationError(f"name: {value} already exists")
+        #     if platform == "online_news":
+        #         if canonical_domain != value:
+        #             raise serializers.ValidationError(f"name: {value} does not match the canonicalized version of homepage: {homepage}")
         return value
     
     def validate_pub_country(self, value):

--- a/mcweb/frontend/src/features/feeds/FeedStories.jsx
+++ b/mcweb/frontend/src/features/feeds/FeedStories.jsx
@@ -15,7 +15,7 @@ function FeedStories({ feedId, feed, sourceId }) {
     <div className="results-item-wrapper results-sample-stories">
       <div className="row">
         <div className="col-12">
-          <h1 id="feed-story-title">Stories</h1>
+          <h1 id="feed-story-title">Latest Stories</h1>
         </div>
         <div className="row">
 


### PR DESCRIPTION
- Temporarily shut off name validation for sources, until url_search_string issue is fixed (solution already programmed and should be live next week)
- Change 'Stories' title to 'Latest Stories' on a source or feed page
![Screen Shot 2023-03-13 at 2 35 56 PM](https://user-images.githubusercontent.com/78226696/224798117-60e39fd1-a8e6-4401-b718-f69e14d74208.png)
