### PR TITLE
Change 3 vert dots to ellipse for button conventions

### DIFF
--- a/mcweb/frontend/src/features/directory/DetailedSearch.jsx
+++ b/mcweb/frontend/src/features/directory/DetailedSearch.jsx
@@ -5,7 +5,7 @@ import Tab from '@mui/material/Tab';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import Box from '@mui/material/Box';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import CollectionSearch from './CollectionSearch';
 import SourceSearch from './SourceSearch';
 import GeographicCollectionsSearch from './GeographicCollectionsSearch';
@@ -16,8 +16,8 @@ export default function DetailedSearch() {
 
   return (
     <>
-      <Button variant="outlined" onClick={() => setOpen(true)} endIcon={<MoreVertIcon />}>
-        Detailed Search
+      <Button variant="outlined" onClick={() => setOpen(true)}>
+        Detailed Search...
       </Button>
 
       {/* https://stackoverflow.com/questions/47698037/how-can-i-set-a-height-to-a-dialog-in-material-ui */}

--- a/mcweb/frontend/src/features/search/query/SimpleSearch.jsx
+++ b/mcweb/frontend/src/features/search/query/SimpleSearch.jsx
@@ -79,6 +79,7 @@ export default function SimpleSearch({ queryIndex }) {
                     action={() => setQueryProperty({ advanced: true, queryIndex, property: 'advanced' })}
                     actionTarget
                     onClick={() => setOpen(true)}
+                    variant="outlined"
                     openDialog={open}
                     confirmButtonText="confirm"
                   />

--- a/mcweb/frontend/src/features/search/query/media-picker/MediaPicker.jsx
+++ b/mcweb/frontend/src/features/search/query/media-picker/MediaPicker.jsx
@@ -7,7 +7,6 @@ import Tab from '@mui/material/Tab';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import Box from '@mui/material/Box';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { addSelectedMedia, removePreviewSelectedMedia } from '../querySlice';
 import CollectionSearchPicker from './CollectionSearchPicker';
 import SelectedMedia from '../SelectedMedia';
@@ -36,8 +35,8 @@ export default function MediaPicker({ queryIndex }) {
 
   return (
     <div className="media-picker">
-      <Button variant="outlined" onClick={() => setOpen(true)} endIcon={<MoreVertIcon />}>
-        Select Collections
+      <Button variant="outlined" onClick={() => setOpen(true)}>
+        Select Collections...
       </Button>
 
       {/* https://stackoverflow.com/questions/47698037/how-can-i-set-a-height-to-a-dialog-in-material-ui */}

--- a/mcweb/frontend/src/features/ui/AlertDialog.jsx
+++ b/mcweb/frontend/src/features/ui/AlertDialog.jsx
@@ -6,7 +6,6 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
@@ -61,9 +60,9 @@ export default function AlertDialog({
         variant={variant}
         onClick={handleClickOpen}
         startIcon={startIcon}
-        endIcon={<MoreVertIcon />}
       >
         {outsideTitle}
+        ...
       </Button>
       <Dialog
         open={open}


### PR DESCRIPTION
Adjust buttons to use conventions laid out in #429 (change buttons that open menus to ellipse)
![Screen Shot 2023-07-19 at 1 15 50 PM](https://github.com/mediacloud/web-search/assets/78226696/858990d5-ff0f-42cb-bc73-962eb1ec9799)
