### PR TITLE
Add Day, Week, Month view to Attention Over Time and other changes

### DIFF
--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -17,6 +17,7 @@ from django.contrib.auth.decorators import login_required
 from rest_framework.decorators import action, authentication_classes, permission_classes
 import backend.util.csv_stream as csv_stream
 from .utils import parse_query, parse_query_array
+from util.cache import cache_by_kwargs
 from .tasks import download_all_large_content_csv
 from ..users.models import QuotaHistory
 from backend.users.exceptions import OverQuotaException
@@ -69,6 +70,7 @@ def handle_provider_errors(func):
 @api_view(['GET', 'POST'])
 @authentication_classes([TokenAuthentication, SessionAuthentication])
 @permission_classes([IsAuthenticated])
+@cache_by_kwargs()
 def total_count(request):
     start_date, end_date, query_str, provider_props, provider_name, api_key, base_url = parse_query(request)
     provider = providers.provider_by_name(provider_name, api_key, base_url)
@@ -87,6 +89,7 @@ def total_count(request):
 @api_view(['GET', 'POST'])
 @authentication_classes([TokenAuthentication, SessionAuthentication])
 @permission_classes([IsAuthenticated])
+@cache_by_kwargs()
 def count_over_time(request):
     start_date, end_date, query_str, provider_props, provider_name, api_key, base_url = parse_query(request)
     provider = providers.provider_by_name(provider_name, api_key, base_url)
@@ -105,6 +108,7 @@ def count_over_time(request):
 @api_view(['GET', 'POST'])
 @authentication_classes([TokenAuthentication, SessionAuthentication])
 @permission_classes([IsAuthenticated])
+@cache_by_kwargs()
 def sample(request):
     start_date, end_date, query_str, provider_props, provider_name, api_key, base_url = parse_query(request)
     provider = providers.provider_by_name(provider_name, api_key, base_url)
@@ -120,6 +124,7 @@ def sample(request):
 @api_view(['GET'])
 @authentication_classes([TokenAuthentication, SessionAuthentication])
 @permission_classes([IsAuthenticated])
+@cache_by_kwargs()
 def story_detail(request):
     story_id = request.GET.get("storyId")
     platform = request.GET.get("platform")
@@ -134,6 +139,7 @@ def story_detail(request):
 @api_view(['GET', 'POST'])
 @authentication_classes([TokenAuthentication, SessionAuthentication])
 @permission_classes([IsAuthenticated])
+@cache_by_kwargs()
 def sources(request):
     start_date, end_date, query_str, provider_props, provider_name, api_key, base_url = parse_query(request)
     provider = providers.provider_by_name(provider_name, api_key, base_url)
@@ -183,6 +189,7 @@ def download_sources_csv(request):
 @api_view(['GET', 'POST'])
 @authentication_classes([TokenAuthentication, SessionAuthentication])
 @permission_classes([IsAuthenticated])
+@cache_by_kwargs()
 def languages(request):
     start_date, end_date, query_str, provider_props, provider_name, api_key, base_url = parse_query(request)
     provider = providers.provider_by_name(provider_name, api_key, base_url)
@@ -231,6 +238,7 @@ def download_languages_csv(request):
 @api_view(['GET'])
 @authentication_classes([TokenAuthentication])  # API-only method for now
 @permission_classes([IsAuthenticated])
+@cache_by_kwargs()
 def story_list(request):
     start_date, end_date, query_str, provider_props, provider_name, api_key, base_url = parse_query(request)
     provider = providers.provider_by_name(provider_name, api_key, base_url)
@@ -250,6 +258,7 @@ def story_list(request):
 @api_view(['GET', 'POST'])
 @authentication_classes([TokenAuthentication, SessionAuthentication])
 @permission_classes([IsAuthenticated])
+@cache_by_kwargs()
 def words(request):
     start_date, end_date, query_str, provider_props, provider_name, api_key, base_url = parse_query(request)
     provider = providers.provider_by_name(provider_name, api_key, base_url)

--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -70,7 +70,7 @@ def handle_provider_errors(func):
 @api_view(['GET', 'POST'])
 @authentication_classes([TokenAuthentication, SessionAuthentication])
 @permission_classes([IsAuthenticated])
-@cache_by_kwargs()
+# @cache_by_kwargs()
 def total_count(request):
     start_date, end_date, query_str, provider_props, provider_name, api_key, base_url = parse_query(request)
     provider = providers.provider_by_name(provider_name, api_key, base_url)
