### PR TITLE
Change url_search_string checks in search utils for WBM

### DIFF
--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -99,11 +99,11 @@ def _for_wayback_machine(collections: List, sources: List) -> Dict:
     domains += [s.name for s in selected_sources if s.url_search_string is None]
     # turn collections ids into list of domains
     selected_sources_in_collections = Source.objects.filter(collections__id__in=collections)
-    domains += [s.name for s in selected_sources_in_collections if s.url_search_string is None]
+    domains += [s.name for s in selected_sources_in_collections if bool(s.url_search_string) is False]
     # 2. pull out all the domains that have url_search_strings and turn those into search clauses
     sources_with_url_search_strs = []
-    sources_with_url_search_strs += [s for s in selected_sources if s.url_search_string is not None]
-    sources_with_url_search_strs += [s for s in selected_sources_in_collections if s.url_search_string is not None]
+    sources_with_url_search_strs += [s for s in selected_sources if bool(s.url_search_string) is not False]
+    sources_with_url_search_strs += [s for s in selected_sources_in_collections if bool(s.url_search_string) is not False]
     domain_url_filters = ["(domain:{} AND url:*{}*)".format(s.name, s.url_search_string) for s in sources_with_url_search_strs]
     return dict(domains=domains, filters=domain_url_filters)
 


### PR DESCRIPTION
Due to there being no check if url_search_string was `''` (empty string) only if is was None, because empty string for python will be not None, added in suggested solution of using bool to check url_search_string and using False instead of None.

closes #414 