### PR TITLE
Return spacing above platform picker

### DIFF
--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -136,6 +136,7 @@ export default function TabbedSearch() {
 
   return (
     <div className="container search-container">
+      <br />
       <PlatformPicker queryIndex={0} sx={{ paddingTop: 50 }} />
       <Box sx={{ width: '100%' }}>
         <Box sx={{ borderBottom: 1, borderColor: 'divider', marginLeft: 6 }}>


### PR DESCRIPTION
In recent change to indentation platform picker lost spacing

Before
![Screen Shot 2023-10-03 at 10 15 24 AM](https://github.com/mediacloud/web-search/assets/78226696/f7cc15c4-79c7-4b48-a6dc-799153c1142a)

After
![Screen Shot 2023-10-03 at 10 14 52 AM](https://github.com/mediacloud/web-search/assets/78226696/7aea1438-20a5-4d1a-9bba-33a34d5058fc)