@@ -89,7 +89,7 @@ def total_count(request):
 @api_view(['GET', 'POST'])
 @authentication_classes([TokenAuthentication, SessionAuthentication])
 @permission_classes([IsAuthenticated])
-@cache_by_kwargs()
+# @cache_by_kwargs()
 def count_over_time(request):
     start_date, end_date, query_str, provider_props, provider_name, api_key, base_url = parse_query(request)
     provider = providers.provider_by_name(provider_name, api_key, base_url)
@@ -108,7 +108,7 @@ def count_over_time(request):
 @api_view(['GET', 'POST'])
 @authentication_classes([TokenAuthentication, SessionAuthentication])
 @permission_classes([IsAuthenticated])
-@cache_by_kwargs()
+# @cache_by_kwargs()
 def sample(request):
     start_date, end_date, query_str, provider_props, provider_name, api_key, base_url = parse_query(request)
     provider = providers.provider_by_name(provider_name, api_key, base_url)
@@ -124,7 +124,7 @@ def sample(request):
 @api_view(['GET'])
 @authentication_classes([TokenAuthentication, SessionAuthentication])
 @permission_classes([IsAuthenticated])
-@cache_by_kwargs()
+# @cache_by_kwargs()
 def story_detail(request):
     story_id = request.GET.get("storyId")
     platform = request.GET.get("platform")
@@ -139,7 +139,7 @@ def story_detail(request):
 @api_view(['GET', 'POST'])
 @authentication_classes([TokenAuthentication, SessionAuthentication])
 @permission_classes([IsAuthenticated])
-@cache_by_kwargs()
+# @cache_by_kwargs()
 def sources(request):
     start_date, end_date, query_str, provider_props, provider_name, api_key, base_url = parse_query(request)
     provider = providers.provider_by_name(provider_name, api_key, base_url)
@@ -189,7 +189,7 @@ def download_sources_csv(request):
 @api_view(['GET', 'POST'])
 @authentication_classes([TokenAuthentication, SessionAuthentication])
 @permission_classes([IsAuthenticated])
-@cache_by_kwargs()
+# @cache_by_kwargs()
 def languages(request):
     start_date, end_date, query_str, provider_props, provider_name, api_key, base_url = parse_query(request)
     provider = providers.provider_by_name(provider_name, api_key, base_url)
@@ -238,7 +238,7 @@ def download_languages_csv(request):
 @api_view(['GET'])
 @authentication_classes([TokenAuthentication])  # API-only method for now
 @permission_classes([IsAuthenticated])
-@cache_by_kwargs()
+# @cache_by_kwargs()
 def story_list(request):
     start_date, end_date, query_str, provider_props, provider_name, api_key, base_url = parse_query(request)
     provider = providers.provider_by_name(provider_name, api_key, base_url)
@@ -258,7 +258,7 @@ def story_list(request):
 @api_view(['GET', 'POST'])
 @authentication_classes([TokenAuthentication, SessionAuthentication])
 @permission_classes([IsAuthenticated])
-@cache_by_kwargs()
+# @cache_by_kwargs()
 def words(request):
     start_date, end_date, query_str, provider_props, provider_name, api_key, base_url = parse_query(request)
     provider = providers.provider_by_name(provider_name, api_key, base_url)

--- a/mcweb/frontend/src/app/services/collectionsApi.js
+++ b/mcweb/frontend/src/app/services/collectionsApi.js
@@ -17,11 +17,10 @@ export const collectionsApi = managerApi.injectEndpoints({
         method: 'GET',
       }),
     }),
