### PR TITLE
DefaultDates dispatching corrected.

### DIFF
--- a/mcweb/frontend/src/features/search/query/DefaultDates.jsx
+++ b/mcweb/frontend/src/features/search/query/DefaultDates.jsx
@@ -2,35 +2,37 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import dayjs from 'dayjs';
-import { Link } from '@mui/material';
+import Link from '@mui/material/Link';
 import PropTypes from 'prop-types';
 import { setQueryProperty } from './querySlice';
 import { latestAllowedEndDate } from '../util/platforms';
 
 export default function DefaultDates({
-  amountOfTime, typeOfTime, message, platform,
+  amountOfTime, typeOfTime, message, platform, queryIndex,
 }) {
   const dispatch = useDispatch();
 
-  const endDate = latestAllowedEndDate(platform);
   return (
-
     <Link
       underline="hover"
       component="button"
       variant="body2"
       sx={{ marginRight: 3 }}
       onClick={() => {
-        dispatch(setQueryProperty({ endDate: endDate.format('MM/DD/YYYY') }));
+        // get last possible endDate per platform
+        const endDate = latestAllowedEndDate(platform).format('MM/DD/YYYY');
+        // substract the amount of time per type of time (month)
+        const startDate = dayjs(endDate, 'MM-DD-YYYY').subtract(amountOfTime, typeOfTime).format('MM/DD/YYYY');
 
-        const day = dayjs(endDate, 'MM-DD-YYYY').subtract(amountOfTime, typeOfTime).format('MM/DD/YYYY');
+        // dispatch startDate
+        dispatch(setQueryProperty({ startDate, queryIndex, property: 'startDate' }));
 
-        dispatch(setQueryProperty({ startDate: day }));
+        // dispatch endDate
+        dispatch(setQueryProperty({ endDate, queryIndex, property: 'endDate' }));
       }}
     >
       {message}
     </Link>
-
   );
 }
 
@@ -39,4 +41,5 @@ DefaultDates.propTypes = {
   typeOfTime: PropTypes.string.isRequired,
   message: PropTypes.string.isRequired,
   platform: PropTypes.string.isRequired,
+  queryIndex: PropTypes.number.isRequired,
 };

--- a/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
+++ b/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
@@ -104,9 +104,9 @@ export default function SearchDatePicker({ queryIndex }) {
         The start and end dates are inclusive.
       </p>
 
-      <DefaultDates platform={platform} amountOfTime="1" typeOfTime="month" message="Last Month" />
+      <DefaultDates platform={platform} amountOfTime="1" typeOfTime="month" message="Last Month" queryIndex={queryIndex} />
 
-      <DefaultDates platform={platform} amountOfTime="3" typeOfTime="month" message="Last 3 Months" />
+      <DefaultDates platform={platform} amountOfTime="3" typeOfTime="month" message="Last 3 Months" queryIndex={queryIndex} />
     </>
   );
 }


### PR DESCRIPTION
When the 'Last Month' or 'Last 3 Months links are clicked, the dispatch now includes the property and queryIndex. 


<img width="1440" alt="Last Month" src="https://user-images.githubusercontent.com/63474660/236846472-141acd9e-8f79-4505-acf2-3aed5bea0b62.png">



<img width="1440" alt="Last Three" src="https://user-images.githubusercontent.com/63474660/236846486-5b8c664b-ef10-4844-b86a-d2babfaf153c.png">




<img width="1440" alt="Online News" src="https://user-images.githubusercontent.com/63474660/236846524-eeebacbc-1604-42cb-9c59-5a47bf82a256.png">




<img width="1440" alt="Last 3 Months Online " src="https://user-images.githubusercontent.com/63474660/236846549-bbe19299-c57a-4fcb-ba7b-1f6da295d70b.png">

