### PR TITLE
Date not adjusting when switching platforms

### DIFF
--- a/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
+++ b/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
@@ -59,16 +59,16 @@ export default function SearchDatePicker({ queryIndex }) {
     }
   };
 
-  // console.log(`endDate: ${endDate}`);
-  // console.log(`toDateMax: ${toDateMax}`);
-  // console.log('');
+  console.log(`endDate: ${endDate}`);
+  console.log(`toDateMax: ${toDateMax}`);
+  console.log('');
+
   // if the platform changes, we want to update the validity of the dates
   useEffect(() => {
-    // console.log(queryState);
-    // if (!checkForBlankQuery(queryState)) {
-    //   handleChangeToDate(latestAllowedEndDate(platform));
-    //   console.log('changed end date');
-    // }
+    // if the queries are empty, change the end date to the latest allowed end date per the platform
+    if (!checkForBlankQuery(queryState)) {
+      handleChangeToDate(latestAllowedEndDate(platform));
+    }
 
     // if the endDate is after than the latest allowed end date, change the end date to the latest allowed date
     if (dayjs(endDate) > dayjs(toDateMax)) {

--- a/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
+++ b/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
@@ -59,10 +59,6 @@ export default function SearchDatePicker({ queryIndex }) {
     }
   };
 
-  console.log(`endDate: ${endDate}`);
-  console.log(`toDateMax: ${toDateMax}`);
-  console.log('');
-
   // if the platform changes, we want to update the validity of the dates
   useEffect(() => {
     // if the queries are empty, change the end date to the latest allowed end date per the platform
@@ -73,12 +69,12 @@ export default function SearchDatePicker({ queryIndex }) {
     // if the endDate is after than the latest allowed end date, change the end date to the latest allowed date
     if (dayjs(endDate) > dayjs(toDateMax)) {
       handleChangeToDate(latestAllowedEndDate(platform));
-      enqueueSnackbar('Changed your end date to match this platform limit', { variant: 'warning' });
+      enqueueSnackbar('We changed your end date to match this platform limit', { variant: 'warning' });
     }
     // if the endDate is earlier than the earliest allowed start date, change the start date to the earliest allowed date
     if (dayjs(startDate) < dayjs(fromDateMin)) {
       handleChangeFromDate(earliestAllowedStartDate(platform));
-      enqueueSnackbar('Changed your start date to match this platform limit', { variant: 'warning' });
+      enqueueSnackbar('We changed your start date to match this platform limit', { variant: 'warning' });
     }
     // why do we do this?
     // we don't save invalid dates, so going into another tab would leave these set to false and a correct date

--- a/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
+++ b/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
@@ -12,6 +12,7 @@ import { setQueryProperty } from './querySlice';
 import { earliestAllowedStartDate, latestAllowedEndDate } from '../util/platforms';
 import validateDate from '../util/dateValidation';
 import DefaultDates from './DefaultDates';
+import checkForBlankQuery from '../util/checkForBlankQuery';
 
 export default function SearchDatePicker({ queryIndex }) {
   const dispatch = useDispatch();
@@ -20,6 +21,8 @@ export default function SearchDatePicker({ queryIndex }) {
   const {
     platform, startDate, endDate, isFromDateValid, isToDateValid,
   } = useSelector((state) => state.query[queryIndex]);
+
+  const queryState = useSelector((state) => state.query);
 
   // the minimum date off platform (From Date Picker)
   const fromDateMin = dayjs(earliestAllowedStartDate(platform)).format('MM/DD/YYYY');
@@ -56,13 +59,24 @@ export default function SearchDatePicker({ queryIndex }) {
     }
   };
 
+  // console.log(`endDate: ${endDate}`);
+  // console.log(`toDateMax: ${toDateMax}`);
+  // console.log('');
+  // if the platform changes, we want to update the validity of the dates
   useEffect(() => {
-    // if the platform changes, we want to update the validity of the dates
-    if (dayjs(endDate) > fromDateMax) {
+    // console.log(queryState);
+    // if (!checkForBlankQuery(queryState)) {
+    //   handleChangeToDate(latestAllowedEndDate(platform));
+    //   console.log('changed end date');
+    // }
+
+    // if the endDate is after than the latest allowed end date, change the end date to the latest allowed date
+    if (dayjs(endDate) > dayjs(toDateMax)) {
       handleChangeToDate(latestAllowedEndDate(platform));
       enqueueSnackbar('Changed your end date to match this platform limit', { variant: 'warning' });
     }
-    if (dayjs(startDate) < earliestAllowedStartDate(platform)) {
+    // if the endDate is earlier than the earliest allowed start date, change the start date to the earliest allowed date
+    if (dayjs(startDate) < dayjs(fromDateMin)) {
       handleChangeFromDate(earliestAllowedStartDate(platform));
       enqueueSnackbar('Changed your start date to match this platform limit', { variant: 'warning' });
     }


### PR DESCRIPTION
- end date adjusts
- if the queries are blank, change the end date to latest allowed end date per the platform
- edited snack bar comments
- added comments