### PR TITLE
Customize Tab (Minus Icon and Color Tab) 

### DIFF
--- a/mcweb/frontend/__tests__/spliceMethod.test.js
+++ b/mcweb/frontend/__tests__/spliceMethod.test.js
@@ -1,0 +1,27 @@
+test('remove first element', () => {
+  const array = [1, 2, 3, 4, 5];
+  array.splice(0, 1);
+
+  expect(array).toStrictEqual([2, 3, 4, 5]);
+});
+
+test('remove second element', () => {
+  const array = [1, 2, 3, 4, 5];
+  array.splice(1, 1);
+
+  expect(array).toStrictEqual([1, 3, 4, 5]);
+});
+
+test('remove third element', () => {
+  const array = [1, 2, 3, 4, 5];
+  array.splice(2, 1);
+
+  expect(array).toStrictEqual([1, 2, 4, 5]);
+});
+
+test('remove last element', () => {
+  const array = [1, 2, 3, 4, 5];
+  array.splice(array.length - 1, 1);
+
+  expect(array).toStrictEqual([1, 2, 3, 4]);
+});

--- a/mcweb/frontend/__tests__/tabTitle.test.js
+++ b/mcweb/frontend/__tests__/tabTitle.test.js
@@ -218,7 +218,7 @@ test('Empty Query (United States - National Collection) (Two Identical Objects)'
   expect(tabTitle(queryState, 1)).toBe('Query 2');
 });
 
