### PR TITLE
support story list API endpoint, with optional params for new MC archive

### DIFF
--- a/mcweb/backend/search/urls.py
+++ b/mcweb/backend/search/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
     path('languages', views.languages),    
     path('sources', views.sources),    
     path('download-top-languages-csv', views.download_languages_csv),
-    path('send-email-large-download-csv', views.send_email_large_download_csv)
+    path('send-email-large-download-csv', views.send_email_large_download_csv),
+    path('story-list', views.story_list)
 ]
 urlpatterns += router.urls

--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -203,9 +203,10 @@ def story_list(request):
         provider_props['expanded'] = provider_props['expanded'] == '1'
         if not request.user.is_staff:
             del provider_props['expanded']
-    response = provider.paged_items(query_str, start_date, end_date, **provider_props)
+    page, pagination_token = provider.paged_items(query_str, start_date, end_date, **provider_props)
     QuotaHistory.increment(request.user.id, request.user.is_staff, provider_name, 1)
-    return HttpResponse(json.dumps({"paged_items": response}, default=str), content_type="application/json",
+    return HttpResponse(json.dumps({"stories": page, "pagination_token": pagination_token}, default=str),
+                        content_type="application/json",
                         status=200)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,7 @@ djangorestframework-simplejwt[crypto]==5.2.*
 pyhumps==3.8.*
 django-environ==0.9.*
 dj-database-url==1.0.*
-mediacloud-metadata==0.9.*
-mediacloud==3.13.*
+mediacloud-metadata==0.*
 python-dateutil==2.8.*
 dateparser==1.1.*
 django-redis==5.2.*
@@ -15,9 +14,8 @@ gunicorn==20.1.*
 whitenoise==6.2.*
 sentry-sdk==1.11.*
 requests  # let the other dependencies sort out which is the right version
-wayback-news-search==1.0.*
 fasttext==0.9.*
-mc-providers==0.2.*
+mc-providers==0.3.*
 pycountry==22.3.*
 django-background-tasks-updated==1.2.* # need >= 1.2.6
 feed-seeker==1.0.*


### PR DESCRIPTION
This is an untested first pass at adding a new `story-list` endpoint for API integration. This allows pulling one page of results from an API call, using a `pagination_token` param to support paging through lists. It also adds an `expanded` boolean param to include text content in results (importantly limited to **staff only**).

Probably doesn't work yet, and needs to be tested somehow.