### PR TITLE
Re: Adjust Bar Chart perspective 

### DIFF
--- a/mcweb/frontend/src/features/search/results/BarChart.jsx
+++ b/mcweb/frontend/src/features/search/results/BarChart.jsx
@@ -23,6 +23,7 @@ export default function BarChart({
     },
     yAxis: {
       min: 0,
+      max: normalized ? 100 : null,
       title: {
         text: normalized ? 'Percentage' : 'Count',
         align: 'high',

--- a/mcweb/frontend/src/features/search/results/BarChart.jsx
+++ b/mcweb/frontend/src/features/search/results/BarChart.jsx
@@ -30,7 +30,7 @@ export default function BarChart({
       },
       labels: {
         overflow: 'justify',
-        format: normalized ? '{value: .2f}%' : '{value.toLocaleString()}',
+        format: normalized ? '{value}%' : '{value.toLocaleString()}',
       },
     },
     plotOptions: {


### PR DESCRIPTION
- Updated the max value of the bar chart to default to 100 if the view of the chart was normalized
<img width="973" alt="Screenshot 2023-05-26 at 3 12 20 PM" src="https://github.com/mediacloud/web-search/assets/91026581/70abd2f3-ee66-4895-a6bd-b1d01593e00d">