-test('Empty Query (United States - National Collection) (Two Identical Objects)', () => {
+test('(Tab 1 Title with two objects', () => {
   const queryState = [{
     advanced: false,
     anyAll: 'any',
@@ -278,3 +278,65 @@ test('Empty Query (United States - National Collection) (Two Identical Objects)'
   expect(tabTitle(queryState, 1)).toBe('Query 2');
 });
 
+test('Empty Query (United States - National Collection) (Additional Test)', () => {
+  const queryState = [{
+    advanced: false,
+    anyAll: 'any',
+    collections:
+      [{
+        id: 34412234,
+        name: 'United States - National',
+        public: true,
+        type: 'collection',
+      }],
+    startDate: '03/28/2023',
+    endDate: '04/30/2023',
+    lastSearchTime: 1682943747,
+    negatedQueryList: [['War'], [], []],
+    platform: 'onlinenews-waybackmachine',
+    previewCollections: [{
+      type: 'collection',
+      id: 34412234,
+      name: 'United States - National',
+      platform: 'online_news',
+      public: true,
+    }],
+    sources: [],
+    previewSources: [],
+    queryList: [['Love'], [], []],
+    queryString: '',
+  },
+  {
+    advanced: false,
+    anyAll: 'any',
+    collections:
+      [{
+        id: 34412234,
+        name: 'United States - National',
+        public: true,
+        type: 'collection',
+      }],
+    startDate: '03/28/2023',
+    endDate: '04/30/2023',
+    lastSearchTime: 1682943747,
+    negatedQueryList: [['Artificial Intelligence'], [], []],
+    platform: 'reddit-reddit',
+    previewCollections: [{
+      type: 'collection',
+      id: 34412234,
+      name: 'United States - National',
+      platform: 'online_news',
+      public: true,
+    }],
+    sources: [],
+    previewSources: [],
+    queryList: [['Artificial Intelligence'], [], []],
+    queryString: '',
+  }];
+
+  const queryTitle = '(Artificial Intelligence) AND NOT (Artificial Intelligence)';
+  const queryTabResult = `${queryTitle.substring(0, 35)} ...`;
+
+  expect(tabTitle(queryState, 0)).toBe('(Love) AND NOT (War)');
+  expect(tabTitle(queryState, 1)).toBe(queryTabResult);
+});

--- a/mcweb/frontend/__tests__/tabTitle.test.js
+++ b/mcweb/frontend/__tests__/tabTitle.test.js
@@ -1,0 +1,280 @@
+import tabTitle from '../src/features/search/util/tabTitle';
+// import { PROVIDER_NEWS_MEDIA_CLOUD } from '../src/features/search/util/platforms';
+
+test('Empty Query (United States - National Collection)', () => {
+  const queryState = [{
+    advanced: false,
+    anyAll: 'any',
+    collections:
+      [{
+        id: 34412234,
+        name: 'United States - National',
+        public: true,
+        type: 'collection',
+      }],
+    startDate: '03/28/2023',
+    endDate: '04/30/2023',
+    lastSearchTime: 1682943747,
+    negatedQueryList: [[], [], []],
+    platform: 'onlinenews-mediacloud',
+    previewCollections: [{
+      type: 'collection',
+      id: 34412234,
+      name: 'United States - National',
+      platform: 'online_news',
+      public: true,
+    }],
+    sources: [],
+    previewSources: [],
+    queryList: [[], [], []],
+    queryString: '',
+  }];
+
+  const queryIndex = 0;
+
+  expect(tabTitle(queryState, queryIndex)).toBe('Query 1');
+});
+
+test('Empty Query WayBackMachine', () => {
+  const queryState = [{
+    advanced: false,
+    anyAll: 'any',
+    collections:
+      [{
+        id: 34412234,
+        name: 'United States - National',
+        public: true,
+        type: 'collection',
+      }],
+    startDate: '03/28/2023',
+    endDate: '04/30/2023',
+    lastSearchTime: 1682943747,
+    negatedQueryList: [[], [], []],
+    platform: 'onlinenews-waybackmachine',
+    previewCollections: [{
+      type: 'collection',
+      id: 34412234,
+      name: 'United States - National',
+      platform: 'online_news',
+      public: true,
+    }],
+    sources: [],
+    previewSources: [],
+    queryList: [[], [], []],
+    queryString: '',
+  }];
+
+  const queryIndex = 0;
+
+  expect(tabTitle(queryState, queryIndex)).toBe('Query 1');
+});
+
+test('Empty Query Reddit', () => {
+  const queryState = [{
+    advanced: false,
+    anyAll: 'any',
+    collections: [{
+      id: 34412234,
+      name: 'United States - National',
+      public: true,
+      type: 'collection',
+    }],
+    startDate: '03/28/2023',
+    endDate: '04/30/2023',
+    lastSearchTime: 1682943747,
+    negatedQueryList: [[], [], []],
+    platform: 'reddit-pushift',
+    previewCollections: [{
+      type: 'collection',
+      id: 34412234,
+      name: 'United States - National',
+      platform: 'online_news',
+      public: true,
+    }],
+    sources: [],
+    previewSources: [],
+    queryList: [[], [], []],
+    queryString: '',
+  }];
+
+  const queryIndex = 0;
+
+  expect(tabTitle(queryState, queryIndex)).toBe('Query 1');
+});
+
+test('Empty Query Twitter', () => {
+  const queryState = [{
+    advanced: false,
+    anyAll: 'any',
+    collections: [],
+    startDate: '03/28/2023',
+    endDate: '04/27/2023',
+    lastSearchTime: 1682943747,
+    negatedQueryList: [[], [], []],
+    platform: 'twitter-twitter',
+    previewCollections: [{
+      type: 'collection',
+      id: 34412234,
+      name: 'United States - National',
+      platform: 'online_news',
+      public: true,
+    }],
+    previewSources: [],
+    sources: [],
+    queryList: [[], [], []],
+    queryString: '',
+  }];
+
+  const queryIndex = 0;
+
+  expect(tabTitle(queryState, queryIndex)).toBe('Query 1');
+});
+
+test('Empty Query Youtube', () => {
+  const queryState = [{
+    advanced: false,
+    anyAll: 'any',
+    collections: [],
+    startDate: '03/28/2023',
+    endDate: '04/27/2023',
+    lastSearchTime: 1682943747,
+    negatedQueryList: [[], [], []],
+    platform: 'yotube-youtube',
+    previewCollections: [{
+      type: 'collection',
+      id: 34412234,
+      name: 'United States - National',
+      platform: 'online_news',
+      public: true,
+    }],
+    previewSources: [],
+    sources: [],
+    queryList: [[], [], []],
+    queryString: '',
+  }];
+
+  const queryIndex = 0;
+
+  expect(tabTitle(queryState, queryIndex)).toBe('Query 1');
+});
+
+test('Empty Query (United States - National Collection) (Two Identical Objects)', () => {
+  const queryState = [{
+    advanced: false,
+    anyAll: 'any',
+    collections:
+      [{
+        id: 34412234,
+        name: 'United States - National',
+        public: true,
+        type: 'collection',
+      }],
+    startDate: '03/28/2023',
+    endDate: '04/30/2023',
+    lastSearchTime: 1682943747,
+    negatedQueryList: [[], [], []],
+    platform: 'onlinenews-mediacloud',
+    previewCollections: [{
+      type: 'collection',
+      id: 34412234,
+      name: 'United States - National',
+      platform: 'online_news',
+      public: true,
+    }],
+    sources: [],
+    previewSources: [],
+    queryList: [[], [], []],
+    queryString: '',
+  },
+  {
+    advanced: false,
+    anyAll: 'any',
+    collections:
+      [{
+        id: 34412234,
+        name: 'United States - National',
+        public: true,
+        type: 'collection',
+      }],
+    startDate: '03/28/2023',
+    endDate: '04/30/2023',
+    lastSearchTime: 1682943747,
+    negatedQueryList: [[], [], []],
+    platform: 'onlinenews-mediacloud',
+    previewCollections: [{
+      type: 'collection',
+      id: 34412234,
+      name: 'United States - National',
+      platform: 'online_news',
+      public: true,
+    }],
+    sources: [],
+    previewSources: [],
+    queryList: [[], [], []],
+    queryString: '',
+  }];
+
+  expect(tabTitle(queryState, 0)).toBe('Query 1');
+  expect(tabTitle(queryState, 1)).toBe('Query 2');
+});
+
+test('Empty Query (United States - National Collection) (Two Identical Objects)', () => {
+  const queryState = [{
+    advanced: false,
+    anyAll: 'any',
+    collections:
+      [{
+        id: 34412234,
+        name: 'United States - National',
+        public: true,
+        type: 'collection',
+      }],
+    startDate: '03/28/2023',
+    endDate: '04/30/2023',
+    lastSearchTime: 1682943747,
+    negatedQueryList: [['War'], [], []],
+    platform: 'onlinenews-waybackmachine',
+    previewCollections: [{
+      type: 'collection',
+      id: 34412234,
+      name: 'United States - National',
+      platform: 'online_news',
+      public: true,
+    }],
+    sources: [],
+    previewSources: [],
+    queryList: [['Love'], [], []],
+    queryString: '',
+  },
+  {
+    advanced: false,
+    anyAll: 'any',
+    collections:
+      [{
+        id: 34412234,
+        name: 'United States - National',
+        public: true,
+        type: 'collection',
+      }],
+    startDate: '03/28/2023',
+    endDate: '04/30/2023',
+    lastSearchTime: 1682943747,
+    negatedQueryList: [[], [], []],
+    platform: 'reddit-reddit',
+    previewCollections: [{
+      type: 'collection',
+      id: 34412234,
+      name: 'United States - National',
+      platform: 'online_news',
+      public: true,
+    }],
+    sources: [],
+    previewSources: [],
+    queryList: [[], [], []],
+    queryString: '',
+  }];
+
+  expect(tabTitle(queryState, 0)).toBe('(Love) AND NOT (War)');
+  expect(tabTitle(queryState, 1)).toBe('Query 2');
+});
+

--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -74,22 +74,20 @@ export default function TabbedSearch() {
         <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
           <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
             {queryState.map((query, i) => (
-                <Tab
-                  key={`${tabTitle(queryState, i)}`}
-                  label={(
-                    <div>
-                      {tabTitle(queryState, i)}
-
-                      <RemoveCircleOutlineIcon
-                        sx={{ color: '#d24527', marginLeft: '.5rem' }}
-                        onClick={() => handleRemoveQuery(i)}
-                        variant="contained"
-                      />
-
-                    </div>
-                  )}
-                  {...a11yProps(i)}
-                />
+              <Tab
+                key={`${tabTitle(queryState, i)}`}
+                label={(
+                  <div>
+                    {tabTitle(queryState, i)}
+                    <RemoveCircleOutlineIcon
+                      sx={{ color: '#d24527', marginLeft: '.5rem' }}
+                      onClick={() => handleRemoveQuery(i)}
+                      variant="contained"
+                    />
+                  </div>
+                )}
+                {...a11yProps(i)}
+              />
             ))}
             <Tab label="+ Add Query" onClick={handleAddQuery} />
           </Tabs>

--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -37,8 +37,6 @@ export default function TabbedSearch() {
     setValue(newValue);
   };
 
-  console.log(queryState);
-
   const handleAddQuery = () => {
     const qsLength = queryState.length;
     dispatch(addQuery(platform));

--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -51,8 +51,15 @@ export default function TabbedSearch() {
   };
 
   const handleRemoveQuery = (index) => {
-    setColors((index) => color.filter((_, index) => c !== 0));
+    const newColorArray = [];
+    for (let i = 0; i < color.length; i += 1) {
+      if (i !== index) {
+        newColorArray.push(color[i]);
+      }
+    }
+    setColors(newColorArray);
     dispatch(removeQuery(index));
+
     if (index === 0) {
       setValue(0);
     } else {
@@ -75,13 +82,8 @@ export default function TabbedSearch() {
 
   const [anchorEl, setAnchorEl] = useState(false);
 
-  const handleRightClick = (event) => {
-    event.preventDefault();
-    setAnchorEl(event.currentTarget);
-  };
-
   const handleClose = (index, colorValue) => {
-    console.log(index);
+    setValue(index);
     const newColors = [...color];
     newColors[index] = colorValue;
     setColors(newColors);
@@ -97,32 +99,38 @@ export default function TabbedSearch() {
             {queryState.map((query, i) => (
               <Tab
                 key={`${tabTitle(queryState, i)}`}
-                onContextMenu={handleRightClick}
+                onContextMenu={
+                  (event) => {
+                    setValue(i);
+                    event.preventDefault();
+                    setAnchorEl(event.currentTarget);
+                  }
+                }
+                sx={{ marginRight: 0.5 }}
                 style={{
-                  boxShadow: '0px 0px 4px 2px rgba(255, 0, 0, 0.2)', // adjust the color and blur radius as needed
-                  outline: `4px solid ${color[i]}`, // change the color and size as needed
+                  outline: `3px solid ${color[i]}`, // change the color and size as needed
                   outlineOffset: '-4px', // adjust this value to match the size of the outline
                 }}
                 label={(
                   <div className="tabTitleLabel">
 
-                    {/* <input className="tabNameInput" value={tabTitles[i]} /> */}
                     {tabTitle(queryState, i)}
 
                     <Menu anchorEl={anchorEl} open={anchorEl} onClose={handleClose}>
-                      <MenuItem onClick={() => handleClose(i, 'orange')}>Orange</MenuItem>
-                      <MenuItem onClick={() => handleClose(i, 'yellow')}>Yellow</MenuItem>
-                      <MenuItem onClick={() => handleClose(i, 'green')}>Green</MenuItem>
-                      <MenuItem onClick={() => handleClose(i, 'blue')}>Blue</MenuItem>
-                      <MenuItem onClick={() => handleClose(i, 'indigo')}>Indigo</MenuItem>
-                      <MenuItem onClick={() => handleClose(i, 'deepPurple')}>Violet</MenuItem>
+                      <MenuItem onClick={() => handleClose(value, 'orange')}>Orange</MenuItem>
+                      <MenuItem onClick={() => handleClose(value, 'yellow')}>Yellow</MenuItem>
+                      <MenuItem onClick={() => handleClose(value, 'green')}>Green</MenuItem>
+                      <MenuItem onClick={() => handleClose(value, 'blue')}>Blue</MenuItem>
+                      <MenuItem onClick={() => handleClose(value, 'indigo')}>Indigo</MenuItem>
                     </Menu>
 
-                    <RemoveCircleOutlineIcon
-                      sx={{ color: '#d24527', marginLeft: '.5rem' }}
-                      onClick={() => handleRemoveQuery(i)}
-                      variant="contained"
-                    />
+                    {!(i === 0 && queryState.length - 1 === 0) && (
+                      <RemoveCircleOutlineIcon
+                        sx={{ color: '#d24527', marginLeft: '.5rem' }}
+                        onClick={() => handleRemoveQuery(i)}
+                        variant="contained"
+                      />
+                    )}
                   </div>
                 )}
                 {...a11yProps(i)}

--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -52,13 +52,19 @@ export default function TabbedSearch() {
 
   const handleRemoveQuery = (index) => {
     const newColorArray = [];
+
     for (let i = 0; i < color.length; i += 1) {
       if (i !== index) {
         newColorArray.push(color[i]);
       }
     }
+
     setColors(newColorArray);
     dispatch(removeQuery(index));
+
+    console.log(`value: ${value}`);
+    console.log(`index: ${index}`);
+    console.log(`queryState.length: ${queryState.length}`);
 
     if (index === 0) {
       setValue(0);
@@ -101,6 +107,9 @@ export default function TabbedSearch() {
                 key={`${tabTitle(queryState, i)}`}
                 onContextMenu={
                   (event) => {
+                    console.log(`value: ${value}`);
+                    console.log(`index: ${index}`);
+                    console.log(`queryState.length: ${queryState.length}`);
                     setValue(i);
                     event.preventDefault();
                     setAnchorEl(event.currentTarget);

--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -5,6 +5,8 @@ import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
+import MenuItem from '@mui/material/MenuItem';
+import Menu from '@mui/material/Menu';
 import SearchIcon from '@mui/icons-material/Search';
 import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
 import ContentCopy from '@mui/icons-material/ContentCopy';
@@ -32,18 +34,24 @@ export default function TabbedSearch() {
   const [open, setOpen] = useState(false);
 
   const queryState = useSelector((state) => state.query);
+
+  const [color, setColors] = useState(['White']);
+
   const { platform } = queryState[0];
+
   const handleChange = (event, newValue) => {
     setValue(newValue);
   };
 
   const handleAddQuery = () => {
     const qsLength = queryState.length;
+    setColors(() => [...color, 'White']);
     dispatch(addQuery(platform));
     setValue(qsLength);
   };
 
   const handleRemoveQuery = (index) => {
+    setColors((index) => color.filter((_, index) => c !== 0));
     dispatch(removeQuery(index));
     if (index === 0) {
       setValue(0);
@@ -65,6 +73,21 @@ export default function TabbedSearch() {
     setShow(deactivateButton(queryState));
   }, [queryState]);
 
+  const [anchorEl, setAnchorEl] = useState(false);
+
+  const handleRightClick = (event) => {
+    event.preventDefault();
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = (index, colorValue) => {
+    console.log(index);
+    const newColors = [...color];
+    newColors[index] = colorValue;
+    setColors(newColors);
+    setAnchorEl(null);
+  };
+
   return (
     <div className="container search-container">
       <PlatformPicker queryIndex={0} sx={{ paddingTop: 50 }} />
@@ -74,9 +97,27 @@ export default function TabbedSearch() {
             {queryState.map((query, i) => (
               <Tab
                 key={`${tabTitle(queryState, i)}`}
+                onContextMenu={handleRightClick}
+                style={{
+                  boxShadow: '0px 0px 4px 2px rgba(255, 0, 0, 0.2)', // adjust the color and blur radius as needed
+                  outline: `4px solid ${color[i]}`, // change the color and size as needed
+                  outlineOffset: '-4px', // adjust this value to match the size of the outline
+                }}
                 label={(
-                  <div>
+                  <div className="tabTitleLabel">
+
+                    {/* <input className="tabNameInput" value={tabTitles[i]} /> */}
                     {tabTitle(queryState, i)}
+
+                    <Menu anchorEl={anchorEl} open={anchorEl} onClose={handleClose}>
+                      <MenuItem onClick={() => handleClose(i, 'orange')}>Orange</MenuItem>
+                      <MenuItem onClick={() => handleClose(i, 'yellow')}>Yellow</MenuItem>
+                      <MenuItem onClick={() => handleClose(i, 'green')}>Green</MenuItem>
+                      <MenuItem onClick={() => handleClose(i, 'blue')}>Blue</MenuItem>
+                      <MenuItem onClick={() => handleClose(i, 'indigo')}>Indigo</MenuItem>
+                      <MenuItem onClick={() => handleClose(i, 'deepPurple')}>Violet</MenuItem>
+                    </Menu>
+
                     <RemoveCircleOutlineIcon
                       sx={{ color: '#d24527', marginLeft: '.5rem' }}
                       onClick={() => handleRemoveQuery(i)}

--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -62,10 +62,6 @@ export default function TabbedSearch() {
     setColors(newColorArray);
     dispatch(removeQuery(index));
 
-    console.log(`value: ${value}`);
-    console.log(`index: ${index}`);
-    console.log(`queryState.length: ${queryState.length}`);
-
     if (index === 0) {
       setValue(0);
     } else {
@@ -107,9 +103,6 @@ export default function TabbedSearch() {
                 key={`${tabTitle(queryState, i)}`}
                 onContextMenu={
                   (event) => {
-                    console.log(`value: ${value}`);
-                    console.log(`index: ${index}`);
-                    console.log(`queryState.length: ${queryState.length}`);
                     setValue(i);
                     event.preventDefault();
                     setAnchorEl(event.currentTarget);
@@ -117,7 +110,7 @@ export default function TabbedSearch() {
                 }
                 sx={{ marginRight: 0.5 }}
                 style={{
-                  outline: `3px solid ${color[i]}`, // change the color and size as needed
+                  outline: `4px solid ${color[i]}`, // change the color and size as needed
                   outlineOffset: '-4px', // adjust this value to match the size of the outline
                 }}
                 label={(

--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -23,7 +23,6 @@ import { searchApi } from '../../app/services/searchApi';
 import deactivateButton from './util/deactivateButton';
 import urlSerializer from './util/urlSerializer';
 import tabTitle from './util/tabTitle';
-import tabTitleLength from './util/tabTitleLength';
 
 export default function TabbedSearch() {
   const dispatch = useDispatch();
@@ -37,6 +36,8 @@ export default function TabbedSearch() {
   const handleChange = (event, newValue) => {
     setValue(newValue);
   };
+
+  console.log(queryState);
 
   const handleAddQuery = () => {
     const qsLength = queryState.length;
@@ -73,25 +74,22 @@ export default function TabbedSearch() {
         <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
           <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
             {queryState.map((query, i) => (
-              <Tab
-                key={`${tabTitle(queryState, i)}`}
-                label={(
-                  <div>
-                    {tabTitle(queryState, i)}
+                <Tab
+                  key={`${tabTitle(queryState, i)}`}
+                  label={(
+                    <div>
+                      {tabTitle(queryState, i)}
 
-                    {tabTitleLength}
+                      <RemoveCircleOutlineIcon
+                        sx={{ color: '#d24527', marginLeft: '.5rem' }}
+                        onClick={() => handleRemoveQuery(i)}
+                        variant="contained"
+                      />
 
-                    <RemoveCircleOutlineIcon
-                      sx={{ color: '#d24527', marginLeft: '.5rem' }}
-                      onClick={() => handleRemoveQuery(i)}
-                      variant="contained"
-                    />
-
-                  </div>
-                )}
-                {...a11yProps(i)}
-              />
-
+                    </div>
+                  )}
+                  {...a11yProps(i)}
+                />
             ))}
             <Tab label="+ Add Query" onClick={handleAddQuery} />
           </Tabs>

--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -6,6 +6,7 @@ import Tab from '@mui/material/Tab';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import SearchIcon from '@mui/icons-material/Search';
+import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
 import ContentCopy from '@mui/icons-material/ContentCopy';
 import dayjs from 'dayjs';
 import { addQuery, setLastSearchTime, removeQuery } from './query/querySlice';
@@ -21,6 +22,8 @@ import TabPanelHelper from '../ui/TabPanelHelper';
 import { searchApi } from '../../app/services/searchApi';
 import deactivateButton from './util/deactivateButton';
 import urlSerializer from './util/urlSerializer';
+import tabTitle from './util/tabTitle';
+import tabTitleLength from './util/tabTitleLength';
 
 export default function TabbedSearch() {
   const dispatch = useDispatch();
@@ -70,7 +73,25 @@ export default function TabbedSearch() {
         <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
           <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
             {queryState.map((query, i) => (
-              <Tab key={`Query ${i + 1}`} label={`Query ${i + 1}`} {...a11yProps(i)} />
+              <Tab
+                key={`${tabTitle(queryState, i)}`}
+                label={(
+                  <div>
+                    {tabTitle(queryState, i)}
+
+                    {tabTitleLength}
+
+                    <RemoveCircleOutlineIcon
+                      sx={{ color: '#d24527', marginLeft: '.5rem' }}
+                      onClick={() => handleRemoveQuery(i)}
+                      variant="contained"
+                    />
+
+                  </div>
+                )}
+                {...a11yProps(i)}
+              />
+
             ))}
             <Tab label="+ Add Query" onClick={handleAddQuery} />
           </Tabs>
@@ -78,12 +99,6 @@ export default function TabbedSearch() {
 
         {queryState.map((query, i) => (
           <TabPanelHelper key={i} value={value} index={i}>
-            <Button
-              onClick={() => handleRemoveQuery(i)}
-              variant="contained"
-            >
-              Remove Query
-            </Button>
             <Search queryIndex={i} />
           </TabPanelHelper>
         ))}

--- a/mcweb/frontend/src/features/search/query/querySlice.js
+++ b/mcweb/frontend/src/features/search/query/querySlice.js
@@ -32,23 +32,23 @@ const cleanQuery = (platform) => ({
 const querySlice = createSlice({
   name: 'query',
   initialState:
-  [
-    {
-      queryString: '',
-      queryList: [[], [], []],
-      negatedQueryList: [[], [], []],
-      platform: DEFAULT_PROVIDER,
-      startDate,
-      endDate: dayjs(latestAllowedEndDate(DEFAULT_PROVIDER)).format('MM/DD/YYYY'),
-      collections: DEFAULT_ONLINE_NEWS_COLLECTIONS,
-      previewCollections: DEFAULT_ONLINE_NEWS_COLLECTIONS,
-      sources: [],
-      previewSources: [],
-      lastSearchTime: dayjs().unix(),
-      anyAll: 'any',
-      advanced: false,
-    },
-  ],
+    [
+      {
+        queryString: '',
+        queryList: [[], [], []],
+        negatedQueryList: [[], [], []],
+        platform: DEFAULT_PROVIDER,
+        startDate,
+        endDate: dayjs(latestAllowedEndDate(DEFAULT_PROVIDER)).format('MM/DD/YYYY'),
+        collections: DEFAULT_ONLINE_NEWS_COLLECTIONS,
+        previewCollections: DEFAULT_ONLINE_NEWS_COLLECTIONS,
+        sources: [],
+        previewSources: [],
+        lastSearchTime: dayjs().unix(),
+        anyAll: 'any',
+        advanced: false,
+      },
+    ],
 
   reducers: {
     addSelectedMedia: (state, { payload }) => {
@@ -143,7 +143,7 @@ const querySlice = createSlice({
       } else if (payload === 0) {
         freezeState.shift();
       } else {
-        freezeState.splice(payload, payload);
+        freezeState.splice(payload, 1);
       }
     },
   },

--- a/mcweb/frontend/src/features/search/styles/_search.scss
+++ b/mcweb/frontend/src/features/search/styles/_search.scss
@@ -47,6 +47,24 @@
     
   }
   
+  .tabTitleLabel {
+    
+    .tabNameInput{ 
+      border: none;
+      outline: none;
+      background: transparent;
+      color: inherit;
+      font-style: inherit;
+      font-weight: inherit;
+      font-size: inherit;
+      line-height: inherit;
+      display: inline-flex;
+      size: inherit;
+      text-align: center;
+      
+    }
+  }
+  
   
   
   p.help {
@@ -57,7 +75,7 @@
   }
   
   .date-accuracy-alert {
-
+    
     .enable-alert {
       font-size: 12px;
       margin-left: 55%;

--- a/mcweb/frontend/src/features/search/util/tabTitle.js
+++ b/mcweb/frontend/src/features/search/util/tabTitle.js
@@ -1,0 +1,15 @@
+import queryTitle from './queryTitle';
+import tabTitleLength from './tabTitleLength';
+
+const tabTitle = (queryState, queryIndex) => {
+  const title = queryTitle(queryState, queryIndex);
+
+  if (title === '*') {
+    return `Query ${queryIndex + 1}`;
+  } if (tabTitleLength(queryState, queryIndex)) {
+    return `${title.substring(0, 35)} ...`;
+  }
+  return title;
+};
+
+export default tabTitle;

--- a/mcweb/frontend/src/features/search/util/tabTitle.js
+++ b/mcweb/frontend/src/features/search/util/tabTitle.js
@@ -1,12 +1,17 @@
 import queryTitle from './queryTitle';
-import tabTitleLength from './tabTitleLength';
+import { PROVIDER_NEWS_MEDIA_CLOUD } from './platforms';
 
 const tabTitle = (queryState, queryIndex) => {
-  const title = queryTitle(queryState, queryIndex);
+  const query = queryState.map((item) => ({
+    ...item,
+    platform: PROVIDER_NEWS_MEDIA_CLOUD,
+  }));
+
+  const title = queryTitle(query, queryIndex);
 
   if (title === '*') {
     return `Query ${queryIndex + 1}`;
-  } if (tabTitleLength(queryState, queryIndex)) {
+  } if (title.length > 35) {
     return `${title.substring(0, 35)} ...`;
   }
   return title;

--- a/mcweb/frontend/src/features/search/util/tabTitleLength.js
+++ b/mcweb/frontend/src/features/search/util/tabTitleLength.js
@@ -1,9 +1,0 @@
-import queryTitle from './queryTitle';
-
-const tabTitleLength = (queryState, queryIndex) => {
-  const title = queryTitle(queryState, queryIndex);
-
-  return title.length > 35;
-};
-
-export default tabTitleLength;

--- a/mcweb/frontend/src/features/search/util/tabTitleLength.js
+++ b/mcweb/frontend/src/features/search/util/tabTitleLength.js
@@ -1,0 +1,9 @@
+import queryTitle from './queryTitle';
+
+const tabTitleLength = (queryState, queryIndex) => {
+  const title = queryTitle(queryState, queryIndex);
+
+  return title.length > 35;
+};
+
+export default tabTitleLength;


### PR DESCRIPTION
- tabTitle.js produces a title for each tab
- created styling for input, later going to be implemented 
- fixed bug with freezeState.splice(payload,payload) 
- add doubleClick menu to change color

<img width="1440" alt="Screen Shot 2023-05-04 at 8 47 42 AM" src="https://user-images.githubusercontent.com/63474660/236209252-0d1aea31-b424-4f65-9c30-c0af13099355.png">


- future: replace name of color with color circles like Google Chrome Tab Feature 
- future: customize title of tab