### PR TITLE
Adjust range to 2 std devs for sources returning high story volume

### DIFF
--- a/mcweb/backend/sources/tasks.py
+++ b/mcweb/backend/sources/tasks.py
@@ -208,9 +208,10 @@ def _alert_system(collection_ids):
                 send_alert_email(alert_dict)
 
 def _classify_alert(month_mean, week_mean, std_dev):
-    range = std_dev * 1.5
-    lower = month_mean - range
-    upper = month_mean + range 
+    lower_range = std_dev * 1.5
+    upper_range = std_dev * 2
+    lower = month_mean - lower_range
+    upper = month_mean + upper_range 
     if week_mean < lower:
         return ALERT_LOW
     elif week_mean > upper:


### PR DESCRIPTION
Adjusted the alert for stories returning higher than normal story volume to 2 std devs (up from 1.5) after a request.