### PR TITLE
Add method to add short delay between queries to backend

### DIFF
--- a/mcweb/frontend/src/app/services/searchApi.js
+++ b/mcweb/frontend/src/app/services/searchApi.js
@@ -1,5 +1,13 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
+const TIMEOUT_CONST_MS = 5;
+
+const timeoutAction = (fetchFunc) => new Promise((resolve) => {
+  setTimeout(() => {
+    resolve(fetchFunc);
+  }, TIMEOUT_CONST_MS);
+});
+
 export const searchApi = createApi({
   reducerPath: 'searchApi',
   baseQuery: fetchBaseQuery({
@@ -13,11 +21,11 @@ export const searchApi = createApi({
   endpoints: (builder) => ({
     getTotalCount: builder.mutation({
       queryFn: (queryState, _queryApi, _extraOptions, fetchWithBQ) => {
-        const promises = queryState.map((queryObject) => fetchWithBQ({
+        const promises = queryState.map((queryObject) => timeoutAction(fetchWithBQ({
           url: 'total-count',
           method: 'POST',
           body: { queryObject },
-        }));
+        })));
         return Promise.all(promises).then(
           (results) => (
             results[0].data
@@ -28,11 +36,11 @@ export const searchApi = createApi({
     }),
     getCountOverTime: builder.mutation({
       queryFn: (queryState, _queryApi, _extraOptions, fetchWithBQ) => {
-        const promises = queryState.map((queryObject) => fetchWithBQ({
+        const promises = queryState.map((queryObject) => timeoutAction(fetchWithBQ({
           url: 'count-over-time',
           method: 'POST',
           body: { queryObject },
-        }));
+        })));
         return Promise.all(promises).then(
           (results) => (
             results[0].data
@@ -43,11 +51,11 @@ export const searchApi = createApi({
     }),
     getSampleStories: builder.mutation({
       queryFn: (queryState, _queryApi, _extraOptions, fetchWithBQ) => {
-        const promises = queryState.map((queryObject) => fetchWithBQ({
+        const promises = queryState.map((queryObject) => timeoutAction(fetchWithBQ({
           url: 'sample',
           method: 'POST',
           body: { queryObject },
-        }));
+        })));
         return Promise.all(promises).then(
           (results) => (
             results[0].data
@@ -64,11 +72,11 @@ export const searchApi = createApi({
     }),
     getTopWords: builder.mutation({
       queryFn: (queryState, _queryApi, _extraOptions, fetchWithBQ) => {
-        const promises = queryState.map((queryObject) => fetchWithBQ({
+        const promises = queryState.map((queryObject) => timeoutAction(fetchWithBQ({
           url: 'words',
           method: 'POST',
           body: { queryObject },
-        }));
+        })));
         return Promise.all(promises).then(
           (results) => (
             results[0].data
@@ -79,11 +87,11 @@ export const searchApi = createApi({
     }),
     getTopLanguages: builder.mutation({
       queryFn: (queryState, _queryApi, _extraOptions, fetchWithBQ) => {
-        const promises = queryState.map((queryObject) => fetchWithBQ({
+        const promises = queryState.map((queryObject) => timeoutAction(fetchWithBQ({
           url: 'languages',
           method: 'POST',
           body: { queryObject },
-        }));
+        })));
         return Promise.all(promises).then(
           (results) => (results[0].data
             ? { data: results.map((result) => (result.data)) }


### PR DESCRIPTION
Attempt to prevent 504 errors when sending searches with a large amount of queries. Instead of sending all queries at once (could be around 25 for 5 query search), add a 5 ms delay between requests, help back off the server a little.
closes #510 .