### PR TITLE
Feature rescrape collection for new rss feeds

### DIFF
--- a/mcweb/backend/sources/api.py
+++ b/mcweb/backend/sources/api.py
@@ -23,7 +23,7 @@ from .rss_fetcher_api import RssFetcherApi
 from util.send_emails import send_source_upload_email
 
 from mc_providers import PLATFORM_REDDIT, PLATFORM_TWITTER, PLATFORM_YOUTUBE
-from .tasks import schedule_scrape_source, get_completed_tasks, get_pending_tasks
+from .tasks import schedule_scrape_source, get_completed_tasks, get_pending_tasks, schedule_scrape_collection
 
 def _featured_collection_ids(platform: Optional[str]) -> List:
     this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -115,6 +115,12 @@ class CollectionViewSet(viewsets.ModelViewSet):
         json_data = open(file_path)  
         deserial_data = json.load(json_data) 
         return Response({"countries": deserial_data})
+    
+    # NOTE!!!! returns a "Task" object! Maybe belongs in a TaskView??
+    @action(methods=['post'], detail=False, url_path='rescrape-collection')
+    def rescrape_feeds(self, request):
+        collection_id = int(request.data["collection_id"])
+        return Response(schedule_scrape_collection(collection_id, request.user))
 
 
 class FeedsViewSet(viewsets.ModelViewSet):

--- a/mcweb/backend/sources/tasks.py
+++ b/mcweb/backend/sources/tasks.py
@@ -93,26 +93,17 @@ def _scrape_collection(collection_id):
         return _return_error(f"collection {collection_id} not found")
     
     sources = collection.source_set.all()
-
+    email = ""
     for source in sources:
-        print(source)
-
         # check source.homepage not empty??
-    # if not source.homepage:
-    #     return _return_error(f"source {source_id} missing homepage")
-
-    # # maybe check if re-scraped recently????
-
-    # name_or_home = source.name or source.homepage
-
-    # # NOTE! Will remove any other pending scrapes for same source
-    # # rather than queuing a duplicate; the new user will "steal" the task
-    # # (leaving no trace of the old one). Returns a Task object.
-    # task = _scrape_source(source_id, source.homepage, creator=user,
-    #                       verbose_name=f"rescrape {name_or_home}",
-    #                       remove_existing_tasks=True)
-    # return {'task': _return_task(task)}
-    return {'task': "hello"}
+        if not source.homepage:
+            return _return_error(f"source {source.id} missing homepage")
+        scraped_source_text = Source._scrape_source(source.id, source.homepage)
+        email += f"{scraped_source_text} \n"
+        logger.info(f"==== finished _scrape_source {source.name}")
+        
+    # send email????
+    logger.info(f"==== finished _scrape_collection({collection.id}, {collection.name})")
 
 run_at = dt.time(hour=14, minute=32)
 # Calculate the number of days until next Friday
@@ -198,20 +189,6 @@ def schedule_scrape_collection(collection_id, user):
     collection = Collection.objects.get(id=collection_id)
     task = _scrape_collection(collection_id, creator=user, verbose_name=f"rescrape {collection.name}", remove_existing_tasks=True)
 
-    # check source.homepage not empty??
-    # if not source.homepage:
-    #     return _return_error(f"source {source_id} missing homepage")
-
-    # # maybe check if re-scraped recently????
-
-    # name_or_home = source.name or source.homepage
-
-    # # NOTE! Will remove any other pending scrapes for same source
-    # # rather than queuing a duplicate; the new user will "steal" the task
-    # # (leaving no trace of the old one). Returns a Task object.
-    # task = _scrape_source(source_id, source.homepage, creator=user,
-    #                       verbose_name=f"rescrape {name_or_home}",
-    #                       remove_existing_tasks=True)
     return {'task': _return_task(task)}
 
 
@@ -238,6 +215,7 @@ def schedule_scrape_source(source_id, user):
                           verbose_name=f"rescrape {name_or_home}",
                           remove_existing_tasks=True)
     return {'task': _return_task(task)}
+
 
 
 def get_completed_tasks(user):

--- a/mcweb/backend/sources/tasks.py
+++ b/mcweb/backend/sources/tasks.py
@@ -83,6 +83,37 @@ def _scrape_source(source_id, homepage):
     logger.info(f"==== finished _scrape_source(source_id, homepage)")
 
 
