### PR TITLE
Adjust search architecture 

### DIFF
--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -28,8 +28,8 @@ def fill_in_dates(start_date, end_date, existing_counts):
 
 
 def parse_query(request, http_method: str = 'POST') -> tuple:
-    # payload = json.loads(request.body).get("queryObject") if http_method == 'POST' else json.loads(request.GET.get("queryObject"))
-    payload = request
+    payload = json.loads(request.body).get("queryObject") if http_method == 'POST' else json.loads(request.GET.get("queryObject"))
+    # payload = request
     provider_name = payload["platform"]
     query_str = payload["query"]
     collections = payload["collections"]

--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -41,6 +41,20 @@ def parse_query(request, http_method: str = 'POST') -> tuple:
     end_date = dt.datetime.strptime(end_date, '%m/%d/%Y')
     return start_date, end_date, query_str, provider_props, provider_name
 
+def parse_query_array(queryObject) -> tuple:
+    # payload = json.loads(request.body).get("queryObject") if http_method == 'POST' else json.loads(request.GET.get("queryObject"))
+    payload = queryObject
+    provider_name = payload["platform"]
+    query_str = payload["query"]
+    collections = payload["collections"]
+    sources = payload["sources"]
+    provider_props = search_props_for_provider(provider_name, collections, sources)
+    start_date = payload["startDate"]
+    start_date = dt.datetime.strptime(start_date, '%m/%d/%Y')
+    end_date = payload["endDate"]
+    end_date = dt.datetime.strptime(end_date, '%m/%d/%Y')
+    return start_date, end_date, query_str, provider_props, provider_name
+
 
 def search_props_for_provider(provider, collections: List, sources: List) -> Dict:
     if provider == provider_name(PLATFORM_TWITTER, PLATFORM_SOURCE_TWITTER):

--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -10,7 +10,7 @@ from django.views.decorators.http import require_http_methods
 from django.contrib.auth.decorators import login_required
 from rest_framework.decorators import action
 import backend.util.csv_stream as csv_stream
-from .utils import parse_query
+from .utils import parse_query, parse_query_array
 from .tasks import download_all_large_content_csv
 from ..users.models import QuotaHistory
 from backend.users.exceptions import OverQuotaException
@@ -129,8 +129,7 @@ def download_languages_csv(request):
     queryState = json.loads(request.GET.get("qS"))
     data = []
     for query in queryState:
