### PR TITLE
Bug for deleting a query tab after searching

### DIFF
--- a/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
+++ b/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
@@ -82,7 +82,6 @@ export default function CountOverTimeResults() {
       </Alert>
     );
   } else {
-    // console.log(prepareCountOverTimeData(data.count_over_time, normalized, queryState));
     const preparedData = prepareCountOverTimeData(data.count_over_time, normalized, queryState);
     if (preparedData.length !== queryState.length) return null;
     const updatedPrepareCountOverTimeData = preparedData.map(

--- a/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
+++ b/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
@@ -63,7 +63,6 @@ export default function CountOverTimeResults() {
       executeScroll();
     }
   }, [data, error]);
-
   if (newQuery) return null;
   let content;
 
@@ -83,7 +82,10 @@ export default function CountOverTimeResults() {
       </Alert>
     );
   } else {
-    const updatedPrepareCountOverTimeData = prepareCountOverTimeData(data.count_over_time, normalized, queryState).map(
+    // console.log(prepareCountOverTimeData(data.count_over_time, normalized, queryState));
+    const preparedData = prepareCountOverTimeData(data.count_over_time, normalized, queryState);
+    if (preparedData.length !== queryState.length) return null;
+    const updatedPrepareCountOverTimeData = preparedData.map(
       (originalDataObj, index) => {
         const queryTitleForPreparation = { name: queryState[index].name };
         return { ...queryTitleForPreparation, ...originalDataObj };

--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -107,9 +107,12 @@ function TotalAttentionResults() {
       </Alert>
     );
   } else {
-    const updatedTotalAttentionData = prepareTotalAttentionData(data, normalized).map(
+    console.log(prepareTotalAttentionData(data, normalized));
+    const preparedTAdata = prepareTotalAttentionData(data, normalized);
+    if (preparedTAdata.length !== queryState.length) return null;
+    const updatedTotalAttentionData = preparedTAdata.map(
       (originalDataObj, index) => {
-        const queryTitleForPreparation = { name: queryState[index].name };
+        const queryTitleForPreparation = { name: queryState[index].name ? queryState[index].name : '' };
         return { ...queryTitleForPreparation, ...originalDataObj };
       },
     );

--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -107,12 +107,11 @@ function TotalAttentionResults() {
       </Alert>
     );
   } else {
-    console.log(prepareTotalAttentionData(data, normalized));
     const preparedTAdata = prepareTotalAttentionData(data, normalized);
     if (preparedTAdata.length !== queryState.length) return null;
     const updatedTotalAttentionData = preparedTAdata.map(
       (originalDataObj, index) => {
-        const queryTitleForPreparation = { name: queryState[index].name ? queryState[index].name : '' };
+        const queryTitleForPreparation = { name: queryState[index].name };
         return { ...queryTitleForPreparation, ...originalDataObj };
       },
     );


### PR DESCRIPTION
After searching, deleting a tab would cause the app to crash, could map undefined name.
Made check to ensure if the data returned no longer matches the length of the querystate to return null. (name was tied to mapping over data, which would not change after a tab was deleted in the query).