### PR TITLE
Trim whitespace, add advanced link, download all content button change

### DIFF
--- a/mcweb/frontend/src/features/search/query/AdvancedSearch.jsx
+++ b/mcweb/frontend/src/features/search/query/AdvancedSearch.jsx
@@ -55,7 +55,13 @@ function AdvancedSearch({ queryIndex }) {
           <div className="row">
             <div className="col-4">
               <p>
-                Please enter query terms following the proper query syntax
+
+                Please enter query terms following the
+                {' '}
+                <a href="https://www.mediacloud.org/documentation/query-guide">
+                  proper query syntax
+                </a>
+                {' '}
                 for the choosen platform.
               </p>
             </div>

--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -186,7 +186,7 @@ function TotalAttentionResults() {
           <div className="float-end">
             <div>
               <TotalAttentionEmailModal
-                outsideTitle="Download CSV of All URLs"
+                outsideTitle="Download All URLs"
                 title={
                   `Your current email is: ${currentUserEmail}
                   Would you like to send your downloaded data to your current email or a new email?`

--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -186,7 +186,7 @@ function TotalAttentionResults() {
           <div className="float-end">
             <div>
               <TotalAttentionEmailModal
-                outsideTitle="Download CSV of All Content"
+                outsideTitle="Download CSV of All URLs"
                 title={
                   `Your current email is: ${currentUserEmail}
                   Would you like to send your downloaded data to your current email or a new email?`

--- a/mcweb/frontend/src/features/search/util/queryGenerator.js
+++ b/mcweb/frontend/src/features/search/util/queryGenerator.js
@@ -12,11 +12,19 @@ const queryGenerator = (queryList, negatedQueryList, platform, anyAll) => {
   const deQuoter = (w) => (w.replaceAll('"', ''));
   const quoter = (w) => (w.includes(' ') ? `"${w}"` : w); // add quotes if there is a space in string
 
-  const query = queryList ? queryList.filter((queryWord) => queryWord.length >= 1).map(deQuoter).map(quoter) : [];
+  const query = queryList ? queryList.filter((queryWord) => queryWord.length >= 1).map((term) => {
+    const trimmed = term.trim();
+    const deQuoted = deQuoter(trimmed);
+    return quoter(deQuoted);
+  }) : [];
 
   const negatedQuery = negatedQueryList ? negatedQueryList.filter(
     (queryWord) => queryWord.length >= 1,
-  ).map(deQuoter).map(quoter) : [[]];
+  ).map((term) => {
+    const trimmed = term.trim();
+    const deQuoted = deQuoter(trimmed);
+    return quoter(deQuoted);
+  }) : [];
 
   // first add in the match list
   if ((platform === PROVIDER_NEWS_MEDIA_CLOUD) || (platform === PROVIDER_NEWS_WAYBACK_MACHINE)) {


### PR DESCRIPTION
Knocked out some low hanging fruit.

### Add advanced query guide link to advanced search
![Screen Shot 2023-10-31 at 1 23 19 PM](https://github.com/mediacloud/web-search/assets/78226696/0b639105-3db0-42db-b10c-6c46a39dfbf7)

### Change name of Download All Content Button to Download all URLs
![Screen Shot 2023-11-01 at 9 32 53 AM](https://github.com/mediacloud/web-search/assets/78226696/413ac8d4-8444-4788-ab64-90a971774652)

### Adjust query generator to trim whitespace of user input

closes #546 
closes #543 
closes #539