### PR TITLE
Add rescrape of source when uploading a new source

### DIFF
--- a/mcweb/backend/sources/api.py
+++ b/mcweb/backend/sources/api.py
@@ -298,6 +298,7 @@ class SourcesViewSet(viewsets.ModelViewSet):
                 serializer = SourceSerializer(data=cleaned_source_input)
                 if serializer.is_valid():
                     existing_source = serializer.save()
+                    schedule_scrape_source(existing_source.id, request.user)
                     email_text += "\n {}: created new {} source".format(existing_source.name, existing_source.platform)
                     counts['created'] += 1
                 else:

--- a/mcweb/backend/sources/api.py
+++ b/mcweb/backend/sources/api.py
@@ -272,6 +272,7 @@ class SourcesViewSet(viewsets.ModelViewSet):
     @action(methods=['post'], detail=False)
     def upload_sources(self, request):
         collection = Collection.objects.get(pk=request.data['collection_id'])
+        rescrape = request.data['rescrape']
         email_title = "Updating collection {}".format(collection.name)
         email_text = ""
         queryset = Source.objects
@@ -298,7 +299,8 @@ class SourcesViewSet(viewsets.ModelViewSet):
                 serializer = SourceSerializer(data=cleaned_source_input)
                 if serializer.is_valid():
                     existing_source = serializer.save()
-                    schedule_scrape_source(existing_source.id, request.user)
+                    if rescrape:
+                        schedule_scrape_source(existing_source.id, request.user)
                     email_text += "\n {}: created new {} source".format(existing_source.name, existing_source.platform)
                     counts['created'] += 1
                 else:

--- a/mcweb/frontend/src/features/collections/ModifyCollection.jsx
+++ b/mcweb/frontend/src/features/collections/ModifyCollection.jsx
@@ -38,7 +38,7 @@ export default function ModifyCollection() {
 
   // form state for text fields
   const [formState, setFormState] = useState({
-    id: 0, name: '', notes: '', platform: 'online_news', public: true, featured: false,
+    id: 0, name: '', notes: '', platform: 'online_news', public: true, featured: false, rescrape: true,
   });
 
   const [open, setOpen] = useState(false);
@@ -84,6 +84,7 @@ export default function ModifyCollection() {
         platform: data.platform,
         public: data.public,
         featured: data.featured,
+        rescrape: true,
       };
       setFormState(formData);
     }
@@ -287,8 +288,25 @@ export default function ModifyCollection() {
             )}
           />
           <br />
-          <UploadSources collectionId={collectionId} />
+
         </div>
+
+        <div style={{ display: 'flex' }}>
+
+          <FormControlLabel
+            control={(
+              <Checkbox
+                name="rescrape"
+                checked={formState.rescrape}
+                onChange={handleChange}
+              />
+              )}
+            label="Automatically discover RSS feeds in new sources?"
+          />
+
+          <UploadSources className="col-6" collectionId={collectionId} rescrape={formState.rescrape} />
+        </div>
+
       </div>
 
       <Dialog

--- a/mcweb/frontend/src/features/sources/UploadSources.jsx
+++ b/mcweb/frontend/src/features/sources/UploadSources.jsx
@@ -7,21 +7,19 @@ import Button from '@mui/material/Button';
 import { CircularProgress } from '@mui/material';
 import { useUploadSourcesMutation } from '../../app/services/sourceApi';
 
-export default function UploadSources(props) {
-  const { collectionId } = props;
+export default function UploadSources({ collectionId, rescrape }) {
   const { enqueueSnackbar } = useSnackbar();
   const [updating, setUpdating] = useState(false);
   const [uploadSources, { isLoading: isUpdating }] = useUploadSourcesMutation();
 
   const { CSVReader } = useCSVReader();
-
   return (
     <div>
       <CSVReader
         config={{ header: true }}
         onUploadAccepted={async (uploadInfo) => {
           setUpdating(true);
-          const results = await uploadSources({ sources: uploadInfo.data, collection_id: collectionId });
+          const results = await uploadSources({ sources: uploadInfo.data, collection_id: collectionId, rescrape });
           setUpdating(false);
           enqueueSnackbar(
             `Created ${results.data.created}. Updated ${results.data.updated}. Skipped ${results.data.skipped}.`,
@@ -56,4 +54,5 @@ export default function UploadSources(props) {
 
 UploadSources.propTypes = {
   collectionId: PropTypes.number.isRequired,
+  rescrape: PropTypes.bool.isRequired,
 };


### PR DESCRIPTION
- It was requested that when a CSV is uploaded to a collection, that new sources will get scheduled to be scraped
  - this will only apply to created sources and not updated sources