### PR TITLE
Change chevron symbol and add tooltip

### DIFF
--- a/mcweb/frontend/src/features/search/util/CopyToAll.jsx
+++ b/mcweb/frontend/src/features/search/util/CopyToAll.jsx
@@ -47,7 +47,21 @@ export default function CopyToAll({
 
   return (
     <>
-      <Tooltip title="Copy To All Queries">
+      <Tooltip
+        slotProps={{
+          popper: {
+            modifiers: [
+              {
+                name: 'offset',
+                options: {
+                  offset: [0, -17],
+                },
+              },
+            ],
+          },
+        }}
+        title="Copy To All Queries"
+      >
         <div
           style={{
             color: '#d24527', marginLeft: '3px', cursor: 'pointer',

--- a/mcweb/frontend/src/features/search/util/CopyToAll.jsx
+++ b/mcweb/frontend/src/features/search/util/CopyToAll.jsx
@@ -5,6 +5,7 @@ import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
+import Tooltip from '@mui/material/Tooltip';
 import DialogTitle from '@mui/material/DialogTitle';
 import { useDispatch } from 'react-redux';
 import { useSnackbar } from 'notistack';
@@ -46,14 +47,16 @@ export default function CopyToAll({
 
   return (
     <>
-      <div
-        style={{
-          color: '#d24527', fontSize: '12px', marginLeft: '3px', cursor: 'pointer',
-        }}
-        onClick={handleClickOpen}
-      >
-        &gt;&gt;
-      </div>
+      <Tooltip title="Copy To All Queries">
+        <div
+          style={{
+            color: '#d24527', marginLeft: '3px', cursor: 'pointer',
+          }}
+          onClick={handleClickOpen}
+        >
+          &#187;
+        </div>
+      </Tooltip>
       <Dialog
         open={open}
         onClose={handleClose}


### PR DESCRIPTION
Change chevron symbol to remove space between.
Add tooltip to icon to let people know it is a 'copy to all' feature.
![Screen Shot 2024-02-08 at 9 50 55 AM](https://github.com/mediacloud/web-search/assets/78226696/6f378f43-26d5-4696-8e62-ccf9f25f2dac)
