### PR TITLE
Revert changes to query preview to allow accurate query preview

### DIFF
--- a/mcweb/frontend/src/features/search/query/QueryPreview.jsx
+++ b/mcweb/frontend/src/features/search/query/QueryPreview.jsx
@@ -1,17 +1,22 @@
 import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import tabTitle from '../util/tabTitle';
-// import queryGenerator from '../util/queryGenerator';
+// import tabTitle from '../util/tabTitle';
+import queryGenerator from '../util/queryGenerator';
 
 export default function QueryPreview({ queryIndex }) {
-  const queryState = useSelector((state) => state.query);
+  const {
+    queryList,
+    negatedQueryList,
+    platform,
+    anyAll,
+  } = useSelector((state) => state.query[queryIndex]);
 
-  let query = tabTitle(queryState, queryIndex);
+  let query = queryGenerator(queryList, negatedQueryList, platform, anyAll);
 
   useEffect(() => {
-    query = tabTitle(queryState, queryIndex);
-  }, [queryState]);
+    query = queryGenerator(queryList, negatedQueryList, platform, anyAll);
+  }, [queryList, negatedQueryList]);
 
   return (
     <>


### PR DESCRIPTION
Query preview was not responsive to the query or platform, reverted changes to use queryGenerator again.