### PR TITLE
Adjustment to source show and edit pages

### DIFF
--- a/mcweb/backend/sources/api.py
+++ b/mcweb/backend/sources/api.py
@@ -301,8 +301,6 @@ class SourcesViewSet(viewsets.ModelViewSet):
             return Response({"source": serializer.data})
         else:
             error_string = str(serializer.errors)
-            print(error_string)
-            # error_string = str(error_string['name'][0])
             raise APIException(f"{error_string}")
 
     def partial_update(self, request, pk=None):
@@ -313,7 +311,6 @@ class SourcesViewSet(viewsets.ModelViewSet):
             return Response({"source": serializer.data})
         else:
             error_string = serializer.errors
-            error_string = str(error_string['name'][0])
             raise APIException(f"{error_string}")
 
     @action(methods=['post'], detail=False)
@@ -504,3 +501,4 @@ class SourcesCollectionsViewSet(viewsets.ViewSet):
 
 def _filename_timestamp() -> str:
     return time.strftime("%Y%m%d%H%M%S", time.localtime())
+

--- a/mcweb/frontend/src/features/sources/ModifySource.jsx
+++ b/mcweb/frontend/src/features/sources/ModifySource.jsx
@@ -23,7 +23,17 @@ export default function ModifySource() {
   const sourceId = Number(params.sourceId);
 
   const [formState, setFormState] = React.useState({
-    name: '', notes: '', homepage: '', label: '', service: '', platform: '', url_search_string: '',
+    name: '',
+    notes: '',
+    homepage: '',
+    label: '',
+    service: '',
+    platform: '',
+    url_search_string: '',
+    media_type: '',
+    primary_language: '',
+    pub_country: '',
+    pub_state: '',
   });
 
   const handleChange = ({ target: { name, value } }) => (
@@ -51,14 +61,16 @@ export default function ModifySource() {
         label: data.label,
         platform: data.platform,
         url_search_string: data.url_search_string,
+        media_type: data.media_type ? data.media_type : '',
+        primary_language: data.primary_language,
+        pub_country: data.pub_country,
+        pub_state: data.pub_state,
       };
       setFormState(formData);
     }
   }, [data]);
 
   const [collectionId, setCollectionId] = useState('');
-
-  // const collectionData = useGetCollectionQuery(collectionId);
 
   const [createSourceCollectionAssociation] = useCreateSourceCollectionAssociationMutation();
 
