### PR TITLE
Adjust db settings

### DIFF
--- a/mcweb/settings.py
+++ b/mcweb/settings.py
@@ -94,7 +94,7 @@ WSGI_APPLICATION = "wsgi.application"
 # https://docs.djangoproject.com/en/dev/ref/settings/#databases
 
 DATABASES = {
-    "default": dj_database_url.parse(env('DATABASE_URI'), conn_max_age=600)
+    "default": dj_database_url.parse(env('DATABASE_URI'), conn_max_age=300, conn_health_checks=True)
 }
 
 # Password validation


### PR DESCRIPTION
Adjust db settings of conn_max_age to 300 and add [conn_health_checks](https://docs.djangoproject.com/en/4.2/ref/databases/#general-notes). Ideally this will close idle db connections faster and if a connection closes that the system is expecting it shouldn't error out