### PR TITLE
Fix negated query for mc search

### DIFF
--- a/mcweb/frontend/src/features/search/util/queryGenerator.js
+++ b/mcweb/frontend/src/features/search/util/queryGenerator.js
@@ -58,8 +58,10 @@ const queryGenerator = (queryList, negatedQueryList, platform, anyAll) => {
   if (negatedQuery.length > 0) {
     if (platform === PROVIDER_NEWS_MEDIA_CLOUD_LEGACY) {
       fullQuery = `(${fullQuery}) AND NOT (${negatedQuery.join(' OR ')})`;
-    } else if (platform === PROVIDER_NEWS_WAYBACK_MACHINE || platform === PROVIDER_NEWS_MEDIA_CLOUD) {
+    } else if (platform === PROVIDER_NEWS_WAYBACK_MACHINE) {
       fullQuery = `(${fullQuery}) -(${negatedQuery.join(' -')})`;
+    } else if (platform === PROVIDER_NEWS_MEDIA_CLOUD) {
+      fullQuery = `(${fullQuery}) -(${negatedQuery.join(' OR ')})`;
     } else if (platform === PROVIDER_REDDIT_PUSHSHIFT) {
       fullQuery = `(${fullQuery}) -${negatedQuery.join(' -')}`;
     } else if (platform === PROVIDER_YOUTUBE_YOUTUBE) {

--- a/mcweb/frontend/src/features/sources/ModifySource.jsx
+++ b/mcweb/frontend/src/features/sources/ModifySource.jsx
@@ -60,7 +60,7 @@ export default function ModifySource() {
         homepage: data.homepage,
         label: data.label,
         platform: data.platform,
-        url_search_string: data.url_search_string,
+        url_search_string: data.url_search_string ? data.url_search_string : '',
         media_type: data.media_type ? data.media_type : '',
         primary_language: data.primary_language,
         pub_country: data.pub_country,
@@ -77,7 +77,7 @@ export default function ModifySource() {
   const prepareSource = (formData) => {
     const preparedSource = {};
     Object.keys(formData).forEach((column) => {
-      if (formData[column] && formData[column] !== '') {
+      if ((formData[column] && formData[column] !== '') || column === 'url_search_string') {
         preparedSource[column] = formData[column];
       }
     });

--- a/mcweb/frontend/src/features/sources/util/buildStatArray.js
+++ b/mcweb/frontend/src/features/sources/util/buildStatArray.js
@@ -10,9 +10,7 @@ const statPanelValues = [
 const buildStatArray = (sourceObject) => {
   const returnArr = [];
   statPanelValues.forEach((panelValue) => {
-    if (sourceObject[panelValue.value]) {
-      returnArr.push({ label: panelValue.label, value: sourceObject[panelValue.value] });
-    }
+    returnArr.push({ label: panelValue.label, value: sourceObject[panelValue.value] });
   });
   return returnArr;
 };

--- a/mcweb/frontend/src/features/sources/util/buildStatArray.js
+++ b/mcweb/frontend/src/features/sources/util/buildStatArray.js
@@ -1,9 +1,9 @@
 const statPanelValues = [
   { label: 'First Story', value: 'first_story' },
   { label: 'Stories per Week', value: 'stories_per_week' },
-  { label: 'Publication Country', value: 'pub_country' },
-  { label: 'Publication State', value: 'pub_state' },
-  { label: 'Primary Language', value: 'primary_language' },
+  { label: 'Pub Country', value: 'pub_country' },
+  { label: 'Pub State', value: 'pub_state' },
+  { label: 'Language', value: 'primary_language' },
   { label: 'Media Type', value: 'media_type' },
 ];
 


### PR DESCRIPTION
In simple search negated queries were still being searched against.
Fix simple search negation query logic:
![Screen Shot 2024-06-20 at 10 06 13 AM](https://github.com/mediacloud/web-search/assets/78226696/3cf289e0-53c6-442e-ada0-2ea27175e1c1)
(now using OR to separate negations)

Results do not have negated terms:
![Screen Shot 2024-06-20 at 10 06 37 AM](https://github.com/mediacloud/web-search/assets/78226696/07885dd3-b6fb-4e9f-bb50-4fe8bb7f77e7)
closes #667 