@@ -169,6 +181,55 @@ export default function ModifySource() {
             (such as news.bbc.co.uk/nigeria). If this is one of those exceptions, enter a wild-carded search string here,
             such as '*news.bbc.co.uk/nigeria/*'."
           />
+          <br />
+          <br />
+          <TextField
+            fullWidth
+            name="primary_language"
+            label="Primary Language"
+            value={formState.primary_language}
+            onChange={handleChange}
+            helperText="Primary language, code should be valid ISO 639-1"
+          />
+          <br />
+          <br />
+          <TextField
+            fullWidth
+            name="pub_country"
+            label="Publication Country"
+            value={formState.pub_country}
+            onChange={handleChange}
+            helperText="Publication country code, country code should be valid ISO 3166-1 alpha-3"
+          />
+          <br />
+          <br />
+          <TextField
+            fullWidth
+            name="pub_state"
+            label="Publication State"
+            value={formState.pub_state}
+            onChange={handleChange}
+            helperText="Publication State code, should be valid ISO 3166-2"
+          />
+          <br />
+          <br />
+          <FormControl fullWidth>
+            <InputLabel id="media-select-label">Media Type</InputLabel>
+            <Select
+              labelId="media-select-label"
+              id="media-select"
+              value={formState.media_type}
+              name="media_type"
+              label="Media Type"
+              onChange={handleChange}
+            >
+              <MenuItem value="audio_broadcast">Audio Broadcast</MenuItem>
+              <MenuItem value="digital_native">Digital Native</MenuItem>
+              <MenuItem value="print_native">Print Native</MenuItem>
+              <MenuItem value="video_broadcast">Video Broadcast</MenuItem>
+              <MenuItem value="other">Other</MenuItem>
+            </Select>
+          </FormControl>
           <br />
           <br />
           <Button

--- a/mcweb/frontend/src/features/sources/SourceShow.jsx
+++ b/mcweb/frontend/src/features/sources/SourceShow.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
 import CircularProgress from '@mui/material/CircularProgress';
-
+import buildStatArray from './util/buildStatArray';
 import CollectionList from '../collections/CollectionList';
 import { useGetSourceQuery } from '../../app/services/sourceApi';
 import StatPanel from '../ui/StatPanel';
@@ -22,17 +22,8 @@ export default function SourceShow() {
 
   return (
     <div className="container">
-
       {(source.platform === 'online_news') && (
-        <StatPanel items={[
-          { label: 'First Story', value: source.first_story },
-          { label: 'Stories per Week', value: source.stories_per_week },
-          { label: 'Publication Country', value: source.pub_country },
-          { label: 'Publication State', value: source.pub_state },
-          { label: 'Primary Language', value: source.primary_language },
-          { label: 'Media Type', value: source.media_type },
-        ]}
-        />
+        <StatPanel items={buildStatArray(source)} />
       )}
 
       <div className="row">

--- a/mcweb/frontend/src/features/sources/util/buildStatArray.js
+++ b/mcweb/frontend/src/features/sources/util/buildStatArray.js
@@ -1,0 +1,48 @@
+const statPanelValues = [
+  { label: 'First Story', value: 'first_story' },
+  { label: 'Stories per Week', value: 'stories_per_week' },
+  { label: 'Publication Country', value: 'pub_country' },
+  { label: 'Publication State', value: 'pub_state' },
+  { label: 'Primary Language', value: 'primary_language' },
+  { label: 'Media Type', value: 'media_type' },
+];
+
+const buildStatArray = (sourceObject) => {
+  const returnArr = [];
+  statPanelValues.forEach((panelValue) => {
+    if (sourceObject[panelValue.value]) {
+      returnArr.push({ label: panelValue.label, value: sourceObject[panelValue.value] });
+    }
+  });
+  return returnArr;
+};
+
+export default buildStatArray;
+
+// [
+//     { label: 'First Story', value: source.first_story },
+//     { label: 'Stories per Week', value: source.stories_per_week },
+//     { label: 'Publication Country', value: source.pub_country },
+//     { label: 'Publication State', value: source.pub_state },
+//     { label: 'Primary Language', value: source.primary_language },
+//     { label: 'Media Type', value: source.media_type },
+//   ]
+
+// {
+//     "id": 1096,
+//     "name": "npr.org",
+//     "url_search_string": null,
+//     "label": "NPR",
+//     "homepage": "http://www.npr.org/",
+//     "notes": null,
+//     "platform": "online_news",
+//     "stories_per_week": 635,
+//     "first_story": null,
+//     "created_at": "2023-02-21T16:54:28.035524Z",
+//     "modified_at": "2023-07-20T13:24:37.455921Z",
+//     "pub_country": "USA",
+//     "pub_state": null,
+//     "primary_language": null,
+//     "media_type": "video_broadcast",
+//     "collection_count": 26
+// }


### PR DESCRIPTION
At the request of research a Source show page will only show the metadata we have available.
Source metadata can now be edited on the source edit page. 
<img width="922" alt="Screen Shot 2023-09-20 at 10 07 14 AM" src="https://github.com/mediacloud/web-search/assets/78226696/5881ab6d-1287-47be-8466-497d2c94b348">
<img width="703" alt="Screen Shot 2023-09-20 at 10 05 51 AM" src="https://github.com/mediacloud/web-search/assets/78226696/5ed2bc77-80af-4dbb-a850-dd8a57a518ab">
