### PR TITLE
Integrate new providers with MC cache change

### DIFF
--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -7,23 +7,20 @@ import requests
 from typing import Optional
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
-from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden, HttpResponse
-from rest_framework.authentication import SessionAuthentication, BasicAuthentication, TokenAuthentication
+from django.http import HttpResponseBadRequest, HttpResponseForbidden, HttpResponse
+from rest_framework.authentication import SessionAuthentication, TokenAuthentication
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.response import Response
 from rest_framework.decorators import api_view
 from django.views.decorators.http import require_http_methods
 from django.contrib.auth.decorators import login_required
 from rest_framework.decorators import action, authentication_classes, permission_classes
 import backend.util.csv_stream as csv_stream
 from .utils import parse_query, parse_query_array
-from util.cache import cache_by_kwargs
 from .tasks import download_all_large_content_csv
 from ..users.models import QuotaHistory
 from backend.users.exceptions import OverQuotaException
 import mc_providers as providers
 from mc_providers.exceptions import UnsupportedOperationException, QueryingEverythingUnsupportedQuery
-from mc_providers import PLATFORM_ONLINE_NEWS, PLATFORM_SOURCE_WAYBACK_MACHINE, PLATFORM_REDDIT
 from mc_providers.exceptions import ProviderException
 from mc_providers.cache import CachingManager
 

--- a/mcweb/util/cache.py
+++ b/mcweb/util/cache.py
@@ -1,4 +1,5 @@
 from django.core.cache import cache
+from typing import Callable, Any
 
 # not integrated yet: super useful (we keep results of api) (lasts for 24 hours)
 
@@ -39,11 +40,13 @@ class django_caching_interface():
     def __init__(self, time_secs: int = 60*60*24):
         self.time_secs = time_secs
         
-    def __call__(self, fn, *args, **kwargs):
-        key = _cache_get_key(fn.__name__, *args, **kwargs)
+    def __call__(self, fn: Callable, cache_prefix: str, *args, **kwargs) -> tuple[Any, bool]:
+        was_cached = True
+        key = _cache_get_key(cache_prefix, *args, **kwargs)
         results = cache.get(key)
         if not results:
+            was_cached = False
             results = fn(*args, **kwargs)
             cache.set(key, results, self.time_secs)
-        return results
+        return results, was_cached
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ djangorestframework-simplejwt[crypto]==5.2.*
 pyhumps==3.8.*
 django-environ==0.9.*
 dj-database-url==1.0.*
-mediacloud-metadata==0.11.*
+mediacloud-metadata==1.*
 python-dateutil==2.8.*
 django-redis==5.2.*
 gunicorn==20.1.*
@@ -14,7 +14,7 @@ whitenoise==6.2.*
 sentry-sdk==1.39.*
 requests  # let the other dependencies sort out which is the right version
 fasttext==0.9.*
-mc-providers>=1.0.1
+mc-providers==2.0.*
 pycountry==22.3.*
 django-background-tasks-updated==1.2.* # need >= 1.2.6
 feed-seeker==1.0.*


### PR DESCRIPTION
This significantly speeds up results by integrating the new `mc-providers` release, which has cache fixes. Related to #645 