### PR TITLE
Add None check for sources without name, causes search error

### DIFF
--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -114,7 +114,7 @@ def _for_wayback_machine(collections: List, sources: List) -> Dict:
     # turn collections ids into list of domains
     selected_sources_in_collections = Source.objects.filter(collections__id__in=collections)
     selected_sources_in_collections = [s for s in selected_sources_in_collections if s.name is not None]
-    domains += [s.name for s in selected_sources_in_collections if (bool(s.url_search_string) is False)]
+    domains += [s.name for s in selected_sources_in_collections if bool(s.url_search_string) is False]
     # 2. pull out all the domains that have url_search_strings and turn those into search clauses
     sources_with_url_search_strs = []
     sources_with_url_search_strs += [s for s in selected_sources if bool(s.url_search_string) is not False]

--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -113,7 +113,8 @@ def _for_wayback_machine(collections: List, sources: List) -> Dict:
     domains += [s.name for s in selected_sources if s.url_search_string is None]
     # turn collections ids into list of domains
     selected_sources_in_collections = Source.objects.filter(collections__id__in=collections)
-    domains += [s.name for s in selected_sources_in_collections if bool(s.url_search_string) is False]
+    selected_sources_in_collections = [s for s in selected_sources_in_collections if s.name is not None]
+    domains += [s.name for s in selected_sources_in_collections if (bool(s.url_search_string) is False)]
     # 2. pull out all the domains that have url_search_strings and turn those into search clauses
     sources_with_url_search_strs = []
     sources_with_url_search_strs += [s for s in selected_sources if bool(s.url_search_string) is not False]


### PR DESCRIPTION
Search was erroring on certain collections, some sources don't have a `name` causing error in providers 
<img width="675" alt="Screen Shot 2023-10-11 at 11 52 55 AM" src="https://github.com/mediacloud/web-search/assets/78226696/ab15e39d-b55b-428e-b303-306f9bbce67e">
Added a check to see if a source does not have a name