### PR TITLE
Quick fix for negated query problem

### DIFF
--- a/mcweb/frontend/src/features/search/util/setSearchQuery.js
+++ b/mcweb/frontend/src/features/search/util/setSearchQuery.js
@@ -163,7 +163,7 @@ const setSearchQuery = (searchParams, dispatch) => {
 
   negatedQuery = negatedQuery ? negatedQuery.split(',') : null;
   negatedQuery = formatQuery(negatedQuery);
-  negatedQuery = negatedQuery ? sizeQuery(negatedQuery) : null;
+  negatedQuery = sizeQuery(negatedQuery);
 
   queryStrings = queryStrings ? handleDecode(queryStrings) : null; // come back to
 


### PR DESCRIPTION
Fix for negated queries not being set in state on refresh for a single query.