+
+@background()
+def _scrape_collection(collection_id):
+    logger.info(f"==== starting _scrape_collection(collection_id)")
+
+    collection = Collection.objects.get(id=collection_id)
+    if not collection:
+        return _return_error(f"collection {collection_id} not found")
+    
+    sources = collection.source_set.all()
+
+    for source in sources:
+        print(source)
+
+        # check source.homepage not empty??
+    # if not source.homepage:
+    #     return _return_error(f"source {source_id} missing homepage")
+
+    # # maybe check if re-scraped recently????
+
+    # name_or_home = source.name or source.homepage
+
+    # # NOTE! Will remove any other pending scrapes for same source
+    # # rather than queuing a duplicate; the new user will "steal" the task
+    # # (leaving no trace of the old one). Returns a Task object.
+    # task = _scrape_source(source_id, source.homepage, creator=user,
+    #                       verbose_name=f"rescrape {name_or_home}",
+    #                       remove_existing_tasks=True)
+    # return {'task': _return_task(task)}
+    return {'task': "hello"}
+
 run_at = dt.time(hour=14, minute=32)
 # Calculate the number of days until next Friday
 today = dt.date.today()
@@ -90,8 +121,6 @@ days_until_friday = (4 - today.weekday()) % 7
 # Calculate the datetime when the task should run
 next_friday = today + dt.timedelta(days=days_until_friday)
 run_datetime = dt.datetime.combine(next_friday, run_at)
-
-
 
 def run_alert_system():
     user = User.objects.get(username='e.leon@northeastern.edu')
