### PR TITLE
Fix large content downloads and minor info text to email

### DIFF
--- a/mcweb/backend/search/tasks.py
+++ b/mcweb/backend/search/tasks.py
@@ -32,9 +32,9 @@ def download_all_large_content_csv(queryState, user_id, user_isStaff, email):
 def _download_all_large_content_csv(queryState, user_id, user_isStaff, email):
     data = []
     for query in queryState:
-        start_date, end_date, query_str, provider_props, provider_name = parse_query_array(
+        start_date, end_date, query_str, provider_props, provider_name, api_key, base_url = parse_query_array(
             query)
-        provider = providers.provider_by_name(provider_name)
+        provider = providers.provider_by_name(provider_name,  api_key, base_url)
         data.append(provider.all_items(
             query_str, start_date, end_date, **provider_props))
 

--- a/mcweb/util/send_emails.py
+++ b/mcweb/util/send_emails.py
@@ -61,6 +61,7 @@ def send_zipped_large_download_email(zipped_filename, zipped_data, to):
     if not EMAIL_HOST:
         return
     email = EmailMessage(subject="Downloaded Total Attention's Data",
+                         body=zipped_filename,
                          from_email='noreply@mediacloud.org', to=[to])
     try:
         email.attach(zipped_filename, zipped_data, 'application/zip')


### PR DESCRIPTION
From sentry errors I was able to find a problem with large content downloads. Fixed bug, added timestamp to email body (temporary until csv downloads gets revamped soon).