### PR TITLE
allow earlier start date, update version notes

### DIFF
--- a/mcweb/frontend/src/features/search/util/platforms.js
+++ b/mcweb/frontend/src/features/search/util/platforms.js
@@ -49,7 +49,7 @@ export const latestAllowedEndDate = (provider) => {
 export const earliestAllowedStartDate = (provider) => {
   if (provider === PROVIDER_NEWS_WAYBACK_MACHINE) return dayjs('2022-08-01');
   if (provider === PROVIDER_REDDIT_PUSHSHIFT) return dayjs('2022-11-1');
-  return dayjs('2023-01-01');
+  return dayjs('2022-01-01');
 };
 
 export const defaultPlatformProvider = (platform) => {

--- a/mcweb/frontend/static/about/release_history.json
+++ b/mcweb/frontend/static/about/release_history.json
@@ -1,4 +1,10 @@
-[{"version": "v2.0.3",
+[{"version": "v2.0.4",
+"date": "2024-05-14",
+"notes": ["update cacheing",
+"now search attention over time first, followed by other results components",
+"decrease earliest searchable start date to 01/01/2022"
+]},
+{"version": "v2.0.3",
 "date": "2024-03-19",
 "notes": ["update low-level internal libraries",
 "fixes on story API call"

--- a/mcweb/settings.py
+++ b/mcweb/settings.py
@@ -23,7 +23,7 @@ from django.core.exceptions import ImproperlyConfigured
 logger = logging.getLogger(__file__)
 
 # The static version of the app
-VERSION = "2.0.3"
+VERSION = "2.0.4"
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent


### PR DESCRIPTION
Allow earliest searchable date for Media Cloud to be 01/01/2022
