### PR TITLE
Disable search button if from or to date are invalid

### DIFF
--- a/mcweb/frontend/src/features/search/query/Search.jsx
+++ b/mcweb/frontend/src/features/search/query/Search.jsx
@@ -23,15 +23,6 @@ export default function Search({ queryIndex }) {
 
   return (
     <div className="search-container">
-      {/* <div className="container">
-        <div className="row">
-          <div className="col">
-
-            <PlatformPicker queryIndex={queryIndex} />
-          </div>
-        </div>
-      </div> */}
-
       <div className="container">
         {advanced && (
         <AdvancedSearch queryIndex={queryIndex} />

--- a/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
+++ b/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
@@ -17,10 +17,9 @@ export default function SearchDatePicker({ queryIndex }) {
   const dispatch = useDispatch();
   const { enqueueSnackbar } = useSnackbar();
 
-  const { platform, startDate, endDate } = useSelector((state) => state.query[queryIndex]);
-
-  const [isFromDateMatching, setIsFromDateMatching] = useState(true);
-  const [isToDateMatching, setIsToDateMatching] = useState(true);
+  const {
+    platform, startDate, endDate, isFromDateValid, isToDateValid,
+  } = useSelector((state) => state.query[queryIndex]);
 
   // the minimum date off platform (From Date Picker)
   const fromDateMin = dayjs(earliestAllowedStartDate(platform)).format('MM/DD/YYYY');
@@ -34,23 +33,22 @@ export default function SearchDatePicker({ queryIndex }) {
   const handleChangeFromDate = (newValue) => {
     if (validateDate(dayjs(newValue), dayjs(fromDateMin), dayjs(fromDateMax))) {
       dispatch(setQueryProperty({ startDate: dayjs(newValue).format('MM/DD/YYYY'), queryIndex, property: 'startDate' }));
-      setIsFromDateMatching(true);
+      dispatch(setQueryProperty({ isFromDateValid: true, queryIndex, property: 'isFromDateValid' }));
     } else {
-      setIsFromDateMatching(false);
+      dispatch(setQueryProperty({ isFromDateValid: false, queryIndex, property: 'isFromDateValid' }));
     }
   };
 
   const handleChangeToDate = (newValue) => {
     if (validateDate(dayjs(newValue), dayjs(toDateMin), dayjs(toDateMax))) {
       dispatch(setQueryProperty({ endDate: dayjs(newValue).format('MM/DD/YYYY'), queryIndex, property: 'endDate' }));
-      setIsToDateMatching(true);
+      dispatch(setQueryProperty({ isToDateValid: true, queryIndex, property: 'isToDateValid' }));
     } else {
-      setIsToDateMatching(false);
+      dispatch(setQueryProperty({ isToDateValid: false, queryIndex, property: 'isToDateValid' }));
     }
   };
 
   useEffect(() => {
-    // dispatch(setQueryProperty({ endDate: latestAllowedEndDate(platform).format('MM/DD/YYYY') }));
     if (dayjs(endDate) > latestAllowedEndDate(platform)) {
       handleChangeToDate(latestAllowedEndDate(platform));
       enqueueSnackbar('Changed your end date to match this platform limit', { variant: 'warning' });
@@ -66,7 +64,7 @@ export default function SearchDatePicker({ queryIndex }) {
       <div className="date-picker-wrapper local-provider">
         <LocalizationProvider dateAdapter={AdapterDateFns}>
           <div className="date-accuracy-alert">
-            <h1 className={`banner ${isFromDateMatching ? 'disable-alert' : 'enable-alert'}`}>Invalid Date</h1>
+            <h1 className={`banner ${isFromDateValid ? 'disable-alert' : 'enable-alert'}`}>Invalid Date</h1>
             <DatePicker
               required
               type="date"
@@ -82,7 +80,7 @@ export default function SearchDatePicker({ queryIndex }) {
           </div>
 
           <div className="date-accuracy-alert">
-            <h1 className={`banner ${isToDateMatching ? 'disable-alert' : 'enable-alert'}`}>Invalid Date</h1>
+            <h1 className={`banner ${isToDateValid ? 'disable-alert' : 'enable-alert'}`}>Invalid Date</h1>
             <DatePicker
               required
               label="To"

--- a/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
+++ b/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
@@ -30,26 +30,35 @@ export default function SearchDatePicker({ queryIndex }) {
   // the maximum date off platform (To Date Picker)
   const toDateMax = dayjs(latestAllowedEndDate(platform)).format('MM/DD/YYYY');
 
+  // handler for the fromDate MUI DatePicker
   const handleChangeFromDate = (newValue) => {
     if (validateDate(dayjs(newValue), dayjs(fromDateMin), dayjs(fromDateMax))) {
-      dispatch(setQueryProperty({ startDate: dayjs(newValue).format('MM/DD/YYYY'), queryIndex, property: 'startDate' }));
+      // if the fromDate is valid, we are going to make this change in state and set the isFromDateValid to true
       dispatch(setQueryProperty({ isFromDateValid: true, queryIndex, property: 'isFromDateValid' }));
+      dispatch(setQueryProperty({ startDate: dayjs(newValue).format('MM/DD/YYYY'), queryIndex, property: 'startDate' }));
     } else {
+      // we do not save the invalid date, if a user goes onto another tab, the previously valid date will be presented
+      // if the date is invalid, we are going to set isToDateValid to false because the date provided is not valid
       dispatch(setQueryProperty({ isFromDateValid: false, queryIndex, property: 'isFromDateValid' }));
     }
   };
 
+  // handler for the toDate MUI DatePicker
   const handleChangeToDate = (newValue) => {
     if (validateDate(dayjs(newValue), dayjs(toDateMin), dayjs(toDateMax))) {
-      dispatch(setQueryProperty({ endDate: dayjs(newValue).format('MM/DD/YYYY'), queryIndex, property: 'endDate' }));
+      // if the toDate is valid, we are going to make this change in state and set the isToDateValid to true
       dispatch(setQueryProperty({ isToDateValid: true, queryIndex, property: 'isToDateValid' }));
+      dispatch(setQueryProperty({ endDate: dayjs(newValue).format('MM/DD/YYYY'), queryIndex, property: 'endDate' }));
     } else {
+      // we do not save the invalid date, if a user goes onto another tab, the previously valid date will be presented
+      // if the date is invalid, we are going to set isToDateValid to false because the date provided is not valid
       dispatch(setQueryProperty({ isToDateValid: false, queryIndex, property: 'isToDateValid' }));
     }
   };
 
   useEffect(() => {
-    if (dayjs(endDate) > latestAllowedEndDate(platform)) {
+    // if the platform changes, we want to update the validity of the dates
+    if (dayjs(endDate) > fromDateMax) {
       handleChangeToDate(latestAllowedEndDate(platform));
       enqueueSnackbar('Changed your end date to match this platform limit', { variant: 'warning' });
     }
@@ -57,6 +66,10 @@ export default function SearchDatePicker({ queryIndex }) {
       handleChangeFromDate(earliestAllowedStartDate(platform));
       enqueueSnackbar('Changed your start date to match this platform limit', { variant: 'warning' });
     }
+    // why do we do this?
+    // we don't save invalid dates, so going into another tab would leave these set to false and a correct date
+    dispatch(setQueryProperty({ isToDateValid: true, queryIndex, property: 'isToDateValid' }));
+    dispatch(setQueryProperty({ isFromDateValid: true, queryIndex, property: 'isFromDateValid' }));
   }, [platform]);
 
   return (

--- a/mcweb/frontend/src/features/search/query/querySlice.js
+++ b/mcweb/frontend/src/features/search/query/querySlice.js
@@ -140,23 +140,6 @@ const querySlice = createSlice({
       });
     },
 
-    isFromDateValid: (state, { payload }) => {
-      const freezeState = state;
-
-      freezeState.forEach((qS) => {
-        const copyQs = qS;
-        copyQs.isFromDateValid = payload;
-      });
-    },
-
-    setIsToDateValid: (state, { payload }) => {
-      const freezeState = state;
-
-      freezeState.forEach((qS) => {
-        const copyQs = qS;
-        copyQs.isToDateValid = payload;
-      });
-    },
     removeQuery: (state, { payload }) => {
       const freezeState = state;
       if (payload === 0 && freezeState.length === 1) {

--- a/mcweb/frontend/src/features/search/query/querySlice.js
+++ b/mcweb/frontend/src/features/search/query/querySlice.js
@@ -25,6 +25,8 @@ const cleanQuery = (platform) => ({
   sources: [],
   previewSources: [],
   lastSearchTime: dayjs().unix(),
+  isFromDateValid: true,
+  isToDateValid: true,
   anyAll: 'any',
   advanced: false,
 });
@@ -45,6 +47,8 @@ const querySlice = createSlice({
         sources: [],
         previewSources: [],
         lastSearchTime: dayjs().unix(),
+        isFromDateValid: true,
+        isToDateValid: true,
         anyAll: 'any',
         advanced: false,
       },
@@ -133,6 +137,24 @@ const querySlice = createSlice({
       freezeState.forEach((qS) => {
         const copyQs = qS;
         copyQs.lastSearchTime = payload;
+      });
+    },
+
+    isFromDateValid: (state, { payload }) => {
+      const freezeState = state;
+
+      freezeState.forEach((qS) => {
+        const copyQs = qS;
+        copyQs.isFromDateValid = payload;
+      });
+    },
+
+    setIsToDateValid: (state, { payload }) => {
+      const freezeState = state;
+
+      freezeState.forEach((qS) => {
+        const copyQs = qS;
+        copyQs.isToDateValid = payload;
       });
     },
     removeQuery: (state, { payload }) => {

--- a/mcweb/frontend/src/features/search/query/querySlice.js
+++ b/mcweb/frontend/src/features/search/query/querySlice.js
@@ -120,6 +120,8 @@ const querySlice = createSlice({
           sources: [],
           previewSources: [],
           lastSearchTime: dayjs().unix(),
+          isFromDateValid: true,
+          isToDateValid: true,
           anyAll: 'any',
           advanced: false,
         },

--- a/mcweb/frontend/src/features/search/util/deactivateButton.js
+++ b/mcweb/frontend/src/features/search/util/deactivateButton.js
@@ -7,8 +7,6 @@ dayjs.extend(isSameOrBefore);
 const deactvateButton = (queryState) => {
   let returnVal = true;
 
-  // console.log(queryState);
-
   queryState.forEach((queryObject) => {
     const {
       queryString,
@@ -32,6 +30,7 @@ const deactvateButton = (queryState) => {
       return false;
     }
 
+    // parameters are both boolean variables
     function validFromAndToDates(validatedFromDate, validatedToDate) {
       return validatedFromDate && validatedToDate;
     }
@@ -43,7 +42,7 @@ const deactvateButton = (queryState) => {
 
     // is the advanced search query string not just the "*"
     function validQueryString(queryStr) {
-      return queryString.length !== 0;
+      return queryStr.length !== 0;
     }
 
     // is the query string empty?

--- a/mcweb/frontend/src/features/search/util/deactivateButton.js
+++ b/mcweb/frontend/src/features/search/util/deactivateButton.js
@@ -6,6 +6,9 @@ dayjs.extend(isSameOrBefore);
 
 const deactvateButton = (queryState) => {
   let returnVal = true;
+
+  // console.log(queryState);
+
   queryState.forEach((queryObject) => {
     const {
       queryString,
@@ -13,6 +16,8 @@ const deactvateButton = (queryState) => {
       negatedQueryList,
       startDate,
       endDate,
+      isFromDateValid,
+      isToDateValid,
     } = queryObject;
 
     const totalQuery = queryList.concat(negatedQueryList);
@@ -27,21 +32,25 @@ const deactvateButton = (queryState) => {
       return false;
     }
 
+    function validFromAndToDates(validatedFromDate, validatedToDate) {
+      return validatedFromDate && validatedToDate;
+    }
+
     // checks to see if the startDAte is before the endDAte
-    function validDates(sD, eD) {
-      return dayjs(sD).isSameOrBefore(dayjs(eD));
+    function validDates(startingDate, endingDate) {
+      return dayjs(startingDate).isSameOrBefore(dayjs(endingDate));
     }
 
     // is the advanced search query string not just the "*"
-    function validQueryString(qS) {
-      return qS.length !== 0;
+    function validQueryString(queryStr) {
+      return queryString.length !== 0;
     }
 
     // is the query string empty?
     const isQueryEmpty = validQuery(totalQuery);
 
-    // are the dates in correct order?
-    const areDatesValid = validDates(startDate, endDate);
+    // are the dates in correct order and validated?
+    const areDatesValid = validDates(startDate, endDate) && validFromAndToDates(isFromDateValid, isToDateValid);
 
     // is the advanced search query empty?
     const isQueryStringEmpty = validQueryString(queryString);


### PR DESCRIPTION
- Added isFromDateValid and isToDateValid into querySlice
- These variables represent if the formDate DatePicker and toDate DatePicker are valid. 
- These were originally set locally and the Search button was never disabled even if they were invalid

Since fromDate is invalid, button is disabled

<img width="1228" alt="Screen Shot 2023-06-02 at 6 34 55 PM" src="https://github.com/mediacloud/web-search/assets/63474660/5f586696-3f31-48ef-922a-5eb67fc79568">

Since fromDate and toDate are invalid, button is disabled

<img width="1230" alt="Screen Shot 2023-06-02 at 6 41 02 PM" src="https://github.com/mediacloud/web-search/assets/63474660/46ef7e55-787b-4d7d-a401-cacaa71a0218">

You may ask: "we've added another tab, queried 'world', and the search button is now activated?" 
Since the invalid dates aren't saved to the state, adding another tab is going to fetch the previously saved (and validated) dates and replace the invalid dates. 

<img width="1202" alt="Screen Shot 2023-06-02 at 6 42 21 PM" src="https://github.com/mediacloud/web-search/assets/63474660/eacd3de0-acd1-4e98-98e4-571449d1d4e8">

