### PR TITLE
Remove pushift twitter

### DIFF
--- a/mcweb/frontend/src/features/search/query/PlatformPicker.jsx
+++ b/mcweb/frontend/src/features/search/query/PlatformPicker.jsx
@@ -83,7 +83,7 @@ export default function PlatformPicker({ queryIndex }) {
                 (Wayback Machine)
               </ToggleButton>
             )}
-            {document.settings.availableProviders.includes(PROVIDER_REDDIT_PUSHSHIFT) && (
+            {/* {document.settings.availableProviders.includes(PROVIDER_REDDIT_PUSHSHIFT) && (
               <ToggleButton
                 onClick={() => { handleChangePlatform(PROVIDER_REDDIT_PUSHSHIFT); }}
                 value={PROVIDER_REDDIT_PUSHSHIFT}
@@ -93,8 +93,8 @@ export default function PlatformPicker({ queryIndex }) {
                 <br />
                 (PushShift.io API)
               </ToggleButton>
-            )}
-            {document.settings.availableProviders.includes(PROVIDER_TWITTER_TWITTER) && (
+            )} */}
+            {/* {document.settings.availableProviders.includes(PROVIDER_TWITTER_TWITTER) && (
               <ToggleButton
                 onClick={() => { handleChangePlatform(PROVIDER_TWITTER_TWITTER); }}
                 value={PROVIDER_TWITTER_TWITTER}
@@ -104,7 +104,7 @@ export default function PlatformPicker({ queryIndex }) {
                 <br />
                 (Twitter API)
               </ToggleButton>
-            )}
+            )} */}
             {document.settings.availableProviders.includes(PROVIDER_YOUTUBE_YOUTUBE) && (
               <ToggleButton
                 onClick={() => { handleChangePlatform(PROVIDER_YOUTUBE_YOUTUBE); }}

--- a/mcweb/frontend/static/about/release_history.json
+++ b/mcweb/frontend/static/about/release_history.json
@@ -5,7 +5,8 @@
 "fix buttons that didn't conform with button conventions",
 "fix bugs with date not accurately adjusting between platforms",
 "fix app crashing bug when switching between platforms",
-"adjustments to the source alert system"
+"adjustments to the source alert system",
+"remove reddit and twitter as platforms in search"
 ]
 },
 {"version": "v1.4.3",


### PR DESCRIPTION
Remove Reddit (pushshift) and Twitter from platforms to query against in search. This is due to the unavailability of the reddit and twitter api due to changes in their API pricing structure as well as removing academic access. closes #441 .