### PR TITLE
Temporarily remove compare global until further 504 solution works

### DIFF
--- a/mcweb/frontend/src/features/ui/TabDropDownMenu.jsx
+++ b/mcweb/frontend/src/features/ui/TabDropDownMenu.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import MenuItem from '@mui/material/MenuItem';
 import Menu from '@mui/material/Menu';
@@ -6,13 +7,15 @@ import CircleIcon from '@mui/icons-material/Circle';
 import PropTypes from 'prop-types';
 import ArrowRight from '@mui/icons-material/ArrowRight';
 import CloseIcon from '@mui/icons-material/Close';
-import { PARTISAN, GLOBAL } from '../search/util/generateComparativeQuery';
+import { PARTISAN } from '../search/util/generateComparativeQuery';
+import { PROVIDER_NEWS_MEDIA_CLOUD } from '../search/util/platforms';
 
 // https://medium.com/geekculture/creating-a-dropdown-with-nested-menu-items-using-react-mui-bb0c084226da was a helpful tool
 
 export default function TabDropDownMenuItems({
   anchorEl, open, handleClose, handleMenuOpen, handleComparative,
 }) {
+  const platform = useSelector((state) => state.query[0].platform);
   const [colorSubMenuOpen, setColorSubMenuOpen] = useState(false);
 
   const handleMouseEnter = () => {
@@ -22,6 +25,19 @@ export default function TabDropDownMenuItems({
   const closeColorSubMenu = (event, color) => {
     handleClose(color);
     setColorSubMenuOpen(false);
+  };
+
+  const colorMenuSizing = () => {
+    if (platform === PROVIDER_NEWS_MEDIA_CLOUD) {
+      return {
+        vertical: -15,
+        horizontal: -232,
+      };
+    }
+    return {
+      vertical: -15,
+      horizontal: -122.5,
+    };
   };
 
   // mouse leaves main menu
@@ -43,7 +59,7 @@ export default function TabDropDownMenuItems({
         open={open}
         onClose={handleClose}
       >
-        {/* Compare across partisanship */}
+        {platform === PROVIDER_NEWS_MEDIA_CLOUD && (
         <MenuItem onClick={() => {
           handleComparative(PARTISAN);
           setColorSubMenuOpen(false);
@@ -51,14 +67,16 @@ export default function TabDropDownMenuItems({
         >
           Compare Across Partisanship
         </MenuItem>
-        {/* compare across the globe */}
-        <MenuItem onClick={() => {
+        )}
+
+        {/* compare across the globe, temp disabled until 504 solution */}
+        {/* <MenuItem onClick={() => {
           handleComparative(GLOBAL);
           setColorSubMenuOpen(false);
         }}
         >
           Compare Across the Globe
-        </MenuItem>
+        </MenuItem> */}
         {/* Add Color Option */}
         <MenuItem
           onMouseEnter={handleMouseEnter}
@@ -93,10 +111,7 @@ export default function TabDropDownMenuItems({
           vertical: 'right',
           horizontal: 'right',
         }}
-        transformOrigin={{
-          vertical: -15,
-          horizontal: -232,
-        }}
+        transformOrigin={colorMenuSizing()}
       >
         <div style={{ pointerEvents: 'all' }}>
           <MenuItem onClick={(e) => closeColorSubMenu(e, 'orange')}>


### PR DESCRIPTION
Still getting 504 when comparing across the globe, have a couple ideas that will be tried in the next couple days.
Also included is a bug fix for Wayback Machine, when searching against certain sources/collections that have `None` as a name, currently not having the menu available for WM because the collections include a url_search_string and it will always generate the error on comparative.