### PR TITLE
Update mc providers package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ whitenoise==6.2.*
 sentry-sdk==1.39.*
 requests  # let the other dependencies sort out which is the right version
 fasttext==0.9.*
-mc-providers>=0.5.1
+mc-providers>=0.5.2
 pycountry==22.3.*
 django-background-tasks-updated==1.2.* # need >= 1.2.6
 feed-seeker==1.0.*


### PR DESCRIPTION
Need to update mc-providers to 0.5.2 to use the new non-chunking feature.

closes #610 