### PR TITLE
Fix for url serializer on advanced search

### DIFF
--- a/mcweb/frontend/src/features/search/util/urlSerializer.js
+++ b/mcweb/frontend/src/features/search/util/urlSerializer.js
@@ -69,9 +69,9 @@ const urlSerializer = (queryState) => {
   });
 
   if (adv[0]) {
-    return `qs=${encode(queryStrings)}&start=${encode(starts)}&end=${encode(ends)}'
-    + '&p=${encode(platforms)}&ss=${encode(sourceArr)}&cs=${encode(collectionArr)}'
-    + '&any=${encode(anys)}&name=${encode(names)}&edit=${encode(edits)}`;
+    return `qs=${encode(queryStrings)}&start=${encode(starts)}&end=${encode(ends)}
+    &p=${encode(platforms)}&ss=${encode(sourceArr)}&cs=${encode(collectionArr)}
+    &any=${encode(anys)}&name=${encode(names)}&edit=${encode(edits)}`;
   }
 
   return `q=${encode(queries)}&nq=${encode(negatedQueries)}&start=${encode(starts)}`


### PR DESCRIPTION
Occasionally the url serializer would serialize collections incorrectly, causing errors when searching.
Fixed url serializer to serialize advanced search properly.