### PR TITLE
Re: Add stories_per_week to Source Search results in Media Picker

### DIFF
--- a/mcweb/frontend/src/features/search/query/media-picker/MediaPickerSelectionTable.jsx
+++ b/mcweb/frontend/src/features/search/query/media-picker/MediaPickerSelectionTable.jsx
@@ -22,6 +22,9 @@ export default function MediaPickerSelectionTable({
           {collection && (
             <th>Sources</th>
           )}
+          {!collection && (
+            <th>Stories per week</th>
+          )}
         </tr>
         {matching.map((c) => (
           <tr key={c.id}>
@@ -37,6 +40,9 @@ export default function MediaPickerSelectionTable({
             <td>{collection ? c.notes : c.label}</td>
             {collection && (
               <td className="numeric">{asNumber(c.source_count)}</td>
+            )}
+            {!collection && (
+            <td>{c.stories_per_week?.toString() ?? '?'}</td>
             )}
             <td>
               {!(alreadySelected(c.id)) && (


### PR DESCRIPTION
- created a column for `stories_per_week` in the Search All Sources tab
- in `MediaPickerSelectionTable.jsx` if you aren't searching through collections, the column of stories per week is displayed
<img width="1406" alt="Screenshot 2023-05-02 at 12 27 59 PM" src="https://user-images.githubusercontent.com/91026581/235727227-46cf079e-c259-4dea-88b4-b144b1b4d979.png">
