### PR TITLE
Change collection and source serialization

### DIFF
--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -39,7 +39,6 @@ def parse_query(request, http_method: str = 'POST') -> tuple:
     start_date = dt.datetime.strptime(start_date, '%m/%d/%Y')
     end_date = payload["endDate"]
     end_date = dt.datetime.strptime(end_date, '%m/%d/%Y')
-
     return start_date, end_date, query_str, provider_props, provider_name
 
 

--- a/mcweb/backend/sources/api.py
+++ b/mcweb/backend/sources/api.py
@@ -4,6 +4,7 @@ import os
 import requests
 import requests.auth
 import datetime as dt
+import urllib.parse
 from django.db.models import Count
 from django.shortcuts import get_object_or_404
 from rest_framework.response import Response
@@ -115,6 +116,18 @@ class CollectionViewSet(viewsets.ModelViewSet):
         json_data = open(file_path)  
         deserial_data = json.load(json_data) 
         return Response({"countries": deserial_data})
+    
+    @action(methods=['GET'], detail=False, url_path='collections-from-list')
+    def collections_from_list(self, request):
+        collection_ids = request.query_params.get('c') # decode
+        collection_ids = collection_ids.split(',')
+        collection_ids = [int(i) for i in collection_ids]
+        # collection_ids = urllib.parse.unquote(collection_ids)
+        # collection_ids = json.loads(collection_ids)
+        print("COLLECTION IDS++++++++++", collection_ids)
+        collections = Collection.objects.filter(id__in=collection_ids )
+        serializer = CollectionWriteSerializer(collections, many=True) 
+        return Response({"collections": serializer.data})
     
     # NOTE!!!! returns a "Task" object! Maybe belongs in a TaskView??
     @action(methods=['post'], detail=False, url_path='rescrape-collection')

--- a/mcweb/backend/sources/api.py
+++ b/mcweb/backend/sources/api.py
@@ -119,12 +119,10 @@ class CollectionViewSet(viewsets.ModelViewSet):
     
     @action(methods=['GET'], detail=False, url_path='collections-from-list')
     def collections_from_list(self, request):
-        collection_ids = request.query_params.get('c') # decode
-        collection_ids = collection_ids.split(',')
-        collection_ids = [int(i) for i in collection_ids]
-        # collection_ids = urllib.parse.unquote(collection_ids)
-        # collection_ids = json.loads(collection_ids)
-        print("COLLECTION IDS++++++++++", collection_ids)
+        collection_ids = request.query_params.get('c')
+        if len(collection_ids) != 0:
+            collection_ids = collection_ids.split(',')
+            collection_ids = [int(i) for i in collection_ids]
         collections = Collection.objects.filter(id__in=collection_ids )
         serializer = CollectionWriteSerializer(collections, many=True) 
         return Response({"collections": serializer.data})
@@ -373,6 +371,16 @@ class SourcesViewSet(viewsets.ModelViewSet):
         filename = "Collection-{}-{}-sources-{}.csv".format(collection_id, collection.name, _filename_timestamp())
         streamer = csv_stream.CSVStream(filename, data_generator)
         return streamer.stream()
+    
+    @action(methods=['GET'], detail=False, url_path='sources-from-list')
+    def sources_from_list(self, request):
+        source_ids = request.query_params.get('s', None) # decode
+        if len(source_ids) != 0:
+            source_ids = source_ids.split(',')
+            source_ids = [int(i) for i in source_ids]
+        sources = Source.objects.filter(id__in=source_ids )
+        serializer = SourceSerializer(sources, many=True) 
+        return Response({"sources": serializer.data})
 
     # NOTE!!!! returns a "Task" object! Maybe belongs in a TaskView??
     @action(methods=['post'], detail=False, url_path='rescrape-feeds')

--- a/mcweb/frontend/src/app/services/collectionsApi.js
+++ b/mcweb/frontend/src/app/services/collectionsApi.js
@@ -11,6 +11,12 @@ export const collectionsApi = managerApi.injectEndpoints({
       providesTags: ({ collections }) => (collections
         ? [...collections.map(({ id }) => ({ type: 'Collection', id }))] : ['Collection']),
     }),