@@ -161,6 +190,29 @@ def _return_error(message):
     """
     logger.info(f"_return_error {message}")
     return {'error': message}
+
+def schedule_scrape_collection(collection_id, user):
+    """
+    call this function from a view action to schedule a (re)scrape for a collection
+    """
+    collection = Collection.objects.get(id=collection_id)
+    task = _scrape_collection(collection_id, creator=user, verbose_name=f"rescrape {collection.name}", remove_existing_tasks=True)
+
+    # check source.homepage not empty??
+    # if not source.homepage:
+    #     return _return_error(f"source {source_id} missing homepage")
+
+    # # maybe check if re-scraped recently????
+
+    # name_or_home = source.name or source.homepage
+
+    # # NOTE! Will remove any other pending scrapes for same source
+    # # rather than queuing a duplicate; the new user will "steal" the task
+    # # (leaving no trace of the old one). Returns a Task object.
+    # task = _scrape_source(source_id, source.homepage, creator=user,
+    #                       verbose_name=f"rescrape {name_or_home}",
+    #                       remove_existing_tasks=True)
+    return {'task': _return_task(task)}
 
 
 def schedule_scrape_source(source_id, user):

--- a/mcweb/frontend/src/app/services/collectionsApi.js
+++ b/mcweb/frontend/src/app/services/collectionsApi.js
@@ -57,6 +57,13 @@ export const collectionsApi = managerApi.injectEndpoints({
       }),
       invalidatesTags: ['Collection'],
     }),
+    rescrapeCollection: builder.mutation({
+      query: (collectionId) => ({
+        url: 'collections/rescrape-collection/',
+        method: 'POST',
+        body: { collection_id: collectionId },
+      }),
+    }),
   }),
 });
 
@@ -70,4 +77,5 @@ export const {
   useDeleteCollectionMutation,
   useLazyGetCollectionQuery,
   useGetGlobalCollectionsQuery,
+  useRescrapeCollectionMutation,
 } = collectionsApi;

--- a/mcweb/frontend/src/features/collections/CollectionHeader.jsx
+++ b/mcweb/frontend/src/features/collections/CollectionHeader.jsx
@@ -6,7 +6,11 @@ import SearchIcon from '@mui/icons-material/Search';
 import Chip from '@mui/material/Chip';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
 import { Outlet, Link, useParams } from 'react-router-dom';
-import { useGetCollectionQuery, useDeleteCollectionMutation } from '../../app/services/collectionsApi';
+import {
+  useGetCollectionQuery,
+  useDeleteCollectionMutation,
+  useRescrapeCollectionMutation,
+} from '../../app/services/collectionsApi';
 import DownloadSourcesCsv from './util/DownloadSourcesCsv';
 import Permissioned, { ROLE_STAFF } from '../auth/Permissioned';
 import urlSerializer from '../search/util/urlSerializer';
@@ -27,7 +31,10 @@ export default function CollectionHeader() {
   } = useGetCollectionQuery(collectionId);
 
   const [deleteCollection] = useDeleteCollectionMutation();
+  const [rescrapeCollection] = useRescrapeCollectionMutation();
+
   const [open, setOpen] = useState(false);
+  const [openRescrape, setOpenRescrape] = useState(false);
   if (isFetching) {
     return (<CircularProgress size={75} />);
   }
@@ -100,7 +107,25 @@ export default function CollectionHeader() {
             secondAction={false}
             confirmButtonText="Delete"
           />
+          <AlertDialog
+            outsideTitle="Rescrape Collection For Feeds"
+            title={`Rescrape Collection #${collectionId}: ${collection.name} for new feeds?`}
+            content="Are you sure you want to rescrape each source in this collection for new feeds?"
+            dispatchNeeded={false}
+            action={rescrapeCollection}
+            actionTarget={collectionId}
+            snackbar
+            snackbarText="Collection Queued for rescraping!"
+            onClick={() => setOpenRescrape(true)}
+            openDialog={openRescrape}
+            variant="outlined"
+            navigateNeeded={false}
+            endIcon={<LockOpenIcon titleAccess="admin-delete" />}
+            secondAction={false}
+            confirmButtonText="Rescrape"
+          />
         </Permissioned>
+
       </ControlBar>
       <Outlet />
     </>

--- a/mcweb/frontend/src/features/collections/CollectionHeader.jsx
+++ b/mcweb/frontend/src/features/collections/CollectionHeader.jsx
@@ -107,6 +107,8 @@ export default function CollectionHeader() {
             secondAction={false}
             confirmButtonText="Delete"
           />
+          { collection.platform === 'online_news' && (
+
           <AlertDialog
             outsideTitle="Rescrape Collection For Feeds"
             title={`Rescrape Collection #${collectionId}: ${collection.name} for new feeds?`}
@@ -124,6 +126,7 @@ export default function CollectionHeader() {
             secondAction={false}
             confirmButtonText="Rescrape"
           />
+          )}
         </Permissioned>
 
       </ControlBar>

--- a/mcweb/frontend/src/features/collections/ModifyCollection.jsx
+++ b/mcweb/frontend/src/features/collections/ModifyCollection.jsx
@@ -84,7 +84,7 @@ export default function ModifyCollection() {
         platform: data.platform,
         public: data.public,
         featured: data.featured,
-        rescrape: true,
+        rescrape: data.platform === 'online_news',
       };
       setFormState(formData);
     }
@@ -292,6 +292,7 @@ export default function ModifyCollection() {
         </div>
 
         <div style={{ display: 'flex' }}>
+          {formState.platform === 'online_news' && (
 
           <FormControlLabel
             control={(
@@ -303,6 +304,7 @@ export default function ModifyCollection() {
               )}
             label="Automatically discover RSS feeds in new sources?"
           />
+          )}
 
           <UploadSources className="col-6" collectionId={collectionId} rescrape={formState.rescrape} />
         </div>

--- a/mcweb/frontend/src/features/sources/SourceHeader.jsx
+++ b/mcweb/frontend/src/features/sources/SourceHeader.jsx
@@ -131,6 +131,7 @@ export default function SourceHeader() {
             secondAction={false}
             confirmButtonText="delete"
           />
+          {source.platform === 'online_news' && (
 
           <AlertDialog
             outsideTitle="Rescrape Source"
@@ -150,6 +151,7 @@ export default function SourceHeader() {
             secondAction={false}
             confirmButtonText="Rescrape"
           />
+          )}
 
         </Permissioned>
       </ControlBar>


### PR DESCRIPTION
closes #299 allow user to click button to rescrape a collection.
- background task that iterates through each source and has that source look for new feeds (re-uses _scrape_source code)
  - allows rescrape collection to appear as its own task
![Screen Shot 2023-04-27 at 3 26 42 PM](https://user-images.githubusercontent.com/78226696/234971118-738ad834-dde3-446c-9265-447232492177.png)
