### PR TITLE
Change naming of csv in background task, remove csv from name

### DIFF
--- a/mcweb/backend/search/tasks.py
+++ b/mcweb/backend/search/tasks.py
@@ -64,10 +64,10 @@ def _download_all_large_content_csv(queryState, user_id, user_isStaff, email):
     csvfile = StringIO()
     csvwriter = csv.writer(csvfile)
     
-    filename = "mc-{}-{}-content.csv".format(
+    filename = "mc-{}-{}-content".format(
         provider_name, _filename_timestamp())
    
-    zip_filename = "mc-{}-{}-content.csv.gz".format(
+    zip_filename = "mc-{}-{}-content".format(
         provider_name, _filename_timestamp())
     
     # Generate and write data to the CSV


### PR DESCRIPTION
Adjust naming where download csv is named to remove '.csv'.
<img width="452" alt="Screen Shot 2023-07-07 at 1 57 14 PM" src="https://github.com/mediacloud/web-search/assets/78226696/5fbaeef6-6483-4d33-a0bf-328f061ed3bd">
closes #413.