### PR TITLE
Fetch attention-over-time first then other results components

### DIFF
--- a/mcweb/frontend/src/features/auth/ResetPassword.jsx
+++ b/mcweb/frontend/src/features/auth/ResetPassword.jsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
+import Alert from '@mui/material/Alert';
 import Avatar from '@mui/material/Avatar';
 import Button from '@mui/material/Button';
 import CssBaseline from '@mui/material/CssBaseline';
@@ -52,6 +53,11 @@ export default function ResetPassword() {
           <Typography component="h1" variant="h5">
             Reset Password
           </Typography>
+
+          <Alert severity="warning">
+            Please do not refresh the page in the time between enterting your email and entering
+            the verification code that was emailed to you
+          </Alert>
 
           <Box
             component="form"
@@ -108,7 +114,7 @@ export default function ResetPassword() {
                   }
                 }}
               >
-                Send Login Link
+                Email Reset Code
               </Button>
             )}
 

--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -13,7 +13,7 @@ import CancelIcon from '@mui/icons-material/Cancel';
 import dayjs from 'dayjs';
 import TabDropDownMenu from '../ui/TabDropDownMenu';
 import {
-  addQuery, setLastSearchTime, removeQuery, setQueryProperty, addComparativeQuery,
+  addQuery, setInitialSearchTime, removeQuery, setQueryProperty, addComparativeQuery,
 } from './query/querySlice';
 import Search from './query/Search';
 import PlatformPicker from './query/PlatformPicker';
@@ -282,7 +282,7 @@ export default function TabbedSearch() {
                 startIcon={<SearchIcon titleAccess="search this query" />}
                 onClick={async () => {
                   dispatch(searchApi.util.resetApiState());
-                  dispatch(setLastSearchTime(dayjs().unix()));
+                  dispatch(setInitialSearchTime(dayjs().unix()));
                   const collectionNames = await fetchCollectionNames();
                   const updatedQueryState = JSON.parse(JSON.stringify(queryState));
                   queryState.forEach((q, i) => {

--- a/mcweb/frontend/src/features/search/query/querySlice.js
+++ b/mcweb/frontend/src/features/search/query/querySlice.js
@@ -24,6 +24,7 @@ const cleanQuery = (platform) => ({
   sources: [],
   previewSources: [],
   lastSearchTime: dayjs().unix(),
+  initialSearchTime: dayjs().unix(),
   isFromDateValid: true,
   isToDateValid: true,
   anyAll: 'any',
@@ -48,6 +49,7 @@ const querySlice = createSlice({
         sources: [],
         previewSources: [],
         lastSearchTime: dayjs().unix(),
+        initialSearchTime: dayjs().unix(),
         isFromDateValid: true,
         isToDateValid: true,
         anyAll: 'any',
@@ -179,6 +181,14 @@ const querySlice = createSlice({
         copyQs.lastSearchTime = payload;
       });
     },
+    setInitialSearchTime: (state, { payload }) => {
+      const freezeState = state;
+
+      freezeState.forEach((qS) => {
+        const copyQs = qS;
+        copyQs.initialSearchTime = payload;
+      });
+    },
     addComparativeQuery: (state, { payload }) => {
       const { type, query } = payload;
       const newState = generateComparativeQuery(type, query);
@@ -256,6 +266,7 @@ export const {
   setSelectedMedia,
   addComparativeQuery,
   copyToAllQueries,
+  setInitialSearchTime,
 } = querySlice.actions;
 
 export default querySlice.reducer;

--- a/mcweb/frontend/src/features/search/util/setSearchQuery.js
+++ b/mcweb/frontend/src/features/search/util/setSearchQuery.js
@@ -4,7 +4,7 @@ import {
   setPreviewSelectedMedia,
   addQuery,
   setPlatform,
-  setLastSearchTime,
+  setInitialSearchTime,
   setSelectedMedia,
 } from '../query/querySlice';
 
@@ -146,7 +146,7 @@ export const setState = (
 
   dispatch(setPreviewSelectedMedia({ sourceOrCollection: media }));
   dispatch(setSelectedMedia({ sourceOrCollection: media }));
-  dispatch(setLastSearchTime(dayjs().unix()));
+  dispatch(setInitialSearchTime(dayjs().unix()));
 
   if (edited) {
     edited.forEach((edit, i) => {


### PR DESCRIPTION
- Hitting search or refreshing a search, first fetches attention over time, once that has successfully fetched the other results components will then fetch.
  - should help with cacheing and overall performance 🙏 

- Also added alert warning to reset password page to not refresh between entering email and entering the verification code   
![Screen Shot 2024-04-24 at 11 12 41 AM](https://github.com/mediacloud/web-search/assets/78226696/f06ef850-9e7b-4882-9953-ae2c71d788ad)
![Screen Shot 2024-04-24 at 11 12 55 AM](https://github.com/mediacloud/web-search/assets/78226696/7edcdcd8-17fc-409e-83e8-a441cdb76170)
