### PR TITLE
Test fix for sending search after every entered char

### DIFF
--- a/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
+++ b/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
@@ -69,6 +69,7 @@ export default function CountOverTimeResults() {
   useEffect(() => {
     if ((data)) {
       if ((data.length === queryState.length)) { executeScroll(); }
+      dispatch(setLastSearchTime(dayjs().unix()));
     } else if (error) {
       executeScroll();
     }
@@ -94,7 +95,6 @@ export default function CountOverTimeResults() {
       </Alert>
     );
   } else {
-    dispatch(setLastSearchTime(dayjs().unix()));
     const preparedData = prepareCountOverTimeData(data, normalized, chartBy);
     if (preparedData.length !== queryState.length) return null;
     const updatedPrepareCountOverTimeData = preparedData.map(


### PR DESCRIPTION
With the last PR to send Attention Over Time first, bug was introduced that triggered results components after every character entered when a search had already been completed.

Attempt to only send other results components if the data has changed on attention over time.