### PR TITLE
Adjust start date for online news and fix no results top sources

### DIFF
--- a/mcweb/frontend/src/features/search/query/media-picker/MediaPickerSelectionTable.jsx
+++ b/mcweb/frontend/src/features/search/query/media-picker/MediaPickerSelectionTable.jsx
@@ -85,5 +85,9 @@ MediaPickerSelectionTable.propTypes = {
   selected: PropTypes.arrayOf(PropTypes.number).isRequired,
   collection: PropTypes.bool.isRequired,
   queryIndex: PropTypes.number.isRequired,
-  isGlobalCollection: PropTypes.bool.isRequired,
+  isGlobalCollection: PropTypes.bool,
+};
+
+MediaPickerSelectionTable.defaultProps = {
+  isGlobalCollection: false,
 };

--- a/mcweb/frontend/src/features/search/results/TopSources.jsx
+++ b/mcweb/frontend/src/features/search/results/TopSources.jsx
@@ -69,7 +69,7 @@ export default function TopSources() {
   let content;
   if (!data && !error) return null;
 
-  if (error) {
+  if (error || !data[0].sources[0]) {
     content = (
       <Alert severity="warning">
         Sorry, but something went wrong.

--- a/mcweb/frontend/src/features/search/util/platforms.js
+++ b/mcweb/frontend/src/features/search/util/platforms.js
@@ -49,7 +49,7 @@ export const latestAllowedEndDate = (provider) => {
 export const earliestAllowedStartDate = (provider) => {
   if (provider === PROVIDER_NEWS_WAYBACK_MACHINE) return dayjs('2022-08-01');
   if (provider === PROVIDER_REDDIT_PUSHSHIFT) return dayjs('2022-11-1');
-  return dayjs('2010-01-01');
+  return dayjs('2023-10-17');
 };
 
 export const defaultPlatformProvider = (platform) => {


### PR DESCRIPTION
- Change start date for the new index to be the earliest day we have data available (10/17/23).
- Add error handling in Top Sources if something with no results returns