### PR TITLE
Fix weird indentations in search ui

### DIFF
--- a/mcweb/frontend/src/features/search/query/DefaultDates.jsx
+++ b/mcweb/frontend/src/features/search/query/DefaultDates.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import dayjs from 'dayjs';
-import Link from '@mui/material/Link';
+import Button from '@mui/material/Button';
 import PropTypes from 'prop-types';
 import { setQueryProperty } from './querySlice';
 import { latestAllowedEndDate } from '../util/platforms';
@@ -13,10 +13,8 @@ export default function DefaultDates({
   const dispatch = useDispatch();
 
   return (
-    <Link
-      underline="hover"
-      component="button"
-      variant="body2"
+    <Button
+      variant="outlined"
       sx={{ marginRight: 3 }}
       onClick={() => {
         // get last possible endDate per platform
@@ -32,7 +30,7 @@ export default function DefaultDates({
       }}
     >
       {message}
-    </Link>
+    </Button>
   );
 }
 

--- a/mcweb/frontend/src/features/search/query/Search.jsx
+++ b/mcweb/frontend/src/features/search/query/Search.jsx
@@ -23,18 +23,16 @@ export default function Search({ queryIndex }) {
 
   return (
     <div className="search-container">
-      <div className="container">
-        {advanced && (
+
+      {advanced && (
         <AdvancedSearch queryIndex={queryIndex} />
-        )}
-        {!advanced && (
+      )}
+      {!advanced && (
         <SimpleSearch queryIndex={queryIndex} />
-        )}
-      </div>
+      )}
 
       <div className="container">
         <div className="row">
-
           <div className="col-5">
             <div className="query-section">
               <h3>
@@ -44,6 +42,7 @@ export default function Search({ queryIndex }) {
 
               <SelectedMedia onRemove={removeSelectedMedia} collections={collections} sources={sources} queryIndex={queryIndex} />
               <MediaPicker queryIndex={queryIndex} />
+
               <p className="help">
                 Choose individual sources or collections to be searched.
                 Our system includes collections for a large range of countries,

--- a/mcweb/frontend/src/features/search/query/style/_simple-search.scss
+++ b/mcweb/frontend/src/features/search/query/style/_simple-search.scss
@@ -1,7 +1,7 @@
 
 .simple-search-container {
     display: flex;
-    margin: 1rem;
+    
 }
 
 .simple-search-title {
@@ -23,7 +23,6 @@
 
 .negated-query-list {
     margin-top: 4rem;
-    margin-left: 2rem;
 }
 
 .first-division {
@@ -35,7 +34,7 @@
 }
 
 .and-or {
-  margin-left: $padding-s;
+  margin-left: $padding-xs;
   color: #aaa;
   font-weight: bold;
   font-size: 13px;

--- a/mcweb/frontend/src/features/search/styles/_search.scss
+++ b/mcweb/frontend/src/features/search/styles/_search.scss
@@ -25,8 +25,6 @@
 }
 
 .search-container {
-  padding: $padding-m 0px;
-  
   code {
     font-size: 14px;
     font-family: sans-serif;
@@ -134,10 +132,6 @@
   .end-buttons {
     display: flex;
     margin-right: 30px;
-  }
-
-  div {
-    padding-left: 10px ;
   }
   
 }


### PR DESCRIPTION
Errant left padding in search container skewed all divs. 
![Screen Shot 2023-09-28 at 2 17 01 PM](https://github.com/mediacloud/web-search/assets/78226696/3f07d569-8523-4c3c-a2c4-8e91ec391049)

additionally make and/or padding xs and remove unneeded container div in Search.jsx
have date helper buttons conform with button conventions
closes #507 