### PR TITLE
Add function to test closing db connection

### DIFF
--- a/mcweb/backend/users/models.py
+++ b/mcweb/backend/users/models.py
@@ -1,3 +1,4 @@
+from django import db
 from django.db import models
 from django.contrib.auth.models import User
 import datetime as dt
@@ -41,13 +42,14 @@ class Profile(models.Model):
         if provider == provider_name(PLATFORM_ONLINE_NEWS, PLATFORM_SOURCE_WAYBACK_MACHINE):
             return self.quota_wayback_machine
         if provider == provider_name(PLATFORM_ONLINE_NEWS, PLATFORM_SOURCE_MEDIA_CLOUD):
-            return self.quota_mediacloud_legacy
+            return self.quota_mediacloud_legacyq
         raise UnknownProviderException(provider)
 
     @classmethod
     def user_provider_quota(cls, user_id: int, provider: str) -> int:
         # as a backup catchall - create the profile in case it isn't there already (maybe for pre-existing user? 🤷🏽‍)
         profile, _ = Profile.objects.get_or_create(user_id=user_id)
+        db.connections.close_all()
         return profile.quota_for(provider)
 
 

--- a/mcweb/backend/users/models.py
+++ b/mcweb/backend/users/models.py
@@ -42,7 +42,7 @@ class Profile(models.Model):
         if provider == provider_name(PLATFORM_ONLINE_NEWS, PLATFORM_SOURCE_WAYBACK_MACHINE):
             return self.quota_wayback_machine
         if provider == provider_name(PLATFORM_ONLINE_NEWS, PLATFORM_SOURCE_MEDIA_CLOUD):
-            return self.quota_mediacloud_legacyq
+            return self.quota_mediacloud_legacy
         raise UnknownProviderException(provider)
 
     @classmethod


### PR DESCRIPTION
When adding multiple workers to production there was a problem with too many connections being opened to the psql db (max is 100). Upon inspection it looks like a lot of connections are being opened to the db and then sitting idle. This looks to be a feature of [Django](https://stackoverflow.com/questions/43262566/django-orm-leaves-idle-connections-on-postgres-db). It looks like an option is to manually close the connection after making a call to the db. 
I am attempting this on one function that looks to sit idle (user_provider_quota)
![Screen Shot 2023-11-17 at 12 01 33 PM](https://github.com/mediacloud/web-search/assets/78226696/efbfc9b3-9a73-412e-89da-b64039ec5acd)

will add to staging and check if it closes the idle connections