### PR TITLE
Fix for large downloads, fix for csv naming

### DIFF
--- a/mcweb/backend/search/tasks.py
+++ b/mcweb/backend/search/tasks.py
@@ -3,7 +3,7 @@ Background tasks for 'download_all_content_csv'
 """
 
 from ..users.models import QuotaHistory
-from .utils import parse_query
+from .utils import parse_query_array
 import logging
 import collections
 import logging
@@ -32,8 +32,8 @@ def download_all_large_content_csv(queryState, user_id, user_isStaff, email):
 def _download_all_large_content_csv(queryState, user_id, user_isStaff, email):
     data = []
     for query in queryState:
-        start_date, end_date, query_str, provider_props, provider_name = parse_query(
-            query, 'GET')
+        start_date, end_date, query_str, provider_props, provider_name = parse_query_array(
+            query)
         provider = providers.provider_by_name(provider_name)
         data.append(provider.all_items(
             query_str, start_date, end_date, **provider_props))

--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -287,7 +287,7 @@ def download_all_content_csv(request):
                     yield [v for k, v in ordered_story.items()]
                 first_page = False
 
-    filename = "mc-{}-{}-content.csv".format(
+    filename = "mc-{}-{}-content".format(
         provider_name, _filename_timestamp())
     streamer = csv_stream.CSVStream(filename, data_generator)
     return streamer.stream()


### PR DESCRIPTION
Add fix to for sending large email download of all content.
Change smaller downloads to not have .csv twice.
closes #525, #413. 