### PR TITLE
Fix typos with cache function

### DIFF
--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -31,7 +31,7 @@ from util.cache import django_caching_interface
 logger = logging.getLogger(__name__)
 
 # This is where we set the caching manager and the cache_time
-CachingManager.caching_function = django_caching_interface(time_secs=60*60*24)
+CachingManager.cache_function = django_caching_interface(time_secs=60*60*24)
 
 session = requests.Session()
 retry = Retry(connect=3, backoff_factor=0.5)

--- a/mcweb/util/cache.py
+++ b/mcweb/util/cache.py
@@ -42,8 +42,8 @@ class django_caching_interface():
     def __call__(self, fn, *args, **kwargs):
         key = _cache_get_key(fn.__name__, *args, **kwargs)
         results = cache.get(key)
-        if not result:
-            result = fn(*args, **kwargs)
-            cache.set(key, result, self.time_secs)
-        return result
+        if not results:
+            results = fn(*args, **kwargs)
+            cache.set(key, results, self.time_secs)
+        return results
     


### PR DESCRIPTION
Looks like there were a few typos that was breaking the cache function.
- fixed cache function name to correspond with providers package
- fix typos in cache 

closes #554 