+    listCollectionsFromArray: builder.query({
+      query: (params) => ({
+        url: `collections/collections-from-list/?c=${params}`,
+        method: 'GET',
+      }),
+    }),
     listCollections: builder.query({
       query: (params) => ({
         url: `collections/?${toSearchUrlParams(params)}`,
@@ -71,6 +77,7 @@ export const {
   useGetFeaturedCollectionsQuery,
   useListCollectionsQuery,
   useLazyListCollectionsQuery,
+  useListCollectionsFromArrayQuery,
   useGetCollectionQuery,
   useCreateCollectionMutation,
   useUpdateCollectionMutation,

--- a/mcweb/frontend/src/app/services/sourceApi.js
+++ b/mcweb/frontend/src/app/services/sourceApi.js
@@ -22,6 +22,12 @@ export const sourceApi = managerApi.injectEndpoints({
           ? [...results.map(({ id }) => ({ type: 'Source', id }))] : ['Source']
       ),
     }),
+    listSourcesFromArray: builder.query({
+      query: (params) => ({
+        url: `sources/sources-from-list/?s=${params}`,
+        method: 'GET',
+      }),
+    }),
     createSource: builder.mutation({
       query: (source) => ({
         url: 'sources/',
@@ -79,6 +85,7 @@ export const {
   useGetSourceQuery,
   useListSourcesQuery,
   useLazyListSourcesQuery,
+  useListSourcesFromArrayQuery,
   useCreateSourceMutation,
   useUpdateSourceMutation,
   useDeleteSourceMutation,

--- a/mcweb/frontend/src/features/collections/CollectionHeader.jsx
+++ b/mcweb/frontend/src/features/collections/CollectionHeader.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { CircularProgress, Button } from '@mui/material';
+import CircularProgress from '@mui/material/CircularProgress';
+import Button from '@mui/material/Button';
 import dayjs from 'dayjs';
 import ShieldIcon from '@mui/icons-material/Shield';
 import SearchIcon from '@mui/icons-material/Search';

--- a/mcweb/frontend/src/features/collections/CollectionShow.jsx
+++ b/mcweb/frontend/src/features/collections/CollectionShow.jsx
@@ -5,7 +5,7 @@ import SourceList from '../sources/SourceList';
 export default function CollectionShow() {
   const params = useParams();
   const collectionId = Number(params.collectionId);
-  
+
   return (
     <div className="container">
       <div className="row">

--- a/mcweb/frontend/src/features/feeds/FeedHistory.jsx
+++ b/mcweb/frontend/src/features/feeds/FeedHistory.jsx
@@ -19,7 +19,7 @@ function FeedHistory({ feedId }) {
   }
 
   if (!data) return null;
-  // console.log(data);
+
   return (
     <>
       <h1>Feed History</h1>

--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -26,6 +26,13 @@ import deactivateButton from './util/deactivateButton';
 import urlSerializer from './util/urlSerializer';
 import tabTitle from './util/tabTitle';
 
+function a11yProps(index) {
+  return {
+    id: `simple-tab-${index}`,
+    'aria-controls': `simple-tabpanel-${index}`,
+  };
+}
+
 export default function TabbedSearch() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -135,6 +142,7 @@ export default function TabbedSearch() {
                     )}
                   </div>
                 )}
+                /* eslint-disable-next-line react/jsx-props-no-spreading */
                 {...a11yProps(i)}
               />
             ))}
@@ -143,7 +151,7 @@ export default function TabbedSearch() {
         </Box>
 
         {queryState.map((query, i) => (
-          <TabPanelHelper key={i} value={value} index={i}>
+          <TabPanelHelper key={`${query}`} value={value} index={i}>
             <Search queryIndex={i} />
           </TabPanelHelper>
         ))}
@@ -197,21 +205,14 @@ export default function TabbedSearch() {
       </div>
       <div className="search-results-wrapper">
         <div className="container">
-          {/* <CountOverTimeResults />
+          <CountOverTimeResults />
           <TotalAttentionResults />
           <SampleStories />
           <TopWords />
-          <TopLanguages /> */}
+          <TopLanguages />
         </div>
       </div>
 
     </div>
   );
-}
-
-function a11yProps(index) {
-  return {
-    id: `simple-tab-${index}`,
-    'aria-controls': `simple-tabpanel-${index}`,
-  };
 }

--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -197,11 +197,11 @@ export default function TabbedSearch() {
       </div>
       <div className="search-results-wrapper">
         <div className="container">
-          <CountOverTimeResults />
+          {/* <CountOverTimeResults />
           <TotalAttentionResults />
           <SampleStories />
           <TopWords />
-          <TopLanguages />
+          <TopLanguages /> */}
         </div>
       </div>
 

--- a/mcweb/frontend/src/features/search/query/SelectedMedia.jsx
+++ b/mcweb/frontend/src/features/search/query/SelectedMedia.jsx
@@ -1,20 +1,50 @@
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import RemoveCircleIcon from '@mui/icons-material/RemoveCircleOutline';
+import CircularProgress from '@mui/material/CircularProgress';
 import IconButton from '@mui/material/IconButton';
+import { useListCollectionsFromArrayQuery } from '../../../app/services/collectionsApi';
+import { useListSourcesQuery } from '../../../app/services/sourceApi';
 
 export default function SelectedMedia({
-  onRemove, collections, sources, queryIndex,
+  onRemove, queryIndex,
 }) {
+  const {
+    collections,
+    sources,
+  } = useSelector((state) => state.query[queryIndex]);
+
   const dispatch = useDispatch();
   // note: this only supports collections right now, but needs to support sources too
+  const {
+    data: collectionsData,
+    isLoadingCollections,
+  } = useListCollectionsFromArrayQuery(collections);
+
+  const {
+    data: sourcesData,
+    isLoadingSources,
+  } = useListSourcesFromArrayQuery(sources);
+
+  // const {
+  //   data: sourcesData,
+  //   isLoadingSources,
+  // } = useListSourcesQuery({ source_id: sources, page });
+
+  console.log('collections', collectionsData);
+  // console.log('sources', sourcesData);
+  if (isLoadingCollections) {
+    return <CircularProgress size="75px" />;
+  }
+
+  if (!collectionsData && !sourcesData) return null;
 
   return (
     <div className="selected-media-container">
       <div className="selected-media-item-list">
-        {sources.map((source) => (
+        {sourcesData.sources.map((source) => (
           <div className="selected-media-item" key={`selected-media-${source.id}`}>
             <Link
               target="_blank"
@@ -36,7 +66,7 @@ export default function SelectedMedia({
             </IconButton>
           </div>
         ))}
-        {collections.map((collection) => (
+        {collectionsData.collections.map((collection) => (
           <div className="selected-media-item" key={`selected-media-${collection.id}`}>
             <Link
               target="_blank"

--- a/mcweb/frontend/src/features/search/query/SelectedMedia.jsx
+++ b/mcweb/frontend/src/features/search/query/SelectedMedia.jsx
@@ -6,36 +6,31 @@ import RemoveCircleIcon from '@mui/icons-material/RemoveCircleOutline';
 import CircularProgress from '@mui/material/CircularProgress';
 import IconButton from '@mui/material/IconButton';
 import { useListCollectionsFromArrayQuery } from '../../../app/services/collectionsApi';
-import { useListSourcesQuery } from '../../../app/services/sourceApi';
+import { useListSourcesFromArrayQuery } from '../../../app/services/sourceApi';
 
 export default function SelectedMedia({
-  onRemove, queryIndex,
+  onRemove, queryIndex, preview,
 }) {
   const {
     collections,
     sources,
+    previewCollections,
+    previewSources,
   } = useSelector((state) => state.query[queryIndex]);
 
   const dispatch = useDispatch();
-  // note: this only supports collections right now, but needs to support sources too
+
   const {
     data: collectionsData,
     isLoadingCollections,
-  } = useListCollectionsFromArrayQuery(collections);
+  } = useListCollectionsFromArrayQuery(preview ? previewCollections : collections);
 
   const {
     data: sourcesData,
     isLoadingSources,
-  } = useListSourcesFromArrayQuery(sources);
+  } = useListSourcesFromArrayQuery(preview ? previewSources : sources);
 
-  // const {
-  //   data: sourcesData,
-  //   isLoadingSources,
-  // } = useListSourcesQuery({ source_id: sources, page });
-
-  console.log('collections', collectionsData);
-  // console.log('sources', sourcesData);
-  if (isLoadingCollections) {
+  if (isLoadingCollections || isLoadingSources) {
     return <CircularProgress size="75px" />;
   }
 
@@ -44,51 +39,62 @@ export default function SelectedMedia({
   return (
     <div className="selected-media-container">
       <div className="selected-media-item-list">
-        {sourcesData.sources.map((source) => (
-          <div className="selected-media-item" key={`selected-media-${source.id}`}>
-            <Link
-              target="_blank"
-              to={`/sources/${source.id}`}
-              style={{
-                display: 'block',
-                whiteSpace: 'normal',
-                width: '100%',
-              }}
-            >
-              {source.label || source.name}
-            </Link>
-            <IconButton
-              size="small"
-              aria-label="remove"
-              onClick={() => dispatch(onRemove({ sourceOrCollection: { type: 'source', id: source.id }, queryIndex }))}
-            >
-              <RemoveCircleIcon sx={{ color: '#d24527' }} />
-            </IconButton>
-          </div>
-        ))}
-        {collectionsData.collections.map((collection) => (
-          <div className="selected-media-item" key={`selected-media-${collection.id}`}>
-            <Link
-              target="_blank"
-              to={`/collections/${collection.id}`}
-              style={{
-                display: 'block',
-                whiteSpace: 'normal',
-                width: '100%',
-              }}
-            >
-              {collection.name}
-            </Link>
+        {sourcesData && (
 
-            <IconButton
-              size="small"
-              aria-label="remove"
-              onClick={() => dispatch(onRemove({ sourceOrCollection: { type: 'collection', id: collection.id }, queryIndex }))}
-            >
-              <RemoveCircleIcon sx={{ color: '#d24527' }} />
-            </IconButton>
-          </div>
-        ))}
+        <div>
+          {sourcesData.sources.map((source) => (
+            <div className="selected-media-item" key={`selected-media-${source.id}`}>
+              <Link
+                target="_blank"
+                to={`/sources/${source.id}`}
+                style={{
+                  display: 'block',
+                  whiteSpace: 'normal',
+                  width: '100%',
+                }}
+              >
+                {source.label || source.name}
+              </Link>
+              <IconButton
+                size="small"
+                aria-label="remove"
+                onClick={() => dispatch(onRemove({ sourceOrCollection: { type: 'source', id: source.id }, queryIndex }))}
+              >
+                <RemoveCircleIcon sx={{ color: '#d24527' }} />
+              </IconButton>
+            </div>
+          ))}
+        </div>
+        )}
+
+        {collectionsData && (
+
+        <div>
+          {collectionsData.collections.map((collection) => (
+            <div className="selected-media-item" key={`selected-media-${collection.id}`}>
+              <Link
+                target="_blank"
+                to={`/collections/${collection.id}`}
+                style={{
+                  display: 'block',
+                  whiteSpace: 'normal',
+                  width: '100%',
+                }}
+              >
+                {collection.name}
+              </Link>
+
+              <IconButton
+                size="small"
+                aria-label="remove"
+                onClick={() => dispatch(onRemove({ sourceOrCollection: { type: 'collection', id: collection.id }, queryIndex }))}
+              >
+                <RemoveCircleIcon sx={{ color: '#d24527' }} />
+              </IconButton>
+            </div>
+          ))}
+        </div>
+        )}
       </div>
     </div>
   );
@@ -96,17 +102,11 @@ export default function SelectedMedia({
 
 SelectedMedia.propTypes = {
   onRemove: PropTypes.func.isRequired,
-  collections: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.number.isRequired,
-    name: PropTypes.string.isRequired,
-  })).isRequired,
-  sources: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.number.isRequired,
-    name: PropTypes.string.isRequired,
-  })).isRequired,
   queryIndex: PropTypes.number,
+  preview: PropTypes.bool,
 };
 
 SelectedMedia.defaultProps = {
   queryIndex: 0,
+  preview: false,
 };

--- a/mcweb/frontend/src/features/search/query/media-picker/MediaPicker.jsx
+++ b/mcweb/frontend/src/features/search/query/media-picker/MediaPicker.jsx
@@ -21,6 +21,17 @@ export default function MediaPicker({ queryIndex }) {
   const dispatch = useDispatch();
   const { previewCollections, previewSources, platform } = useSelector((state) => state.query[queryIndex]);
   const [open, setOpen] = useState(false);
+  const addType = (pS, pC) => {
+    const sourceTypes = pS.map((s) => ({
+      id: s,
+      type: 'source',
+    }));
+    const collectionTypes = pC.map((c) => ({
+      id: c,
+      type: 'collection',
+    }));
+    return [...sourceTypes, ...collectionTypes];
+  };
 
   return (
     <div className="media-picker">
@@ -62,12 +73,13 @@ export default function MediaPicker({ queryIndex }) {
                   collections={previewCollections}
                   sources={previewSources}
                   queryIndex={queryIndex}
+                  preview
                 />
                 <Button
                   variant="contained"
                   onClick={() => {
                     setOpen(false);
-                    dispatch(addSelectedMedia({ sourceOrCollection: [...previewCollections, ...previewSources], queryIndex }));
+                    dispatch(addSelectedMedia({ sourceOrCollection: addType(previewSources, previewCollections), queryIndex }));
                   }}
                 >
                   Confirm

--- a/mcweb/frontend/src/features/search/query/media-picker/MediaPickerSelectionTable.jsx
+++ b/mcweb/frontend/src/features/search/query/media-picker/MediaPickerSelectionTable.jsx
@@ -11,7 +11,7 @@ export default function MediaPickerSelectionTable({
   selected, matching, onAdd, onRemove, collection, queryIndex, isGlobalCollection,
 }) {
   const dispatch = useDispatch();
-  const alreadySelected = (cid) => selected.map((c) => c.id).includes(cid);
+  const alreadySelected = (cid) => selected.includes(cid);
 
   return (
     <table>
@@ -50,7 +50,7 @@ export default function MediaPickerSelectionTable({
                   size="sm"
                   aria-label="add"
                   onClick={() => dispatch(onAdd(
-                    { sourceOrCollection: [{ ...c, type: collection ? 'collection' : 'source' }], queryIndex },
+                    { sourceOrCollection: { id: c.id, type: collection ? 'collection' : 'source' }, queryIndex },
                   ))}
                 >
                   <AddCircleIcon sx={{ color: '#d24527' }} />
@@ -82,10 +82,7 @@ MediaPickerSelectionTable.propTypes = {
     id: PropTypes.number.isRequired,
     name: PropTypes.string.isRequired,
   })).isRequired,
-  selected: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.number.isRequired,
-    name: PropTypes.string.isRequired,
-  })).isRequired,
+  selected: PropTypes.arrayOf(PropTypes.number).isRequired,
   collection: PropTypes.bool.isRequired,
   queryIndex: PropTypes.number.isRequired,
   isGlobalCollection: PropTypes.bool.isRequired,

--- a/mcweb/frontend/src/features/search/query/querySlice.js
+++ b/mcweb/frontend/src/features/search/query/querySlice.js
@@ -1,4 +1,4 @@
-import { createSlice, current } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 import dayjs from 'dayjs';
 import { PROVIDER_NEWS_MEDIA_CLOUD, latestAllowedEndDate } from '../util/platforms';
 
@@ -46,22 +46,40 @@ const querySlice = createSlice({
 
   reducers: {
     addSelectedMedia: (state, { payload }) => {
-      const { queryIndex, sourceOrCollection, collectionBool } = payload;
+      const { queryIndex, sourceOrCollection } = payload;
       const currentSlice = state[queryIndex];
-      if (collectionBool) {
-        currentSlice.collections.push(sourceOrCollection);
-      } else {
-        currentSlice.sources.push(sourceOrCollection);
-      }
+      currentSlice.collections = sourceOrCollection.filter((c) => c.type === 'collection').map((c) => c.id);
+      currentSlice.sources = sourceOrCollection.filter((s) => s.type === 'source').map((s) => s.id);
+    },
+    setSelectedMedia: (state, { payload }) => {
+      const { sourceOrCollection } = payload;
+      const freezeState = state;
+      const collections = new Array(sourceOrCollection.length);
+      const sources = new Array(sourceOrCollection.length);
+      sourceOrCollection.forEach((query, i) => {
+        collections[i] = query.filter((m) => m.type === 'collection').map((c) => c.id);
+        sources[i] = query.filter((m) => m.type === 'source').map((s) => s.id);
+      });
+      collections.forEach((c, i) => {
+        freezeState[i].collections = c;
+      });
+      sources.forEach((s, i) => {
+        freezeState[i].sources = s;
+      });
+      return freezeState;
     },
     addPreviewSelectedMedia: (state, { payload }) => {
-      const { queryIndex, sourceOrCollection, collectionBool } = payload;
+      const { queryIndex, sourceOrCollection } = payload;
       const currentSlice = state[queryIndex];
-      currentSlice.previewCollections = [
-        ...currentSlice.previewCollections,
-        ...sourceOrCollection.filter((c) => c.type === 'collection'),
-      ];
-      currentSlice.previewSources = [...currentSlice.previewSources, ...sourceOrCollection.filter((c) => c.type === 'source')];
+      if (sourceOrCollection.type === 'collection') {
+        currentSlice.previewCollections = [
+          ...currentSlice.previewCollections, sourceOrCollection.id,
+        ];
+      } else {
+        currentSlice.previewSources = [
+          ...currentSlice.previewSources, sourceOrCollection.id,
+        ];
+      }
     },
     resetSelectedAndPreviewMedia: (state, { payload }) => {
       const { queryIndex } = payload;
@@ -73,25 +91,36 @@ const querySlice = createSlice({
       const { queryIndex, sourceOrCollection } = payload;
       const currentSlice = state[queryIndex];
       currentSlice.collections = sourceOrCollection.type === 'collection'
-        ? currentSlice.collections.filter((c) => c.id !== sourceOrCollection.id) : currentSlice.collections;
+        ? currentSlice.collections.filter((c) => c !== sourceOrCollection.id) : currentSlice.collections;
       currentSlice.previewCollections = sourceOrCollection.type === 'collection'
-        ? currentSlice.previewCollections.filter((c) => c.id !== sourceOrCollection.id) : currentSlice.collections;
+        ? currentSlice.previewCollections.filter((c) => c !== sourceOrCollection.id) : currentSlice.collections;
       currentSlice.sources = sourceOrCollection.type === 'source'
-        ? currentSlice.sources.filter((s) => s.id !== sourceOrCollection.id) : currentSlice.sources;
+        ? currentSlice.sources.filter((s) => s !== sourceOrCollection.id) : currentSlice.sources;
       currentSlice.previewSources = sourceOrCollection.type === 'source'
-        ? currentSlice.previewSources.filter((s) => s.id !== sourceOrCollection.id) : currentSlice.sources;
+        ? currentSlice.previewSources.filter((s) => s !== sourceOrCollection.id) : currentSlice.sources;
     },
     setPreviewSelectedMedia: (state, { payload }) => {
-      const { queryIndex, sourceOrCollection } = payload;
-      const currentSlice = state[queryIndex];
-      currentSlice.previewCollections = sourceOrCollection.filter((c) => c.type === 'collection');
-      currentSlice.previewSources = sourceOrCollection.filter((c) => c.type === 'source');
+      const { sourceOrCollection } = payload;
+      const freezeState = state;
+      const collections = new Array(sourceOrCollection.length);
+      const sources = new Array(sourceOrCollection.length);
+      sourceOrCollection.forEach((query, i) => {
+        collections[i] = query.filter((m) => m.type === 'collection').map((c) => c.id);
+        sources[i] = query.filter((m) => m.type === 'source').map((s) => s.id);
+      });
+      collections.forEach((c, i) => {
+        freezeState[i].previewCollections = c;
+      });
+      sources.forEach((s, i) => {
+        freezeState[i].previewSources = s;
+      });
+      return freezeState;
     },
     removePreviewSelectedMedia: (state, { payload }) => {
       const { queryIndex, sourceOrCollection } = payload;
       const currentSlice = state[queryIndex];
-      currentSlice.previewCollections = currentSlice.previewCollections.filter((c) => c.id !== sourceOrCollection.id);
-      currentSlice.previewSources = currentSlice.previewSources.filter((s) => s.id !== sourceOrCollection.id);
+      currentSlice.previewCollections = currentSlice.previewCollections.filter((c) => c !== sourceOrCollection.id);
+      currentSlice.previewSources = currentSlice.previewSources.filter((s) => s !== sourceOrCollection.id);
     },
     setQueryProperty: (state, { payload }) => {
       const queryProperty = payload.property;
@@ -158,6 +187,7 @@ export const {
   setPlatform,
   setLastSearchTime,
   removeQuery,
+  setSelectedMedia,
 } = querySlice.actions;
 
 export default querySlice.reducer;

--- a/mcweb/frontend/src/features/search/query/querySlice.js
+++ b/mcweb/frontend/src/features/search/query/querySlice.js
@@ -3,13 +3,7 @@ import dayjs from 'dayjs';
 import { PROVIDER_NEWS_MEDIA_CLOUD, latestAllowedEndDate } from '../util/platforms';
 
 const DEFAULT_PROVIDER = PROVIDER_NEWS_MEDIA_CLOUD;
-export const DEFAULT_ONLINE_NEWS_COLLECTIONS = [{
-  type: 'collection',
-  id: 34412234,
-  name: 'United States - National',
-  platform: 'online_news',
-  public: true,
-}];
+export const DEFAULT_ONLINE_NEWS_COLLECTIONS = [34412234];
 
 const startDate = dayjs().subtract(34, 'day').format('MM/DD/YYYY');
 
@@ -52,13 +46,16 @@ const querySlice = createSlice({
 
   reducers: {
     addSelectedMedia: (state, { payload }) => {
-      const { queryIndex, sourceOrCollection } = payload;
+      const { queryIndex, sourceOrCollection, collectionBool } = payload;
       const currentSlice = state[queryIndex];
-      currentSlice.collections = sourceOrCollection.filter((c) => c.type === 'collection');
-      currentSlice.sources = sourceOrCollection.filter((c) => c.type === 'source');
+      if (collectionBool) {
+        currentSlice.collections.push(sourceOrCollection);
+      } else {
+        currentSlice.sources.push(sourceOrCollection);
+      }
     },
     addPreviewSelectedMedia: (state, { payload }) => {
-      const { queryIndex, sourceOrCollection } = payload;
+      const { queryIndex, sourceOrCollection, collectionBool } = payload;
       const currentSlice = state[queryIndex];
       currentSlice.previewCollections = [
         ...currentSlice.previewCollections,

--- a/mcweb/frontend/src/features/search/util/prepareQueries.js
+++ b/mcweb/frontend/src/features/search/util/prepareQueries.js
@@ -24,15 +24,12 @@ export default function prepareQueries(queryState) {
       return queryReturn;
     };
 
-    const collectionIds = collections.map((c) => c.id);
-    const sourceIds = sources.map((s) => s.id);
     return {
-
       query: fullQuery(),
       startDate,
       endDate,
-      collections: collectionIds,
-      sources: sourceIds,
+      collections,
+      sources,
       platform,
     };
   });

--- a/mcweb/frontend/src/features/search/util/setSearchQuery.js
+++ b/mcweb/frontend/src/features/search/util/setSearchQuery.js
@@ -52,12 +52,11 @@ const formatCorpus = (collections, collectionBool) => collections.map((collectio
 
 const decodeAndFormatCorpus = (mediaArray, collectionBool) => {
   const returnArr = new Array(mediaArray.length);
+
   mediaArray.forEach((queryCorpus, i) => {
     const decoded = handleDecode([queryCorpus]);
-    const formatted = formatCorpus(decoded, collectionBool);
-    if (formatted) {
-      returnArr[i] = formatted;
-    }
+    const numbered = decoded.map((collectionId) => Number(collectionId));
+    returnArr[i] = numbered;
   });
   return returnArr;
 };
@@ -108,23 +107,24 @@ const setState = (queries, negatedQueries, queryStrings, startDates, endDates, p
 
   let reset;
   sources.forEach((source, i) => {
-    if (source[0] === null) {
-      reset = true;
-      return null;
-    }
-    dispatch(setPreviewSelectedMedia({ sourceOrCollection: [...source], queryIndex: i }));
-    dispatch(addSelectedMedia({ sourceOrCollection: [...source], queryIndex: i }));
-    reset = false;
+    // if (source[0] === null) {
+    //   reset = true;
+    //   return null;
+    // }
+    console.log(source);
+    // dispatch(setPreviewSelectedMedia({ sourceOrCollection: [...source], queryIndex: i }));
+    // dispatch(addSelectedMedia({ sourceOrCollection: [...source], queryIndex: i }));
+    // reset = false;
   });
-
   collections.forEach((collection, i) => {
-    if (collection[0] === null) {
-      // reset = true;
-      return null;
-    }
-    dispatch(setPreviewSelectedMedia({ sourceOrCollection: [...collection], queryIndex: i }));
-    dispatch(addSelectedMedia({ sourceOrCollection: [...collection], queryIndex: i }));
-    reset = false;
+    console.log(collection);
+    // if (collection[0] === null) {
+    //   // reset = true;
+    //   return null;
+    // }
+    // dispatch(setPreviewSelectedMedia({ sourceOrCollection: [...collection], queryIndex: i }));
+    // dispatch(addSelectedMedia({ sourceOrCollection: [...collection], queryIndex: i }));
+    // reset = false;
   });
   if (reset) {
     for (let i = 0; i < collections.length; i += 1) {
@@ -166,10 +166,10 @@ const setSearchQuery = (searchParams, dispatch) => {
 
   platforms = platforms ? handleDecode(platforms) : null;
 
-  collections = collections ? collections.split(',') : [];
+  collections = collections ? collections.split(',') : null;
   collections = decodeAndFormatCorpus(collections, true);
 
-  sources = sources ? sources.split(',') : [];
+  sources = sources ? handleDecode(sources) : [];
   sources = decodeAndFormatCorpus(sources, false);
 
   anyAlls = anyAlls ? handleDecode(anyAlls) : null;

--- a/mcweb/frontend/src/features/search/util/setSearchQuery.js
+++ b/mcweb/frontend/src/features/search/util/setSearchQuery.js
@@ -50,7 +50,7 @@ const formatCorpus = (collections, collectionBool) => collections.map((collectio
   return { id, name, type: collectionBool ? 'collection' : 'source' };
 });
 
-const decodeAndFormatCorpus = (mediaArray, collectionBool) => {
+const decodeAndFormatCorpus = (mediaArray) => {
   const returnArr = new Array(mediaArray.length);
 
   mediaArray.forEach((queryCorpus, i) => {
@@ -111,19 +111,18 @@ const setState = (queries, negatedQueries, queryStrings, startDates, endDates, p
     //   reset = true;
     //   return null;
     // }
-    console.log(source);
-    // dispatch(setPreviewSelectedMedia({ sourceOrCollection: [...source], queryIndex: i }));
-    // dispatch(addSelectedMedia({ sourceOrCollection: [...source], queryIndex: i }));
+    console.log('source', source);
+    dispatch(setPreviewSelectedMedia({ sourceOrCollection: [...source], queryIndex: i, collectionBool: false }));
+    dispatch(addSelectedMedia({ sourceOrCollection: [...source], queryIndex: i, collectionBool: false }));
     // reset = false;
   });
-  collections.forEach((collection, i) => {
-    console.log(collection);
+  collections.forEach((collectionList, i) => {
     // if (collection[0] === null) {
     //   // reset = true;
     //   return null;
     // }
-    // dispatch(setPreviewSelectedMedia({ sourceOrCollection: [...collection], queryIndex: i }));
-    // dispatch(addSelectedMedia({ sourceOrCollection: [...collection], queryIndex: i }));
+    dispatch(setPreviewSelectedMedia({ sourceOrCollection: [...collectionList], queryIndex: i, collectionBool: true }));
+    dispatch(addSelectedMedia({ sourceOrCollection: [...collectionList], queryIndex: i, collectionBool: true }));
     // reset = false;
   });
   if (reset) {
@@ -166,11 +165,14 @@ const setSearchQuery = (searchParams, dispatch) => {
 
   platforms = platforms ? handleDecode(platforms) : null;
 
-  collections = collections ? collections.split(',') : null;
-  collections = decodeAndFormatCorpus(collections, true);
+  collections = collections ? collections.split(',') : [];
+  collections = decodeAndFormatCorpus(collections);
+  console.log('decodedC', collections);
 
   sources = sources ? handleDecode(sources) : [];
-  sources = decodeAndFormatCorpus(sources, false);
+  sources = decodeAndFormatCorpus(sources);
+  console.log('decodedSource', sources);
+  // sources = decodeAndFormatCorpus(sources, false);
 
   anyAlls = anyAlls ? handleDecode(anyAlls) : null;
   setState(query, negatedQuery, queryStrings, startDates, endDates, platforms, collections, sources, anyAlls, dispatch);

--- a/mcweb/frontend/src/features/search/util/urlSerializer.js
+++ b/mcweb/frontend/src/features/search/util/urlSerializer.js
@@ -1,12 +1,11 @@
 import dayjs from 'dayjs';
-import { any } from 'prop-types';
 
 const formatCollections = (collectionsArray) => collectionsArray.map((c) => (
-  c.id
+  c
 ));
 
 const formatSources = (sourcesArray) => sourcesArray.map((s) => (
-  s.id
+  s
 ));
 
 const queryListHelper = (queryList) => {
@@ -53,7 +52,6 @@ const urlSerializer = (queryState) => {
     ends.push(dayjs(endDate).format('MM-DD-YYYY'));
 
     platforms.push(platform);
-
     const collectionsFormatted = formatCollections(collections).join(',');
     collectionArr.push([encode(collectionsFormatted)]);
 

--- a/mcweb/frontend/src/features/search/util/urlSerializer.js
+++ b/mcweb/frontend/src/features/search/util/urlSerializer.js
@@ -2,11 +2,11 @@ import dayjs from 'dayjs';
 import { any } from 'prop-types';
 
 const formatCollections = (collectionsArray) => collectionsArray.map((c) => (
-  `${c.id}>${c.name}`
+  c.id
 ));
 
 const formatSources = (sourcesArray) => sourcesArray.map((s) => (
-  `${s.id}>${s.label || s.name}`
+  s.id
 ));
 
 const queryListHelper = (queryList) => {


### PR DESCRIPTION
- Changed the saving of collections and sources (as well as preview sources and collections) in state as an array of ids.
- Now collections and sources are serialized into the url as ids
- support was added to be able to fetch collections and sources by giving an array of ids
- now collections and sources are fetched from the backend for the collections/sources that have been selected 
  - previously we were relying on decoding them from the full name encoded in the url, this not only used A LOT of url space, but also could go wrong when encoding collections of different languages
 From:
![Screen Shot 2023-05-25 at 2 34 56 PM](https://github.com/mediacloud/web-search/assets/78226696/e5c3a2fe-ae7c-4a64-81bf-71de47a7527e)
to:
![Screen Shot 2023-05-25 at 2 33 27 PM](https://github.com/mediacloud/web-search/assets/78226696/fa6babd4-806c-415d-9793-414d782bc9d4)
😅 
closes #363 