### PR TITLE
Fix total count number for downloads

### DIFF
--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -52,7 +52,7 @@ function TotalAttentionResults() {
 
   const currentUserEmail = currentUser.email;
 
-  const getCountsArray = (countsData) => countsData.map((count) => count.relevant);
+  const getCountsArray = (countsData) => countsData.map((count) => count.count.relevant);
 
   const getTotalCountOfQuery = () => {
     const arrayOfCounts = getCountsArray(data);


### PR DESCRIPTION
There was a bug with the wrong total count being passed to the download all content email modal. Fix to now pass accurate count.