### PR TITLE
New command method to update stories per week

### DIFF
--- a/mcweb/backend/sources/management/commands/source-alert-system.py
+++ b/mcweb/backend/sources/management/commands/source-alert-system.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = 'Update the stories-per-week for every media source'
+    help = 'Schedule the source alert system to run'
 
 
     def handle(self, *args, **options):

--- a/mcweb/backend/sources/management/commands/update-stories-per-week.py
+++ b/mcweb/backend/sources/management/commands/update-stories-per-week.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+import logging
+
+from ...tasks import update_stories_per_week
+
+
+
+logger = logging.getLogger(__name__)
+
+
+
+class Command(BaseCommand):
+    help = 'Update the stories-per-week for every media source in rss fetcher'
+
+
+    def handle(self, *args, **options):
+        logger.info("====starting update stories task")
+        update_stories_per_week()

--- a/mcweb/backend/sources/models.py
+++ b/mcweb/backend/sources/models.py
@@ -213,10 +213,13 @@ class Source(models.Model):
         return(f"scraped_source({source_id}, {homepage})")
 
     @classmethod
-    def update_stories_per_week(source, weekly_story_count):
-        source=Source.objects.get(pk=source) 
-        source.stories_per_week = weekly_story_count
-        source.save()
+    def update_stories_per_week(cls, source_id: int , weekly_story_count):
+        try:
+            source=Source.objects.get(pk=source_id) 
+            source.stories_per_week = weekly_story_count
+            source.save()
+        except:
+            logger.warn(f"source {source_id} not found")
 
     
 class Feed(models.Model):


### PR DESCRIPTION
New management command to trigger background task to query rss fetcher for tuples of source_id, daily_count, multiply the daily count by 7 and save to source.