### PR TITLE
Fix info menu

### DIFF
--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -126,9 +126,9 @@ def sample(request):
 @require_http_methods(["GET"])
 def story_detail(request):
     story_id = request.GET.get("storyId")
-    provider_name = providers.provider_name(
-        PLATFORM_ONLINE_NEWS, PLATFORM_SOURCE_WAYBACK_MACHINE)
-    provider = providers.provider_by_name(provider_name)
+    platform = request.GET.get("platform")
+
+    provider = providers.provider_by_name(platform)
     story_details = provider.item(story_id)
     # QuotaHistory.increment(request.user.id, request.user.is_staff, provider_name)
     return HttpResponse(json.dumps({"story": story_details}, default=str), content_type="application/json",

--- a/mcweb/frontend/src/app/services/searchApi.js
+++ b/mcweb/frontend/src/app/services/searchApi.js
@@ -41,8 +41,8 @@ export const searchApi = createApi({
       }),
     }),
     getStoryDetails: builder.query({
-      query: (storyId) => ({
-        url: `story?storyId=${storyId}`,
+      query: ({ storyId, platform }) => ({
+        url: `/story?storyId=${storyId}&platform=${platform}`,
         method: 'GET',
       }),
     }),

--- a/mcweb/frontend/src/features/search/results/SampleStories.jsx
+++ b/mcweb/frontend/src/features/search/results/SampleStories.jsx
@@ -27,15 +27,6 @@ export default function SampleStories() {
 
   const [dispatchQuery, { isLoading, data, error }] = useGetSampleStoriesMutation();
 
-  const [anchorEl, setAnchorEl] = React.useState(null);
-  const open = Boolean(anchorEl);
-
-  const handleClick = (event) => {
-    setAnchorEl(event.currentTarget);
-  };
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
   const [newQuery, setNewQuery] = useState(false);
 
   const [value, setValue] = useState(0);
@@ -95,11 +86,8 @@ export default function SampleStories() {
           {data.sample.map((results, i) => (
             <TabPanelHelper value={value} index={i}>
               <SampleStoryShow
-                open={open}
                 data={results}
                 lSTP={lastSearchTimePlatform}
-                handleClick={handleClick}
-                handleClose={handleClose}
                 platform={platform}
               />
             </TabPanelHelper>

--- a/mcweb/frontend/src/features/search/results/SampleStoryShow.jsx
+++ b/mcweb/frontend/src/features/search/results/SampleStoryShow.jsx
@@ -1,13 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
 import dayjs from 'dayjs';
-import Button from '@mui/material/Button';
-import Menu from '@mui/material/Menu';
-import MenuItem from '@mui/material/MenuItem';
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { PROVIDER_NEWS_WAYBACK_MACHINE } from '../util/platforms';
 import { googleFaviconUrl } from '../../ui/uiUtil';
+import InfoMenu from '../../ui/InfoMenu';
 
 export default function SampleStoryShow({
   data, lSTP, platform, handleClick, open, handleClose, anchorEl,
@@ -28,7 +24,11 @@ export default function SampleStoryShow({
         </tr>
         {data.map((sampleStory) => (
           <tr key={`story-${sampleStory.id}`}>
-            <td><a href={sampleStory.url} target="_blank" rel="noreferrer">{sampleStory.title}</a></td>
+
+            <td>
+              <a href={sampleStory.url} target="_blank" rel="noreferrer">{sampleStory.title}</a>
+            </td>
+
             <td>
               <img
                 className="google-icon"
@@ -37,47 +37,12 @@ export default function SampleStoryShow({
               />
               <a href={sampleStory.media_url} target="_blank" rel="noreferrer">{sampleStory.media_name}</a>
             </td>
-            <td>{dayjs(sampleStory.publish_date).format('MM-DD-YY')}</td>
-            {([PROVIDER_NEWS_WAYBACK_MACHINE].includes(platform)
-          && lSTP === PROVIDER_NEWS_WAYBACK_MACHINE) && (
 
-            <td>
-              <Button
-                variant="outlined"
-                onClick={handleClick}
-                aria-controls={open ? 'basic-menu' : undefined}
-                aria-haspopup="true"
-                aria-expanded={open ? 'true' : undefined}
-                endIcon={<KeyboardArrowDownIcon />}
-              >
-                Info
-              </Button>
-              <Menu
-                anchorEl={anchorEl}
-                open={open}
-                onClose={handleClose}
-              >
-                <MenuItem>
-                  <a href={sampleStory.url} target="_blank" rel="noreferrer">
-                    visit original URL
-                  </a>
-                </MenuItem>
-                <MenuItem>
-                  <a href={sampleStory.archived_url} target="_blank" rel="noreferrer">
-                    visit archived content (on Wayback Machine)
-                  </a>
-                </MenuItem>
-                <MenuItem>
-                  <Link
-                    to={`/story/${platform}/${getStoryId(sampleStory.article_url)}`}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    view extracted content (from Wayback Machine)
-                  </Link>
-                </MenuItem>
-              </Menu>
-            </td>
+            <td>{dayjs(sampleStory.publish_date).format('MM-DD-YY')}</td>
+
+            {([PROVIDER_NEWS_WAYBACK_MACHINE].includes(platform)
+              && lSTP === PROVIDER_NEWS_WAYBACK_MACHINE) && (
+                <InfoMenu platform={platform} sampleStory={sampleStory} />
             )}
           </tr>
         ))}

--- a/mcweb/frontend/src/features/search/results/SampleStoryShow.jsx
+++ b/mcweb/frontend/src/features/search/results/SampleStoryShow.jsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
-import { PROVIDER_NEWS_WAYBACK_MACHINE } from '../util/platforms';
+import { useSelector } from 'react-redux';
+import { PROVIDER_NEWS_WAYBACK_MACHINE, PROVIDER_NEWS_MEDIA_CLOUD } from '../util/platforms';
 import { googleFaviconUrl } from '../../ui/uiUtil';
 import InfoMenu from '../../ui/InfoMenu';
+import { selectCurrentUser } from '../../auth/authSlice';
 
 export default function SampleStoryShow({
-  data, lSTP, platform, handleClick, open, handleClose, anchorEl,
+  data, lSTP, platform,
 }) {
-  const getStoryId = (url) => {
-    if (!url) return null;
-    const parts = url.split('/');
-    return parts[(parts.length - 1)];
-  };
+  const currentUser = useSelector(selectCurrentUser);
+
   return (
 
     <table>
@@ -39,11 +38,13 @@ export default function SampleStoryShow({
             </td>
 
             <td>{dayjs(sampleStory.publish_date).format('MM-DD-YY')}</td>
-
-            {([PROVIDER_NEWS_WAYBACK_MACHINE].includes(platform)
-              && lSTP === PROVIDER_NEWS_WAYBACK_MACHINE) && (
+            {
+              (([PROVIDER_NEWS_WAYBACK_MACHINE].includes(platform) && lSTP === PROVIDER_NEWS_WAYBACK_MACHINE)
+                || ([PROVIDER_NEWS_MEDIA_CLOUD].includes(platform) && lSTP === PROVIDER_NEWS_MEDIA_CLOUD && currentUser.isStaff))
+              && (
                 <InfoMenu platform={platform} sampleStory={sampleStory} />
-            )}
+              )
+            }
           </tr>
         ))}
       </tbody>

--- a/mcweb/frontend/src/features/search/results/SampleStoryShow.jsx
+++ b/mcweb/frontend/src/features/search/results/SampleStoryShow.jsx
@@ -38,6 +38,7 @@ export default function SampleStoryShow({
             </td>
 
             <td>{dayjs(sampleStory.publish_date).format('MM-DD-YY')}</td>
+            {/* if platform is wayback-machine OR media-cloud and the currentUser is a staff */}
             {
               (([PROVIDER_NEWS_WAYBACK_MACHINE].includes(platform) && lSTP === PROVIDER_NEWS_WAYBACK_MACHINE)
                 || ([PROVIDER_NEWS_MEDIA_CLOUD].includes(platform) && lSTP === PROVIDER_NEWS_MEDIA_CLOUD && currentUser.isStaff))
@@ -66,12 +67,4 @@ SampleStoryShow.propTypes = {
   })).isRequired,
   lSTP: PropTypes.string.isRequired,
   platform: PropTypes.string.isRequired,
-  handleClick: PropTypes.func.isRequired,
-  open: PropTypes.bool.isRequired,
-  handleClose: PropTypes.func.isRequired,
-  anchorEl: PropTypes.element,
-};
-
-SampleStoryShow.defaultProps = {
-  anchorEl: undefined,
 };

--- a/mcweb/frontend/src/features/stories/StoryShow.jsx
+++ b/mcweb/frontend/src/features/stories/StoryShow.jsx
@@ -1,14 +1,26 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import dayjs from 'dayjs';
 import { useGetStoryDetailsQuery } from '../../app/services/searchApi';
+import { PROVIDER_NEWS_MEDIA_CLOUD, PROVIDER_NEWS_WAYBACK_MACHINE } from '../search/util/platforms';
 
 export default function StoryShow() {
   const params = useParams();
-  const { storyId } = params;
-  const { data, isLoading } = useGetStoryDetailsQuery(storyId);
+  const { storyId, platform } = params;
+  const { data, isLoading } = useGetStoryDetailsQuery({ storyId, platform });
+
+  const [platformName, setPlatformName] = useState('');
+
+  useEffect(() => {
+    if (platform === PROVIDER_NEWS_MEDIA_CLOUD) {
+      setPlatformName('Media Cloud');
+    } else {
+      setPlatformName('Wayback Machine');
+    }
+  }, [platform]);
 
   if (isLoading) {
     return <CircularProgress size="75px" />;
@@ -24,29 +36,59 @@ export default function StoryShow() {
       </div>
       <div className="row" style={{ marginLeft: 1 }}>
         <Alert severity="info" sx={{ width: '40%', marginBottom: 2 }}>
-          Extracted story information provided by Wayback Machine
+          Extracted story information provided by
+          {' '}
+          {platformName}
         </Alert>
       </div>
 
       <div className="row">
-        <h5>
-          {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-          Originally published on {story.publication_date} in <b>{story.domain}</b>. Collected on {story.capture_time}.
-        </h5>
+        {(platform === PROVIDER_NEWS_WAYBACK_MACHINE) && (
+          <h5>
+            {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
+            Originally published on {dayjs(story.publication_date).format('MM/DD/YYYY')}
+            {' '}
+            in
+            {' '}
+            <b>{story.domain}</b>
+            . Collected on
+            {' '}
+            {dayjs(story.capture_time).format('MM/DD/YYYY')}
+            .
+          </h5>
+        )}
+
+        {(platform === PROVIDER_NEWS_MEDIA_CLOUD) && (
+          <h5>
+            {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
+            Originally published on {dayjs(story.publish_date).format('MM/DD/YYYY')} in <b>{story.media_name}</b>
+          </h5>
+        )}
       </div>
 
-      <div className="clearfix">
-        <h3 className="float-start">Story Text</h3>
-        <h6 className="float-end">
-          <a target="_blank" href={story.archive_playback_url} rel="noreferrer">
-            <OpenInNewIcon />
-          </a>
-        </h6>
+      {(platform === PROVIDER_NEWS_WAYBACK_MACHINE) && (
+        <div>
+          <div className="clearfix">
+            <h3 className="float-start">Story Text</h3>
+            <h6 className="float-end">
+              <a target="_blank" href={story.archive_playback_url} rel="noreferrer">
+                <OpenInNewIcon />
+              </a>
+            </h6>
+          </div>
+          <div className="row">
+            <p>{story.snippet}</p>
+          </div>
+        </div>
+      )}
 
-      </div>
-      <div className="row">
-        <p>{story.snippet}</p>
-      </div>
+      {/* Archived Playback Url and Story Snippet does not exist in returned data with Media Cloud */}
+      {(platform === PROVIDER_NEWS_MEDIA_CLOUD) && (
+        <div className="clearfix">
+          <h3 className="float-start">Story Text and Information Unavailable</h3>
+        </div>
+      )}
+
     </div>
   );
 }

--- a/mcweb/frontend/src/features/ui/InfoMenu.jsx
+++ b/mcweb/frontend/src/features/ui/InfoMenu.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import Button from '@mui/material/Button';
 import Menu from '@mui/material/Menu';
+import { PROVIDER_NEWS_MEDIA_CLOUD, PROVIDER_NEWS_WAYBACK_MACHINE } from '../search/util/platforms';
 
 export default function InfoMenu({ platform, sampleStory }) {
   const getStoryId = (url) => {
@@ -11,8 +12,20 @@ export default function InfoMenu({ platform, sampleStory }) {
     return parts[(parts.length - 1)];
   };
 
-  const [anchorEl, setAnchorEl] = React.useState(null);
+  console.log(platform);
+  console.log(sampleStory);
+
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [platformName, setPlatformName] = useState();
   const open = Boolean(anchorEl);
+
+  useEffect(() => {
+    if (platform === PROVIDER_NEWS_MEDIA_CLOUD) {
+      setPlatformName('Online News');
+    } else {
+      setPlatformName('Wayback Machine');
+    }
+  }, [platform]);
 
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
@@ -60,24 +73,42 @@ export default function InfoMenu({ platform, sampleStory }) {
             >
               Visit original URL
             </a>
-            <a
-              href={sampleStory.archived_url}
-              target="_blank"
-              rel="noreferrer"
-              onClick={handleClose}
-              className="menu-item"
-            >
-              Visit archived content (on Wayback Machine)
-            </a>
-            <NavLink
-              to={`/story/${platform}/${getStoryId(sampleStory.article_url)}`}
-              target="_blank"
-              rel="noreferrer"
-              onClick={handleClose}
-              className="menu-item"
-            >
-              View extracted content (from Wayback Machine)
-            </NavLink>
+
+            {(platform === PROVIDER_NEWS_WAYBACK_MACHINE) && (
+              <a
+                href={sampleStory.archived_url}
+                target="_blank"
+                rel="noreferrer"
+                onClick={handleClose}
+                className="menu-item"
+              >
+                Visit archived content (on Wayback Machine)
+              </a>
+            )}
+
+            {(platform === PROVIDER_NEWS_MEDIA_CLOUD) && (
+              <NavLink
+                to={`/story/${platform}/${sampleStory.id}`}
+                target="_blank"
+                rel="noreferrer"
+                onClick={handleClose}
+                className="menu-item"
+              >
+                View extracted content (from Online News)
+              </NavLink>
+            )}
+
+            {(platform === PROVIDER_NEWS_WAYBACK_MACHINE) && (
+              <NavLink
+                to={`/story/${platform}/${getStoryId(sampleStory.article_url)}`}
+                target="_blank"
+                rel="noreferrer"
+                onClick={handleClose}
+                className="menu-item"
+              >
+                View extracted content (from Wayback Machine)
+              </NavLink>
+            )}
           </div>
         </Menu>
       </div>

--- a/mcweb/frontend/src/features/ui/InfoMenu.jsx
+++ b/mcweb/frontend/src/features/ui/InfoMenu.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import Button from '@mui/material/Button';
@@ -12,20 +12,8 @@ export default function InfoMenu({ platform, sampleStory }) {
     return parts[(parts.length - 1)];
   };
 
-  console.log(platform);
-  console.log(sampleStory);
-
   const [anchorEl, setAnchorEl] = useState(null);
-  const [platformName, setPlatformName] = useState();
   const open = Boolean(anchorEl);
-
-  useEffect(() => {
-    if (platform === PROVIDER_NEWS_MEDIA_CLOUD) {
-      setPlatformName('Online News');
-    } else {
-      setPlatformName('Wayback Machine');
-    }
-  }, [platform]);
 
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
@@ -64,6 +52,7 @@ export default function InfoMenu({ platform, sampleStory }) {
           }}
         >
           <div className="menu">
+            {/* Original URL is the same for both media-cloud and wayback-machine */}
             <a
               href={sampleStory.url}
               target="_blank"
@@ -74,6 +63,7 @@ export default function InfoMenu({ platform, sampleStory }) {
               Visit original URL
             </a>
 
+            {/* wayback-machine only has an archived url */}
             {(platform === PROVIDER_NEWS_WAYBACK_MACHINE) && (
               <a
                 href={sampleStory.archived_url}
@@ -86,6 +76,7 @@ export default function InfoMenu({ platform, sampleStory }) {
               </a>
             )}
 
+            {/* media-cloud story is a bit different, taken out of id */}
             {(platform === PROVIDER_NEWS_MEDIA_CLOUD) && (
               <NavLink
                 to={`/story/${platform}/${sampleStory.id}`}
@@ -98,6 +89,7 @@ export default function InfoMenu({ platform, sampleStory }) {
               </NavLink>
             )}
 
+            {/* wayback-machine story id is taken out of getStoryId function  */}
             {(platform === PROVIDER_NEWS_WAYBACK_MACHINE) && (
               <NavLink
                 to={`/story/${platform}/${getStoryId(sampleStory.article_url)}`}

--- a/mcweb/frontend/src/features/ui/InfoMenu.jsx
+++ b/mcweb/frontend/src/features/ui/InfoMenu.jsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import Button from '@mui/material/Button';
+import Menu from '@mui/material/Menu';
+
+export default function InfoMenu({ platform, sampleStory }) {
+  const getStoryId = (url) => {
+    if (!url) return null;
+    const parts = url.split('/');
+    return parts[(parts.length - 1)];
+  };
+
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <td>
+      <div>
+        <Button
+          id="positioned-button"
+          aria-controls={open ? 'positioned-menu' : undefined}
+          aria-haspopup="true"
+          aria-expanded={open ? 'true' : undefined}
+          onClick={handleClick}
+        >
+          Info
+        </Button>
+
+        <Menu
+          id="positioned-button"
+          aria-labelledby="positioned-button"
+          anchorEl={anchorEl}
+          open={open}
+          onClose={handleClose}
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'left',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'left',
+          }}
+        >
+          <div className="menu">
+            <a
+              href={sampleStory.url}
+              target="_blank"
+              rel="noreferrer"
+              onClick={handleClose}
+              className="menu-item"
+            >
+              Visit original URL
+            </a>
+
+            <a
+              href={sampleStory.archived_url}
+              target="_blank"
+              rel="noreferrer"
+              onClick={handleClose}
+              className="menu-item"
+            >
+              Visit archived content (on Wayback Machine)
+            </a>
+
+            <NavLink
+              to={`/story/${platform}/${getStoryId(sampleStory.article_url)}`}
+              target="_blank"
+              rel="noreferrer"
+              onClick={handleClose}
+              className="menu-item"
+            >
+              View extracted content (from Wayback Machine)
+            </NavLink>
+          </div>
+        </Menu>
+      </div>
+    </td>
+  );
+}
+
+InfoMenu.propTypes = {
+  sampleStory: PropTypes.arrayOf(PropTypes.shape({
+    archived_url: PropTypes.string,
+    article_url: PropTypes.string,
+    id: PropTypes.string,
+    language: PropTypes.string,
+    media_name: PropTypes.string,
+    media_url: PropTypes.string,
+    publish_date: PropTypes.string,
+    title: PropTypes.string,
+    url: PropTypes.string,
+  })).isRequired,
+  platform: PropTypes.string.isRequired,
+};

--- a/mcweb/frontend/src/features/ui/InfoMenu.jsx
+++ b/mcweb/frontend/src/features/ui/InfoMenu.jsx
@@ -85,7 +85,7 @@ export default function InfoMenu({ platform, sampleStory }) {
                 onClick={handleClose}
                 className="menu-item"
               >
-                View extracted content (from Online News)
+                View extracted content (from Media Cloud)
               </NavLink>
             )}
 

--- a/mcweb/frontend/src/features/ui/InfoMenu.jsx
+++ b/mcweb/frontend/src/features/ui/InfoMenu.jsx
@@ -60,7 +60,6 @@ export default function InfoMenu({ platform, sampleStory }) {
             >
               Visit original URL
             </a>
-
             <a
               href={sampleStory.archived_url}
               target="_blank"
@@ -70,7 +69,6 @@ export default function InfoMenu({ platform, sampleStory }) {
             >
               Visit archived content (on Wayback Machine)
             </a>
-
             <NavLink
               to={`/story/${platform}/${getStoryId(sampleStory.article_url)}`}
               target="_blank"

--- a/mcweb/frontend/src/features/ui/style/_infoMenu.scss
+++ b/mcweb/frontend/src/features/ui/style/_infoMenu.scss
@@ -1,0 +1,15 @@
+.menu {
+  display: flex;
+  flex-direction: column;
+ 
+  .menu-item {
+    margin-left: 3px;
+    margin-bottom: 8px;
+    text-decoration: none;
+  }
+
+  .menu-item:hover {
+    background-color: $primary-off-white;
+  }
+}
+

--- a/mcweb/frontend/src/style/Application.scss
+++ b/mcweb/frontend/src/style/Application.scss
@@ -7,7 +7,7 @@
 
 // ui component styling
 @import '../features/ui/style/statpanel';
-
+@import '../features/ui/style/infoMenu';
 // collection styling
 @import '../features/collections/style/collection';
 @import '../features/collections/style/modify-collection';


### PR DESCRIPTION
Created InfoMenu.jsx component that takes in sampleStory and platform. 
Switch out MenuItem with divs and a tags 

If user is staff, online news will also show Info! There's not as much extracted info though.


![image](https://github.com/mediacloud/web-search/assets/63474660/8e04bf6b-153d-4ceb-9019-a1717a1bf6fc)
