### PR TITLE
Add fix for deactivated search button in advanced

### DIFF
--- a/mcweb/backend/sources/data/featured-collections.json
+++ b/mcweb/backend/sources/data/featured-collections.json
@@ -10,6 +10,7 @@
       {
         "platform": "online_news",
         "collections": [
+          34412234,
           186572515,
           186572435,
           186572516

--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -44,7 +44,7 @@ export default function TabbedSearch() {
 
   const [color, setColors] = useState(['White']);
 
-  const { platform } = queryState[0];
+  const { platform, advanced } = queryState[0];
 
   const handleChange = (event, newValue) => {
     setValue(newValue);
@@ -53,7 +53,7 @@ export default function TabbedSearch() {
   const handleAddQuery = () => {
     const qsLength = queryState.length;
     setColors(() => [...color, 'White']);
-    dispatch(addQuery(platform));
+    dispatch(addQuery({ platform, advanced }));
     setValue(qsLength);
   };
 

--- a/mcweb/frontend/src/features/search/query/querySlice.js
+++ b/mcweb/frontend/src/features/search/query/querySlice.js
@@ -138,7 +138,7 @@ const querySlice = createSlice({
           queryString: '',
           queryList: [[], [], []],
           negatedQueryList: [[], [], []],
-          platform: payload,
+          platform: payload.platform,
           startDate,
           endDate: dayjs(latestAllowedEndDate(DEFAULT_PROVIDER)).format('MM/DD/YYYY'),
           collections: [],
@@ -149,7 +149,7 @@ const querySlice = createSlice({
           isFromDateValid: true,
           isToDateValid: true,
           anyAll: 'any',
-          advanced: false,
+          advanced: payload.advanced,
         },
       );
     },

--- a/mcweb/frontend/src/features/search/util/checkForBlankQuery.js
+++ b/mcweb/frontend/src/features/search/util/checkForBlankQuery.js
@@ -7,9 +7,15 @@ const checkForBlankQuery = (queryState) => {
     ({
       queryList, negatedQueryList, advanced, queryString,
     }) => {
-      if ((isQueryListBlank(queryList) && isQueryListBlank(negatedQueryList)) || (advanced && queryString.trim() !== '')) {
+      if ((isQueryListBlank(queryList) && isQueryListBlank(negatedQueryList))) {
         isBlank = true;
-        return true; // exit the loop early
+      } else if (!isQueryListBlank(queryList)) {
+        isBlank = false;
+      }
+      if (advanced && queryString.trim() === '') {
+        isBlank = true;
+      } else if (advanced && queryString.trim() !== '') {
+        isBlank = false;
       }
     },
   );


### PR DESCRIPTION
When in advanced search the 'search' button was deactivated.
- made fix in checkForBlankQueries to not deactivate when in advanced
- Add United States - National to featured collections
- update addQuery method to now add on another advanced search query if the user is in advanced search already