### PR TITLE
Fix for bug when deleting a tab while searching

### DIFF
--- a/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
+++ b/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
@@ -59,7 +59,7 @@ export default function CountOverTimeResults() {
   }, [lastSearchTime, queryState.length]);
 
   useEffect(() => {
-    if (data || error) {
+    if ((data || error) && (data.count_over_time.length === queryState.length)) {
       executeScroll();
     }
   }, [data, error]);


### PR DESCRIPTION
When hitting search and loading data, deleting a tab before results arrived would cause the app to crash.