-        start_date, end_date, query_str, provider_props, provider_name = parse_query(
-            query, 'GET')
+        start_date, end_date, query_str, provider_props, provider_name = parse_query_array(query)
         provider = providers.provider_by_name(provider_name)
         if provider_name.split('-')[0] == PLATFORM_REDDIT:
             data.append(provider.languages(
@@ -174,8 +173,7 @@ def download_words_csv(request):
     queryState = json.loads(request.GET.get("qS"))
     data = []
     for query in queryState:
-        start_date, end_date, query_str, provider_props, provider_name = parse_query(
-            query, 'GET')
+        start_date, end_date, query_str, provider_props, provider_name = parse_query_array(query)
         provider = providers.provider_by_name(provider_name)
         if provider_name.split('-')[0] == PLATFORM_REDDIT:
             words = provider.words(query_str, start_date,
@@ -213,8 +211,7 @@ def download_counts_over_time_csv(request):
     queryState = json.loads(request.GET.get("qS"))
     data = []
     for query in queryState:
-        start_date, end_date, query_str, provider_props, provider_name = parse_query(
-            query, 'GET')
+        start_date, end_date, query_str, provider_props, provider_name = parse_query_array(query)
         provider = providers.provider_by_name(provider_name)
         try:
             data.append(provider.normalized_count_over_time(
@@ -254,8 +251,7 @@ def download_all_content_csv(request):
     queryState = json.loads(request.GET.get("qS"))
     data = []
     for query in queryState:
-        start_date, end_date, query_str, provider_props, provider_name = parse_query(
-            query, 'GET')
+        start_date, end_date, query_str, provider_props, provider_name = parse_query_array(query)
         provider = providers.provider_by_name(provider_name)
         data.append(provider.all_items(
             query_str, start_date, end_date, **provider_props))
@@ -291,7 +287,7 @@ def send_email_large_download_csv(request):
 
     # follows similiar logic from download_all_content_csv, get information and send to tasks
     for query in queryState:
-        start_date, end_date, query_str, provider_props, provider_name = parse_query(query, 'GET')
+        start_date, end_date, query_str, provider_props, provider_name = parse_query_array(query)
         provider = providers.provider_by_name(provider_name)
         try:
             count = provider.count(query_str, start_date, end_date, **provider_props)

--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -63,8 +63,7 @@ def total_count(request):
         total_content_count = provider.count(provider.everything_query(), start_date, end_date, **provider_props)
     except QueryingEverythingUnsupportedQuery as e:
         total_content_count = None
-    QuotaHistory.increment(
-        request.user.id, request.user.is_staff, provider_name)
+    QuotaHistory.increment(request.user.id, request.user.is_staff, provider_name)
     return HttpResponse(json.dumps({"count": {"relevant": relevant_count, "total": total_content_count}}),
                         content_type="application/json", status=200)
 
@@ -76,12 +75,10 @@ def count_over_time(request):
     start_date, end_date, query_str, provider_props, provider_name = parse_query(request)
     provider = providers.provider_by_name(provider_name)
     try:
-        results = provider.normalized_count_over_time(
-            query_str, start_date, end_date, **provider_props)
+        results = provider.normalized_count_over_time(query_str, start_date, end_date, **provider_props)
     except UnsupportedOperationException:
         # for platforms that don't support querying over time
-        results = provider.count_over_time(
-            query_str, start_date, end_date, **provider_props)
+        results = provider.count_over_time(query_str, start_date, end_date, **provider_props)
     response = results
     QuotaHistory.increment(
         request.user.id, request.user.is_staff, provider_name)
@@ -93,13 +90,10 @@ def count_over_time(request):
 @handle_provider_errors
 @require_http_methods(["POST"])
 def sample(request):
-    start_date, end_date, query_str, provider_props, provider_name = parse_query(
-        request)
+    start_date, end_date, query_str, provider_props, provider_name = parse_query(request)
     provider = providers.provider_by_name(provider_name)
-    response = provider.sample(
-        query_str, start_date, end_date, **provider_props)
-    QuotaHistory.increment(
-        request.user.id, request.user.is_staff, provider_name)
+    response = provider.sample(query_str, start_date, end_date, **provider_props)
+    QuotaHistory.increment(request.user.id, request.user.is_staff, provider_name)
     return HttpResponse(json.dumps({"sample": response}, default=str), content_type="application/json",
                         status=200)
 
@@ -121,16 +115,10 @@ def story_detail(request):
 @handle_provider_errors
 @require_http_methods(["POST"])
 def languages(request):
-    payload = json.loads(request.body).get("queryObject")
-    response = []
-    for query in payload:
-        start_date, end_date, query_str, provider_props, provider_name = parse_query(
-            query)
-        provider = providers.provider_by_name(provider_name)
-        response.append(provider.languages(
-            query_str, start_date, end_date, **provider_props))
-        QuotaHistory.increment(
-            request.user.id, request.user.is_staff, provider_name, 2)
+    start_date, end_date, query_str, provider_props, provider_name = parse_query(request)
+    provider = providers.provider_by_name(provider_name)
+    response = provider.languages(query_str, start_date, end_date, **provider_props)
+    QuotaHistory.increment(request.user.id, request.user.is_staff, provider_name, 2)
     return HttpResponse(json.dumps({"languages": response}, default=str), content_type="application/json",
                         status=200)
 
@@ -171,17 +159,11 @@ def download_languages_csv(request):
 @handle_provider_errors
 @require_http_methods(["POST"])
 def words(request):
-    payload = json.loads(request.body).get("queryObject")
-    response = []
-    for query in payload:
-        start_date, end_date, query_str, provider_props, provider_name = parse_query(
-            query)
-        provider = providers.provider_by_name(provider_name)
-        words = provider.words(query_str, start_date,
-                               end_date, **provider_props)
-        response.append(add_ratios(words))
-    QuotaHistory.increment(
-        request.user.id, request.user.is_staff, provider_name, 4)
+    start_date, end_date, query_str, provider_props, provider_name = parse_query(request)
+    provider = providers.provider_by_name(provider_name)
+    words = provider.words(query_str, start_date,end_date, **provider_props)
+    response = add_ratios(words)
+    QuotaHistory.increment(request.user.id, request.user.is_staff, provider_name, 4)
     return HttpResponse(json.dumps({"words": response}, default=str), content_type="application/json",
                         status=200)
 

--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -92,21 +92,17 @@ def total_count(request):
 @handle_provider_errors
 @require_http_methods(["POST"])
 def count_over_time(request):
-    payload = json.loads(request.body).get("queryObject")
-    response = []
-    for query in payload:
-        start_date, end_date, query_str, provider_props, provider_name = parse_query(
-            query)
-        provider = providers.provider_by_name(provider_name)
-        try:
-            results = provider.normalized_count_over_time(
-                query_str, start_date, end_date, **provider_props)
-        except UnsupportedOperationException:
-            # for platforms that don't support querying over time
-            results = provider.count_over_time(
-                query_str, start_date, end_date, **provider_props)
-        # logger.debug("NORMALIZED COUNT OVER TIME: %, %".format(start_date, end_date))
-        response.append(results)
+    start_date, end_date, query_str, provider_props, provider_name = parse_query(request)
+    provider = providers.provider_by_name(provider_name)
+    try:
+        results = provider.normalized_count_over_time(
+            query_str, start_date, end_date, **provider_props)
+    except UnsupportedOperationException:
+        # for platforms that don't support querying over time
+        results = provider.count_over_time(
+            query_str, start_date, end_date, **provider_props)
+    # logger.debug("NORMALIZED COUNT OVER TIME: %, %".format(start_date, end_date))
+    response = results
     QuotaHistory.increment(
         request.user.id, request.user.is_staff, provider_name)
     return HttpResponse(json.dumps({"count_over_time": response}, default=str), content_type="application/json",

--- a/mcweb/frontend/src/app/services/searchApi.js
+++ b/mcweb/frontend/src/app/services/searchApi.js
@@ -12,11 +12,6 @@ export const searchApi = createApi({
   }),
   endpoints: (builder) => ({
     getTotalCount: builder.mutation({
-      // query: (queryObject) => ({
-      //   url: 'total-count',
-      //   method: 'POST',
-      //   body: { queryObject },
-      // }),
       queryFn: (queryState, _queryApi, _extraOptions, fetchWithBQ) => {
         const promises = queryState.map((queryObject) => fetchWithBQ({
           url: 'total-count',
@@ -27,11 +22,19 @@ export const searchApi = createApi({
       },
     }),
     getCountOverTime: builder.mutation({
-      query: (queryObject) => ({
-        url: 'count-over-time',
-        method: 'POST',
-        body: { queryObject },
-      }),
+      // query: (queryObject) => ({
+      //   url: 'count-over-time',
+      //   method: 'POST',
+      //   body: { queryObject },
+      // }),
+      queryFn: (queryState, _queryApi, _extraOptions, fetchWithBQ) => {
+        const promises = queryState.map((queryObject) => fetchWithBQ({
+          url: 'count-over-time',
+          method: 'POST',
+          body: { queryObject },
+        }));
+        return Promise.all(promises).then((results) => ({ data: results.map((result) => (result.data)) }));
+      },
     }),
     getSampleStories: builder.mutation({
       query: (queryObject) => ({

--- a/mcweb/frontend/src/app/services/searchApi.js
+++ b/mcweb/frontend/src/app/services/searchApi.js
@@ -18,7 +18,12 @@ export const searchApi = createApi({
           method: 'POST',
           body: { queryObject },
         }));
-        return Promise.all(promises).then((results) => ({ data: results.map((result) => (result.data)) }));
+        return Promise.all(promises).then(
+          (results) => (
+            results[0].data
+              ? { data: results.map((result) => (result.data)) }
+              : { error: results[0].error.data }),
+        );
       },
     }),
     getCountOverTime: builder.mutation({
@@ -28,7 +33,12 @@ export const searchApi = createApi({
           method: 'POST',
           body: { queryObject },
         }));
-        return Promise.all(promises).then((results) => ({ data: results.map((result) => (result.data)) }));
+        return Promise.all(promises).then(
+          (results) => (
+            results[0].data
+              ? { data: results.map((result) => (result.data)) }
+              : { error: results[0].error.data }),
+        );
       },
     }),
     getSampleStories: builder.mutation({
@@ -38,7 +48,12 @@ export const searchApi = createApi({
           method: 'POST',
           body: { queryObject },
         }));
-        return Promise.all(promises).then((results) => ({ data: results.map((result) => (result.data)) }));
+        return Promise.all(promises).then(
+          (results) => (
+            results[0].data
+              ? { data: results.map((result) => (result.data)) }
+              : { error: results[0].error.data }),
+        );
       },
     }),
     getStoryDetails: builder.query({

--- a/mcweb/frontend/src/app/services/searchApi.js
+++ b/mcweb/frontend/src/app/services/searchApi.js
@@ -63,18 +63,33 @@ export const searchApi = createApi({
       }),
     }),
     getTopWords: builder.mutation({
-      query: (queryObject) => ({
-        url: 'words',
-        method: 'POST',
-        body: { queryObject },
-      }),
+      queryFn: (queryState, _queryApi, _extraOptions, fetchWithBQ) => {
+        const promises = queryState.map((queryObject) => fetchWithBQ({
+          url: 'words',
+          method: 'POST',
+          body: { queryObject },
+        }));
+        return Promise.all(promises).then(
+          (results) => (
+            results[0].data
+              ? { data: results.map((result) => (result.data)) }
+              : { error: results[0].error.data }),
+        );
+      },
     }),
     getTopLanguages: builder.mutation({
-      query: (queryObject) => ({
-        url: 'languages',
-        method: 'POST',
-        body: { queryObject },
-      }),
+      queryFn: (queryState, _queryApi, _extraOptions, fetchWithBQ) => {
+        const promises = queryState.map((queryObject) => fetchWithBQ({
+          url: 'languages',
+          method: 'POST',
+          body: { queryObject },
+        }));
+        return Promise.all(promises).then(
+          (results) => (results[0].data
+            ? { data: results.map((result) => (result.data)) }
+            : { error: results[0].error.data }),
+        );
+      },
     }),
     sendTotalAttentionDataEmail: builder.mutation({
       query: (preparedQueryAndEmail) => ({

--- a/mcweb/frontend/src/app/services/searchApi.js
+++ b/mcweb/frontend/src/app/services/searchApi.js
@@ -23,9 +23,10 @@ export const searchApi = createApi({
           method: 'POST',
           body: { queryObject },
         }));
-        return Promise.all(promises).then((results) => (
-          { data: results }
-        ));
+        return Promise.all(promises).then((results) => {
+          console.log('results', results);
+          return { data: results.map((result) => (result.data)) };
+        });
       },
     }),
     getCountOverTime: builder.mutation({

--- a/mcweb/frontend/src/app/services/searchApi.js
+++ b/mcweb/frontend/src/app/services/searchApi.js
@@ -22,11 +22,6 @@ export const searchApi = createApi({
       },
     }),
     getCountOverTime: builder.mutation({
-      // query: (queryObject) => ({
-      //   url: 'count-over-time',
-      //   method: 'POST',
-      //   body: { queryObject },
-      // }),
       queryFn: (queryState, _queryApi, _extraOptions, fetchWithBQ) => {
         const promises = queryState.map((queryObject) => fetchWithBQ({
           url: 'count-over-time',
@@ -37,11 +32,14 @@ export const searchApi = createApi({
       },
     }),
     getSampleStories: builder.mutation({
-      query: (queryObject) => ({
-        url: 'sample',
-        method: 'POST',
-        body: { queryObject },
-      }),
+      queryFn: (queryState, _queryApi, _extraOptions, fetchWithBQ) => {
+        const promises = queryState.map((queryObject) => fetchWithBQ({
+          url: 'sample',
+          method: 'POST',
+          body: { queryObject },
+        }));
+        return Promise.all(promises).then((results) => ({ data: results.map((result) => (result.data)) }));
+      },
     }),
     getStoryDetails: builder.query({
       query: ({ storyId, platform }) => ({

--- a/mcweb/frontend/src/app/services/searchApi.js
+++ b/mcweb/frontend/src/app/services/searchApi.js
@@ -12,11 +12,21 @@ export const searchApi = createApi({
   }),
   endpoints: (builder) => ({
     getTotalCount: builder.mutation({
-      query: (queryObject) => ({
-        url: 'total-count',
-        method: 'POST',
-        body: { queryObject },
-      }),
+      // query: (queryObject) => ({
+      //   url: 'total-count',
+      //   method: 'POST',
+      //   body: { queryObject },
+      // }),
+      queryFn: (queryState, _queryApi, _extraOptions, fetchWithBQ) => {
+        const promises = queryState.map((queryObject) => fetchWithBQ({
+          url: 'total-count',
+          method: 'POST',
+          body: { queryObject },
+        }));
+        return Promise.all(promises).then((results) => (
+          { data: results }
+        ));
+      },
     }),
     getCountOverTime: builder.mutation({
       query: (queryObject) => ({

--- a/mcweb/frontend/src/app/services/searchApi.js
+++ b/mcweb/frontend/src/app/services/searchApi.js
@@ -23,10 +23,7 @@ export const searchApi = createApi({
           method: 'POST',
           body: { queryObject },
         }));
-        return Promise.all(promises).then((results) => {
-          console.log('results', results);
-          return { data: results.map((result) => (result.data)) };
-        });
+        return Promise.all(promises).then((results) => ({ data: results.map((result) => (result.data)) }));
       },
     }),
     getCountOverTime: builder.mutation({

--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -301,8 +301,8 @@ export default function TabbedSearch() {
       </div>
       <div className="search-results-wrapper">
         <div className="container">
-          {/* <CountOverTimeResults /> */}
-          <TotalAttentionResults />
+          <CountOverTimeResults />
+          {/* <TotalAttentionResults /> */}
           {/* <SampleStories />
           <TopWords />
           <TopLanguages /> */}

--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -301,8 +301,8 @@ export default function TabbedSearch() {
       </div>
       <div className="search-results-wrapper">
         <div className="container">
-          {/* <CountOverTimeResults />
-          <TotalAttentionResults /> */}
+          <CountOverTimeResults />
+          <TotalAttentionResults />
           <SampleStories />
           {/* <TopWords /> */}
           {/* <TopLanguages /> */}

--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -304,8 +304,8 @@ export default function TabbedSearch() {
           <CountOverTimeResults />
           <TotalAttentionResults />
           <SampleStories />
-          {/* <TopWords /> */}
-          {/* <TopLanguages /> */}
+          <TopWords />
+          <TopLanguages />
         </div>
       </div>
     </div>

--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -301,11 +301,11 @@ export default function TabbedSearch() {
       </div>
       <div className="search-results-wrapper">
         <div className="container">
-          <CountOverTimeResults />
-          {/* <TotalAttentionResults /> */}
-          {/* <SampleStories />
-          <TopWords />
-          <TopLanguages /> */}
+          {/* <CountOverTimeResults />
+          <TotalAttentionResults /> */}
+          <SampleStories />
+          {/* <TopWords /> */}
+          {/* <TopLanguages /> */}
         </div>
       </div>
     </div>

--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -301,11 +301,11 @@ export default function TabbedSearch() {
       </div>
       <div className="search-results-wrapper">
         <div className="container">
-          <CountOverTimeResults />
+          {/* <CountOverTimeResults /> */}
           <TotalAttentionResults />
-          <SampleStories />
+          {/* <SampleStories />
           <TopWords />
-          <TopLanguages />
+          <TopLanguages /> */}
         </div>
       </div>
     </div>

--- a/mcweb/frontend/src/features/search/results/CountOverTimeChart.jsx
+++ b/mcweb/frontend/src/features/search/results/CountOverTimeChart.jsx
@@ -71,32 +71,8 @@ export default function CountOverTimeChart({ series, normalized }) {
 CountOverTimeChart.propTypes = {
   series: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.string.isRequired,
-    data: PropTypes.shape({
-      counts: PropTypes.shape({
-        count: PropTypes.number,
-        date: PropTypes.string,
-        ratio: PropTypes.number,
-        total_count: PropTypes.number,
-      }),
-      normalized_total: PropTypes.number,
-      total: PropTypes.number,
-    }),
+    data: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)).isRequired,
     color: PropTypes.string.isRequired,
-  })),
+  })).isRequired,
   normalized: PropTypes.bool.isRequired,
-};
-
-CountOverTimeChart.defaultProps = {
-  series: {
-    data: {
-      counts: {
-        count: 0,
-        date: '',
-        ration: 0,
-        total_count: 0,
-      },
-      normalized_total: 0,
-      total: 0,
-    },
-  },
 };

--- a/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
+++ b/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
@@ -84,7 +84,9 @@ export default function CountOverTimeResults() {
       </Alert>
     );
   } else {
-    const preparedData = prepareCountOverTimeData(data.count_over_time, normalized, queryState);
+    console.log('DATA', data);
+    const preparedData = prepareCountOverTimeData(data, normalized, queryState);
+    console.log('PREPAREDDATA', preparedData);
     if (preparedData.length !== queryState.length) return null;
     const updatedPrepareCountOverTimeData = preparedData.map(
       (originalDataObj, index) => {

--- a/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
+++ b/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
@@ -79,7 +79,7 @@ export default function CountOverTimeResults() {
       <Alert severity="warning">
         Sorry, but something went wrong.
         (
-        {error.data.note}
+        {error.note}
         )
       </Alert>
     );

--- a/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
+++ b/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
@@ -60,7 +60,7 @@ export default function CountOverTimeResults() {
 
   useEffect(() => {
     if ((data)) {
-      if ((data.count_over_time.length === queryState.length)) { executeScroll(); }
+      if ((data.length === queryState.length)) { executeScroll(); }
     } else if (error) {
       executeScroll();
     }
@@ -84,9 +84,7 @@ export default function CountOverTimeResults() {
       </Alert>
     );
   } else {
-    console.log('DATA', data);
     const preparedData = prepareCountOverTimeData(data, normalized, queryState);
-    console.log('PREPAREDDATA', preparedData);
     if (preparedData.length !== queryState.length) return null;
     const updatedPrepareCountOverTimeData = preparedData.map(
       (originalDataObj, index) => {

--- a/mcweb/frontend/src/features/search/results/SampleStories.jsx
+++ b/mcweb/frontend/src/features/search/results/SampleStories.jsx
@@ -15,6 +15,13 @@ import prepareQueries from '../util/prepareQueries';
 import SampleStoryShow from './SampleStoryShow';
 import TabPanelHelper from '../../ui/TabPanelHelper';
 
+function a11yProps(index) {
+  return {
+    id: `simple-tab-${index}`,
+    'aria-controls': `simple-tabpanel-${index}`,
+  };
+}
+
 export default function SampleStories() {
   const queryState = useSelector((state) => state.query);
   const {
@@ -76,16 +83,20 @@ export default function SampleStories() {
         <Box sx={{ width: '100%' }}>
           <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
             <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
-              {data.sample.map((result, i) => (
-                <Tab key={queryTitleArrays[i]} label={queryTitleArrays[i]} {...a11yProps(i)} />
+              {data.map((result, i) => (
+                <Tab
+                  key={queryTitleArrays[i]}
+                  label={queryTitleArrays[i]}
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                  {...a11yProps(i)}
+                />
               ))}
             </Tabs>
           </Box>
-
-          {data.sample.map((results, i) => (
+          {data.map((results, i) => (
             <TabPanelHelper value={value} index={i}>
               <SampleStoryShow
-                data={results}
+                data={results.sample}
                 lSTP={lastSearchTimePlatform}
                 platform={platform}
               />
@@ -133,11 +144,4 @@ export default function SampleStories() {
       </div>
     </div>
   );
-}
-
-function a11yProps(index) {
-  return {
-    id: `simple-tab-${index}`,
-    'aria-controls': `simple-tabpanel-${index}`,
-  };
 }

--- a/mcweb/frontend/src/features/search/results/SampleStories.jsx
+++ b/mcweb/frontend/src/features/search/results/SampleStories.jsx
@@ -64,6 +64,7 @@ export default function SampleStories() {
 
   let content;
   if (!data && !error) return null;
+
   if (error) {
     // const msg = data.note;
 
@@ -71,7 +72,7 @@ export default function SampleStories() {
       <Alert severity="warning">
         Sorry, but something went wrong.
         (
-        {error.data.note}
+        {error.note}
         )
       </Alert>
     );

--- a/mcweb/frontend/src/features/search/results/SampleStories.jsx
+++ b/mcweb/frontend/src/features/search/results/SampleStories.jsx
@@ -95,7 +95,7 @@ export default function SampleStories() {
             </Tabs>
           </Box>
           {data.map((results, i) => (
-            <TabPanelHelper value={value} index={i}>
+            <TabPanelHelper value={value} index={i} key={`${results}`}>
               <SampleStoryShow
                 data={results.sample}
                 lSTP={lastSearchTimePlatform}

--- a/mcweb/frontend/src/features/search/results/TopLanguages.jsx
+++ b/mcweb/frontend/src/features/search/results/TopLanguages.jsx
@@ -90,7 +90,7 @@ export default function TopLanguages() {
             </Box>
 
             {prepareLanguageData(data).map((results, i) => (
-              <TabPanelHelper value={value} index={i}>
+              <TabPanelHelper value={value} index={i} key={`${results}`}>
                 <BarChart
                   series={[results]}
                   normalized

--- a/mcweb/frontend/src/features/search/results/TopLanguages.jsx
+++ b/mcweb/frontend/src/features/search/results/TopLanguages.jsx
@@ -66,7 +66,7 @@ export default function TopLanguages() {
       <Alert severity="warning">
         Sorry, but something went wrong.
         (
-        {error.data.note}
+        {error.note}
         )
       </Alert>
     );

--- a/mcweb/frontend/src/features/search/results/TopWords.jsx
+++ b/mcweb/frontend/src/features/search/results/TopWords.jsx
@@ -67,7 +67,7 @@ export default function TopWords() {
       <Alert severity="warning">
         Sorry, but something went wrong.
         (
-        {error.data.note}
+        {error.note}
         )
       </Alert>
     );
@@ -80,7 +80,7 @@ export default function TopWords() {
           <Box sx={{ width: '100%' }}>
             <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
               <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
-                {data.words.map((result, i) => (
+                {data.map((result, i) => (
                   <Tab
                     key={queryTitleArrays[i]}
                     label={queryTitleArrays[i]}
@@ -92,9 +92,9 @@ export default function TopWords() {
               </Tabs>
             </Box>
 
-            {data.words.map((results, i) => (
+            {data.map((results, i) => (
               <TabPanelHelper value={value} index={i}>
-                <OrderedWordCloud width={600} color="#000" data={results} />
+                <OrderedWordCloud width={600} color="#000" data={results.words} />
               </TabPanelHelper>
             ))}
           </Box>

--- a/mcweb/frontend/src/features/search/results/TopWords.jsx
+++ b/mcweb/frontend/src/features/search/results/TopWords.jsx
@@ -93,7 +93,8 @@ export default function TopWords() {
             </Box>
 
             {data.map((results, i) => (
-              <TabPanelHelper value={value} index={i}>
+              <TabPanelHelper value={value} index={i} key={`${results.words}`}>
+
                 <OrderedWordCloud width={600} color="#000" data={results.words} />
               </TabPanelHelper>
             ))}

--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -84,7 +84,7 @@ function TotalAttentionResults() {
   }, [lastSearchTime, queryState.length]);
 
   if (newQuery) return null;
-
+  console.log(isLoading, data);
   if (isLoading) {
     return (
       <div>
@@ -107,6 +107,7 @@ function TotalAttentionResults() {
       </Alert>
     );
   } else {
+    console.log(data, 'data');
     const preparedTAdata = prepareTotalAttentionData(data, normalized);
     console.log('TA DATA', preparedTAdata);
     if (preparedTAdata.length !== queryState.length) return null;

--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -98,7 +98,7 @@ function TotalAttentionResults() {
       <Alert severity="warning">
         Sorry, but something went wrong.
         (
-        {error.data.note}
+        {error.note}
         )
       </Alert>
     );

--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -108,6 +108,7 @@ function TotalAttentionResults() {
     );
   } else {
     const preparedTAdata = prepareTotalAttentionData(data, normalized);
+    console.log('TA DATA', preparedTAdata);
     if (preparedTAdata.length !== queryState.length) return null;
     const updatedTotalAttentionData = preparedTAdata.map(
       (originalDataObj, index) => {

--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -52,18 +52,14 @@ function TotalAttentionResults() {
 
   const currentUserEmail = currentUser.email;
 
-  // gets total count of entire query
-  // I'm assuming each query's data is put into one csv file
-  // my question: https://stackoverflow.com/questions/29615196/is-csv-with-multi-tabs-sheet-possible
-  // in the case that there is only one csv we have to make sure the count of all csv don't exceed our limits
+  const getCountsArray = (countsData) => countsData.map((count) => count.relevant);
+
   const getTotalCountOfQuery = () => {
-    const arrayOfCounts = data.count.relevant;
-    // gets total count of query
+    const arrayOfCounts = getCountsArray(data);
     let count = 0;
     for (let i = 0; i < arrayOfCounts.length; i += 1) {
       count += arrayOfCounts[i];
     }
-
     return count;
   };
 
@@ -84,7 +80,7 @@ function TotalAttentionResults() {
   }, [lastSearchTime, queryState.length]);
 
   if (newQuery) return null;
-  console.log(isLoading, data);
+
   if (isLoading) {
     return (
       <div>
@@ -107,9 +103,8 @@ function TotalAttentionResults() {
       </Alert>
     );
   } else {
-    console.log(data, 'data');
     const preparedTAdata = prepareTotalAttentionData(data, normalized);
-    console.log('TA DATA', preparedTAdata);
+
     if (preparedTAdata.length !== queryState.length) return null;
     const updatedTotalAttentionData = preparedTAdata.map(
       (originalDataObj, index) => {
@@ -205,7 +200,6 @@ function TotalAttentionResults() {
                 confirmButtonText="Confirm New Email"
                 currentUserEmail={currentUserEmail}
                 totalCountOfQuery={getTotalCountOfQuery()}
-                queryState={queryState}
               />
             </div>
           </div>

--- a/mcweb/frontend/src/features/search/util/prepareCountOverTimeData.js
+++ b/mcweb/frontend/src/features/search/util/prepareCountOverTimeData.js
@@ -11,9 +11,7 @@ const colors = ['#2f2d2b', '#d24527', '#f7a44e', '#334cda', '#d23716'];
 
 const prepareCountOverTimeData = (results, normalized) => {
   const series = [];
-  console.log('PREPARE', results);
   results.forEach((result, i) => {
-    console.log('result', result);
     const preparedData = result.count_over_time.counts.map((r) => [
       dateHelper(r.date),
       normalized ? r.ratio * 100 : r.count,

--- a/mcweb/frontend/src/features/search/util/prepareCountOverTimeData.js
+++ b/mcweb/frontend/src/features/search/util/prepareCountOverTimeData.js
@@ -11,8 +11,10 @@ const colors = ['#2f2d2b', '#d24527', '#f7a44e', '#334cda', '#d23716'];
 
 const prepareCountOverTimeData = (results, normalized) => {
   const series = [];
+  console.log('PREPARE', results);
   results.forEach((result, i) => {
-    const preparedData = result.counts.map((r) => [
+    console.log('result', result);
+    const preparedData = result.count_over_time.counts.map((r) => [
       dateHelper(r.date),
       normalized ? r.ratio * 100 : r.count,
     ]);

--- a/mcweb/frontend/src/features/search/util/prepareLanguageData.js
+++ b/mcweb/frontend/src/features/search/util/prepareLanguageData.js
@@ -2,10 +2,10 @@ const colorArray = ['#2f2d2b', '#d24527', '#2f2d2b', '#d23716', '#f7a44e'];
 
 export default function prepareLanguageData(languageData) {
   const series = [];
-  languageData.languages.forEach((queryData, i) => {
+  languageData.forEach((queryData, i) => {
     series.push(
       {
-        data: queryData.map((l) => ({
+        data: queryData.languages.map((l) => ({
           key: l.language, value: l.ratio * 100,
         })),
         name: 'Language',
@@ -16,6 +16,7 @@ export default function prepareLanguageData(languageData) {
   return series;
 }
 
+// series requirements for word cloud
 // series={[{
 //   data: data.languages.map((l) => ({
 //     key: l.language, value: l.ratio * 100,

--- a/mcweb/frontend/src/features/search/util/prepareTotalAttentionData.js
+++ b/mcweb/frontend/src/features/search/util/prepareTotalAttentionData.js
@@ -10,7 +10,6 @@ const prepareTotalAttentionData = (results, normalized) => {
   // const { relevant, total } = results.data.count;
   results.forEach((result, i) => {
     const { relevant, total } = result.count;
-    console.log('REL', relevant, total);
     const prepareData = {};
     prepareData.key = 'Matching Content';
     prepareData.value = normalized ? normalizeData(relevant, total) : relevant;

--- a/mcweb/frontend/src/features/search/util/prepareTotalAttentionData.js
+++ b/mcweb/frontend/src/features/search/util/prepareTotalAttentionData.js
@@ -7,11 +7,13 @@ const colors = ['#2f2d2b', '#d24527', '#f7a44e', '#334cda', '#d23716'];
 
 const prepareTotalAttentionData = (results, normalized) => {
   const series = [];
-  const { relevant, total } = results.count;
-  relevant.forEach((result, i) => {
+  // const { relevant, total } = results.data.count;
+  results.forEach((result, i) => {
+    const { relevant, total } = result.data.count;
+    console.log('REL', relevant, total);
     const prepareData = {};
     prepareData.key = 'Matching Content';
-    prepareData.value = normalized ? normalizeData(relevant[i], total[i]) : relevant[i];
+    prepareData.value = normalized ? normalizeData(relevant, total) : relevant;
     series.push(
       {
         data: [prepareData],

--- a/mcweb/frontend/src/features/search/util/prepareTotalAttentionData.js
+++ b/mcweb/frontend/src/features/search/util/prepareTotalAttentionData.js
@@ -9,7 +9,7 @@ const prepareTotalAttentionData = (results, normalized) => {
   const series = [];
   // const { relevant, total } = results.data.count;
   results.forEach((result, i) => {
-    const { relevant, total } = result.data.count;
+    const { relevant, total } = result.count;
     console.log('REL', relevant, total);
     const prepareData = {};
     prepareData.key = 'Matching Content';

--- a/mcweb/frontend/src/features/ui/InfoMenu.jsx
+++ b/mcweb/frontend/src/features/ui/InfoMenu.jsx
@@ -109,7 +109,7 @@ export default function InfoMenu({ platform, sampleStory }) {
 }
 
 InfoMenu.propTypes = {
-  sampleStory: PropTypes.arrayOf(PropTypes.shape({
+  sampleStory: PropTypes.shape({
     archived_url: PropTypes.string,
     article_url: PropTypes.string,
     id: PropTypes.string,
@@ -119,6 +119,6 @@ InfoMenu.propTypes = {
     publish_date: PropTypes.string,
     title: PropTypes.string,
     url: PropTypes.string,
-  })).isRequired,
+  }).isRequired,
   platform: PropTypes.string.isRequired,
 };

--- a/mcweb/frontend/src/features/ui/TotalAttentionEmailModal.jsx
+++ b/mcweb/frontend/src/features/ui/TotalAttentionEmailModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
@@ -13,12 +14,12 @@ import prepareQueries from '../search/util/prepareQueries';
 import { useSendTotalAttentionDataEmailMutation } from '../../app/services/searchApi';
 
 export default function TotalAttentionEmailModal({
-  openDialog, outsideTitle, title, variant, endIcon, confirmButtonText, currentUserEmail, totalCountOfQuery, queryState,
+  openDialog, outsideTitle, title, variant, endIcon, confirmButtonText, currentUserEmail, totalCountOfQuery,
 }) {
   const { enqueueSnackbar } = useSnackbar();
 
   const [sendTotalAttentionDataEmail] = useSendTotalAttentionDataEmailMutation();
-
+  const queryState = useSelector((state) => state.query);
   const [open, setOpen] = useState(openDialog);
   const [emailModal, setModalEmail] = useState('');
 
@@ -174,8 +175,6 @@ TotalAttentionEmailModal.propTypes = {
   confirmButtonText: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
   currentUserEmail: PropTypes.string,
   totalCountOfQuery: PropTypes.number,
-  queryState: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
-
 };
 
 TotalAttentionEmailModal.defaultProps = {


### PR DESCRIPTION
Change querying in search to send multiple requests (1 for each query) in javascript. Previously would send query state, which would be looped through in python. This is an unneeded architecture, better to loop through query state in JS and send each query individually and have each results component be a simple and quick view function.

Now using an RTK queryFn, we loop through the query state, sending each request to the back end. Results components had to be updated to deal with slightly new data flow.