-    listCollectionsFromNestedArray: builder.mutation({
-      query: (nestedArrayOfCollections) => ({
-        url: 'collections/collections-from-nested-list/',
-        method: 'POST',
-        body: { ...nestedArrayOfCollections },
+    listCollectionsFromNestedArray: builder.query({
+      query: (params) => ({
+        url: `collections/collections-from-nested-list/?${toSearchUrlParams(params, true)}`,
+        method: 'GET',
       }),
     }),
     listCollections: builder.query({
@@ -92,5 +91,5 @@ export const {
   useLazyGetCollectionQuery,
   useGetGlobalCollectionsQuery,
   useRescrapeCollectionMutation,
-  useListCollectionsFromNestedArrayMutation,
+  useLazyListCollectionsFromNestedArrayQuery,
 } = collectionsApi;

--- a/mcweb/frontend/src/app/services/queryUtil.js
+++ b/mcweb/frontend/src/app/services/queryUtil.js
@@ -1,11 +1,13 @@
 export const PAGE_SIZE = 100;
-
-export const toSearchUrlParams = (params) => {
+// added noLimit argument, bool if limit should be added to params (true = no limit, false/undefined = limit)
+export const toSearchUrlParams = (params, noLimit) => {
   if (params === undefined) {
     return '';
   }
   const queryParams = {};
-  queryParams.limit = PAGE_SIZE;
+  if (!noLimit) {
+    queryParams.limit = PAGE_SIZE;
+  }
   if (params.page) {
     queryParams.offset = params.page ? PAGE_SIZE * params.page : 0;
   }
@@ -16,5 +18,6 @@ export const toSearchUrlParams = (params) => {
     }
     queryParams[key] = value;
   });
+
   return new URLSearchParams(queryParams).toString();
 };

--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -31,7 +31,8 @@ import deactivateButton from './util/deactivateButton';
 import urlSerializer from './util/urlSerializer';
 import isNumber from './util/isNumber';
 import tabTitle from './util/tabTitles';
-import { useListCollectionsFromNestedArrayMutation } from '../../app/services/collectionsApi';
+// import { useListCollectionsFromNestedArrayMutation } from '../../app/services/collectionsApi';
+import { useLazyListCollectionsFromNestedArrayQuery } from '../../app/services/collectionsApi';
 
 function a11yProps(index) {
   return {
@@ -52,7 +53,8 @@ export default function TabbedSearch() {
   const [textFieldsValues, setTextFieldValues] = useState(queryState.map((query) => query.name));
   const { platform, advanced } = queryState[0];
 
-  const [getCollectionNames] = useListCollectionsFromNestedArrayMutation();
+  // const [getCollectionNames] = useListCollectionsFromNestedArrayMutation();
+  const [getCollectionNames] = useLazyListCollectionsFromNestedArrayQuery();
 
   useEffect(() => {
     setShow(deactivateButton(queryState));
@@ -64,9 +66,18 @@ export default function TabbedSearch() {
     navigator.clipboard.writeText(ahref);
   };
 
+  const prepareCollectionIds = (collectionIds) => {
+    const queries = {};
+    collectionIds.forEach((query, i) => {
+      queries[i] = query;
+    });
+    return queries;
+  };
+
   const fetchCollectionNames = async () => {
     const collectionIds = queryState.map((query) => query.collections);
-    const nestedArrayOfCollectionData = await getCollectionNames(collectionIds).unwrap();
+    const prepareCollections = prepareCollectionIds(collectionIds);
+    const nestedArrayOfCollectionData = await getCollectionNames(prepareCollections).unwrap();
     return nestedArrayOfCollectionData.collection;
   };
 

--- a/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
+++ b/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
@@ -5,14 +5,17 @@ import Button from '@mui/material/Button';
 import Alert from '@mui/material/Alert';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
-import { Settings } from '@mui/icons-material';
+import Divider from '@mui/material/Divider';
+import Settings from '@mui/icons-material/Settings';
 import DownloadIcon from '@mui/icons-material/Download';
 import CountOverTimeChart from './CountOverTimeChart';
 import { useGetCountOverTimeMutation } from '../../../app/services/searchApi';
 import { supportsNormalizedCount } from './TotalAttentionResults';
 import checkForBlankQuery from '../util/checkForBlankQuery';
 import prepareQueries from '../util/prepareQueries';
-import prepareCountOverTimeData from '../util/prepareCountOverTimeData';
+import {
+  prepareCountOverTimeData, DAY, WEEK, MONTH,
+} from '../util/prepareCountOverTimeData';
 
 export default function CountOverTimeResults() {
   const queryState = useSelector((state) => state.query);
@@ -23,6 +26,8 @@ export default function CountOverTimeResults() {
   } = queryState[0];
 
   const [normalized, setNormalized] = useState(true);
+
+  const [chartBy, setChartBy] = useState(DAY);
 
   const [anchorEl, setAnchorEl] = useState(null);
 
@@ -84,7 +89,7 @@ export default function CountOverTimeResults() {
       </Alert>
     );
   } else {
-    const preparedData = prepareCountOverTimeData(data, normalized, queryState);
+    const preparedData = prepareCountOverTimeData(data, normalized, chartBy);
     if (preparedData.length !== queryState.length) return null;
     const updatedPrepareCountOverTimeData = preparedData.map(
       (originalDataObj, index) => {
@@ -126,6 +131,25 @@ export default function CountOverTimeResults() {
                     >
                       View Content Count
                     </MenuItem>
+                    <Divider />
+                    <MenuItem onClick={() => {
+                      setChartBy(DAY);
+                    }}
+                    >
+                      Chart by day
+                    </MenuItem>
+                    <MenuItem onClick={() => {
+                      setChartBy(WEEK);
+                    }}
+                    >
+                      Chart by week
+                    </MenuItem>
+                    <MenuItem onClick={() => {
+                      setChartBy(MONTH);
+                    }}
+                    >
+                      Chart by month
+                    </MenuItem>
                   </Menu>
                 </div>
               )}
@@ -149,6 +173,25 @@ export default function CountOverTimeResults() {
                     }}
                     >
                       View Normalized Content Percentage (default)
+                    </MenuItem>
+                    <Divider />
+                    <MenuItem onClick={() => {
+                      setChartBy(DAY);
+                    }}
+                    >
+                      Chart by day
+                    </MenuItem>
+                    <MenuItem onClick={() => {
+                      setChartBy(WEEK);
+                    }}
+                    >
+                      Chart by week
+                    </MenuItem>
+                    <MenuItem onClick={() => {
+                      setChartBy(MONTH);
+                    }}
+                    >
+                      Chart by month
                     </MenuItem>
                   </Menu>
                 </div>

--- a/mcweb/frontend/src/features/search/results/SampleStories.jsx
+++ b/mcweb/frontend/src/features/search/results/SampleStories.jsx
@@ -113,8 +113,6 @@ export default function SampleStories() {
           <h2>Sample Content</h2>
           <p>
             This is a sample of the content that matched your queries.
-            Click the menu on the bottom  right to download a CSV of all the
-            matching content and associated metadata.
           </p>
           {(platform === PROVIDER_NEWS_MEDIA_CLOUD || platform === PROVIDER_NEWS_MEDIA_CLOUD_LEGACY) && (
             <p>

--- a/mcweb/frontend/src/features/search/results/TopSources.jsx
+++ b/mcweb/frontend/src/features/search/results/TopSources.jsx
@@ -174,7 +174,7 @@ export default function TopSources() {
                 handleDownloadRequest(queryState);
               }}
             >
-              Download CSV of Top Languages
+              Download CSV of Top Sources
             </Button>
           </div>
         </div>

--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -220,7 +220,7 @@ function TotalAttentionResults() {
             &quot;view options&quot; menu to switch between story counts and a
             percentage (if supported).
 
-            Click &quot;Download All URLs&quot; to the bottom-right to download a CSV of all the
+            Click &quot;download all urls&quot; to the bottom-right to download a CSV of all the
             matching content and associated metadata.
           </p>
         </div>

--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -219,6 +219,9 @@ function TotalAttentionResults() {
             Compare the total number of items that matched your queries. Use the
             &quot;view options&quot; menu to switch between story counts and a
             percentage (if supported).
+
+            Click &quot;Download All URLs&quot; to the bottom-right to download a CSV of all the
+            matching content and associated metadata.
           </p>
         </div>
         <div className="col-8">

--- a/mcweb/frontend/src/features/search/util/prepareCountOverTimeData.js
+++ b/mcweb/frontend/src/features/search/util/prepareCountOverTimeData.js
@@ -1,27 +1,303 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 
+export const DAY = 'day';
+export const WEEK = 'week';
+export const MONTH = 'month';
+
+const colors = ['#2f2d2b', '#d24527', '#f7a44e', '#334cda', '#d23716'];
+
 const dateHelper = (dateString) => {
   dayjs.extend(utc);
   const newDate = dayjs(dateString, 'YYYY-MM-DD').valueOf();
   return newDate;
 };
 
-const colors = ['#2f2d2b', '#d24527', '#f7a44e', '#334cda', '#d23716'];
+function groupValues(elements, duration, normalized) {
+  console.log('eleements', elements);
+  const formatted = elements.count_over_time.counts.map((elem) => ({
+    date: dayjs(elem.date).startOf(duration).format('YYYY-MM-DD'),
+    count: elem.count,
+    total_count: elem.total_count,
+  }));
 
-const prepareCountOverTimeData = (results, normalized) => {
-  const series = [];
-  results.forEach((result, i) => {
-    const preparedData = result.count_over_time.counts.map((r) => [
-      dateHelper(r.date),
-      normalized ? r.ratio * 100 : r.count,
-    ]);
-    series.push({
-      data: preparedData,
-      color: colors[i],
-    });
+  console.log('FORMATTED', formatted);
+
+  const dates = formatted.map((elem) => elem.date);
+  console.log('DATES', dates);
+  const uniqueDates = dates.filter((date, index) => dates.indexOf(date) === index);
+  console.log('UNIQUIE DATES', uniqueDates);
+  const returnData = uniqueDates.map((date) => {
+    // const count = formatted.filter((elem) => elem.date === date).reduce((count, elem) => count + elem.count, 0);
+    const filtered = formatted.filter((elem) => elem.date === date);
+    console.log('FILTERED', filtered);
+    const count = filtered.reduce((redCount, elem) => redCount + elem.count, 0);
+    console.log('COUNTTTT', count);
+    return [dateHelper(date), count];
   });
+
+  console.log(returnData);
+  return returnData;
+}
+
+export const prepareCountOverTimeData = (results, normalized, chartBy) => {
+  const series = [];
+
+  if (chartBy === DAY) {
+    results.forEach((result, i) => {
+      const preparedData = result.count_over_time.counts.map((r) => [
+        dateHelper(r.date),
+        normalized ? r.ratio * 100 : r.count,
+      ]);
+      console.log('PPPPPP', preparedData);
+      series.push({
+        data: preparedData,
+        color: colors[i],
+      });
+    });
+  } else if (chartBy === WEEK) {
+    results.forEach((result, i) => {
+      const groupedData = groupValues(result, WEEK, normalized);
+      // const preparedData = groupedData.map((r) => [
+      //   dateHelper(r.date),
+      //   normalized ? r.ratio * 100 : r.count,
+      // ]);
+      console.log('WEEK', groupedData);
+      series.push({
+        data: groupedData,
+        color: colors[i],
+      });
+    });
+  } else {
+    results.forEach((result, i) => {
+      const groupedData = groupValues(result, MONTH);
+      const preparedData = groupedData.map((r) => [
+        dateHelper(r.date),
+        normalized ? r.ratio * 100 : r.count,
+      ]);
+      console.log('Month', groupedData);
+      series.push({
+        data: preparedData,
+        color: colors[i],
+      });
+    });
+  }
+  console.log('SERIES', series);
   return series;
 };
 
-export default prepareCountOverTimeData;
+// RESULTS
+// [
+//   {
+//       "count_over_time": {
+//           "counts": [
+//               {
+//                   "date": "2023-12-13 00:00:00",
+//                   "total_count": 8695,
+//                   "count": 313,
+//                   "ratio": 0.03599769982748706
+//               },
+//               {
+//                   "date": "2023-12-14 00:00:00",
+//                   "total_count": 8953,
+//                   "count": 291,
+//                   "ratio": 0.032503071596113035
+//               },
+//               {
+//                   "date": "2023-12-15 00:00:00",
+//                   "total_count": 8096,
+//                   "count": 353,
+//                   "ratio": 0.04360177865612648
+//               },
+//               {
+//                   "date": "2023-12-16 00:00:00",
+//                   "total_count": 4106,
+//                   "count": 203,
+//                   "ratio": 0.04943984413054067
+//               },
+//               {
+//                   "date": "2023-12-17 00:00:00",
+//                   "total_count": 4374,
+//                   "count": 208,
+//                   "ratio": 0.04755372656607224
+//               },
+//               {
+//                   "date": "2023-12-18 00:00:00",
+//                   "total_count": 7947,
+//                   "count": 398,
+//                   "ratio": 0.05008179187114634
+//               },
+//               {
+//                   "date": "2023-12-19 00:00:00",
+//                   "total_count": 8360,
+//                   "count": 365,
+//                   "ratio": 0.04366028708133971
+//               },
+//               {
+//                   "date": "2023-12-20 00:00:00",
+//                   "total_count": 8645,
+//                   "count": 362,
+//                   "ratio": 0.041873915558126085
+//               },
+//               {
+//                   "date": "2023-12-21 00:00:00",
+//                   "total_count": 8227,
+//                   "count": 361,
+//                   "ratio": 0.04387990762124711
+//               },
+//               {
+//                   "date": "2023-12-22 00:00:00",
+//                   "total_count": 7284,
+//                   "count": 315,
+//                   "ratio": 0.04324546952224053
+//               },
+//               {
+//                   "date": "2023-12-23 00:00:00",
+//                   "total_count": 3794,
+//                   "count": 180,
+//                   "ratio": 0.047443331576172906
+//               },
+//               {
+//                   "date": "2023-12-24 00:00:00",
+//                   "total_count": 3323,
+//                   "count": 188,
+//                   "ratio": 0.05657538368943726
+//               },
+//               {
+//                   "date": "2023-12-25 00:00:00",
+//                   "total_count": 3064,
+//                   "count": 165,
+//                   "ratio": 0.05385117493472585
+//               },
+//               {
+//                   "date": "2023-12-26 00:00:00",
+//                   "total_count": 5480,
+//                   "count": 276,
+//                   "ratio": 0.050364963503649635
+//               },
+//               {
+//                   "date": "2023-12-27 00:00:00",
+//                   "total_count": 6526,
+//                   "count": 328,
+//                   "ratio": 0.05026049647563592
+//               },
+//               {
+//                   "date": "2023-12-28 00:00:00",
+//                   "total_count": 6518,
+//                   "count": 331,
+//                   "ratio": 0.050782448603866215
+//               },
+//               {
+//                   "date": "2023-12-29 00:00:00",
+//                   "total_count": 6136,
+//                   "count": 339,
+//                   "ratio": 0.055247718383311606
+//               },
+//               {
+//                   "date": "2023-12-30 00:00:00",
+//                   "total_count": 3845,
+//                   "count": 217,
+//                   "ratio": 0.0564369310793238
+//               },
+//               {
+//                   "date": "2023-12-31 00:00:00",
+//                   "total_count": 3698,
+//                   "count": 183,
+//                   "ratio": 0.0494862087614927
+//               },
+//               {
+//                   "date": "2024-01-01 00:00:00",
+//                   "total_count": 3868,
+//                   "count": 191,
+//                   "ratio": 0.04937952430196484
+//               },
+//               {
+//                   "date": "2024-01-02 00:00:00",
+//                   "total_count": 6867,
+//                   "count": 329,
+//                   "ratio": 0.047910295616717634
+//               },
+//               {
+//                   "date": "2024-01-03 00:00:00",
+//                   "total_count": 5509,
+//                   "count": 247,
+//                   "ratio": 0.04483572336177165
+//               },
+//               {
+//                   "date": "2024-01-04 00:00:00",
+//                   "total_count": 3012,
+//                   "count": 123,
+//                   "ratio": 0.04083665338645418
+//               },
+//               {
+//                   "date": "2024-01-05 00:00:00",
+//                   "total_count": 6775,
+//                   "count": 316,
+//                   "ratio": 0.04664206642066421
+//               },
+//               {
+//                   "date": "2024-01-06 00:00:00",
+//                   "total_count": 3682,
+//                   "count": 206,
+//                   "ratio": 0.05594785442694188
+//               },
+//               {
+//                   "date": "2024-01-07 00:00:00",
+//                   "total_count": 4471,
+//                   "count": 263,
+//                   "ratio": 0.058823529411764705
+//               },
+//               {
+//                   "date": "2024-01-08 00:00:00",
+//                   "total_count": 8540,
+//                   "count": 411,
+//                   "ratio": 0.04812646370023419
+//               },
+//               {
+//                   "date": "2024-01-09 00:00:00",
+//                   "total_count": 8846,
+//                   "count": 538,
+//                   "ratio": 0.060818449016504635
+//               },
+//               {
+//                   "date": "2024-01-10 00:00:00",
+//                   "total_count": 9684,
+//                   "count": 521,
+//                   "ratio": 0.05380008261049153
+//               },
+//               {
+//                   "date": "2024-01-11 00:00:00",
+//                   "total_count": 9313,
+//                   "count": 512,
+//                   "ratio": 0.0549769139911951
+//               },
+//               {
+//                   "date": "2024-01-12 00:00:00",
+//                   "total_count": 8645,
+//                   "count": 554,
+//                   "ratio": 0.06408328513591671
+//               },
+//               {
+//                   "date": "2024-01-13 00:00:00",
+//                   "total_count": 4534,
+//                   "count": 487,
+//                   "ratio": 0.10741067490074989
+//               },
+//               {
+//                   "date": "2024-01-14 00:00:00",
+//                   "total_count": 3418,
+//                   "count": 370,
+//                   "ratio": 0.10825043885313049
+//               },
+//               {
+//                   "date": "2024-01-15 00:00:00",
+//                   "total_count": 102,
+//                   "count": 5,
+//                   "ratio": 0.049019607843137254
+//               }
+//           ],
+//           "total": 10449,
+//           "normalized_total": 204337
+//       }
+//   }
+// ]

--- a/mcweb/frontend/src/features/search/util/prepareSourcesData.js
+++ b/mcweb/frontend/src/features/search/util/prepareSourcesData.js
@@ -16,7 +16,9 @@ export default function prepareSourceData(domainData, normalized) {
     series.push(
       {
         data: queryData.sources.slice(0, 10).map((s) => ({
-          key: s.source, value: normalized ? (s.count / totalCount) * 100 : s.count,
+          key: `<a 
+          href="https://${s.source}" target="_blank" rel="noreferrer">${s.source}</a>`,
+          value: normalized ? (s.count / totalCount) * 100 : s.count,
         })),
         name: 'Source',
         color: colorArray[i],

--- a/mcweb/frontend/src/features/search/util/tabTitleHelpers/createTitle.js
+++ b/mcweb/frontend/src/features/search/util/tabTitleHelpers/createTitle.js
@@ -2,7 +2,9 @@ import queryGenerator from '../queryGenerator';
 
 const createTitle = (queryList, negatedQueryList, platform, anyAll, queryString) => {
   // advanced mode
-  if (queryString) return queryString;
+  if (queryString) {
+    return queryString.length <= 50 ? queryString : `${queryString.slice(0, 50)}...`;
+  }
 
   return queryGenerator(queryList, negatedQueryList, platform, anyAll);
 };

--- a/mcweb/frontend/src/features/stories/StoriesOverTime.jsx
+++ b/mcweb/frontend/src/features/stories/StoriesOverTime.jsx
@@ -4,7 +4,7 @@ import dayjs from 'dayjs';
 import CircularProgress from '@mui/material/CircularProgress';
 import { useGetCountOverTimeMutation } from '../../app/services/searchApi';
 import CountOverTimeChart from '../search/results/CountOverTimeChart';
-import prepareCountOverTimeData from '../search/util/prepareCountOverTimeData';
+import { prepareCountOverTimeData } from '../search/util/prepareCountOverTimeData';
 import prepareQueries from '../search/util/prepareQueries';
 import { PROVIDER_NEWS_MEDIA_CLOUD, latestAllowedEndDate, earliestAllowedStartDate } from '../search/util/platforms';
 

--- a/mcweb/frontend/src/features/ui/TotalAttentionEmailModal.jsx
+++ b/mcweb/frontend/src/features/ui/TotalAttentionEmailModal.jsx
@@ -5,6 +5,7 @@ import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
+import DownloadIcon from '@mui/icons-material/Download';
 import Box from '@mui/material/Box';
 import DialogTitle from '@mui/material/DialogTitle';
 import TextField from '@mui/material/TextField';
@@ -97,6 +98,7 @@ export default function TotalAttentionEmailModal({
         variant={variant}
         onClick={handleClickOpen}
         endIcon={endIcon}
+        startIcon={<DownloadIcon titleAccess="Download CSV of Top Terms" />}
       >
         {outsideTitle}
       </Button>


### PR DESCRIPTION
## Add Day, Week and Month view options to the Attention Over Time Chart
### Day
![Screen Shot 2024-01-17 at 2 32 12 PM](https://github.com/mediacloud/web-search/assets/78226696/a8a7482d-04e5-46b8-9420-1d13035d1317)

### Week
![Screen Shot 2024-01-17 at 2 32 19 PM](https://github.com/mediacloud/web-search/assets/78226696/b443d1c5-7749-439f-a072-b4cf46f81faf)

### Month
![Screen Shot 2024-01-17 at 2 32 27 PM](https://github.com/mediacloud/web-search/assets/78226696/f31cf15a-4554-49c0-9c55-3a919ae27c6a)

- Changes to Total Attention description to move download info to Sample Stories.
- Bug found with method used to get collection names for tab naming, fixed by changing request from POST to GET.
- Added limit to length of tab title if used in advanced search (limit 50)
- Add links to the names in Top Sources results

