### PR TITLE
Change source name to label in selected media

### DIFF
--- a/mcweb/frontend/src/features/search/query/SelectedMedia.jsx
+++ b/mcweb/frontend/src/features/search/query/SelectedMedia.jsx
@@ -54,7 +54,7 @@ export default function SelectedMedia({
                     width: '100%',
                   }}
                 >
-                  {source.name || source.label}
+                  {source.label || source.name}
                 </Link>
                 <IconButton
                   size="small"

--- a/mcweb/frontend/src/features/sources/SourceShow.jsx
+++ b/mcweb/frontend/src/features/sources/SourceShow.jsx
@@ -58,8 +58,8 @@ export default function SourceShow() {
           )}
           {source.notes && (
             <p>
-              <b>Notes</b>
-              {source.notes}
+              {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
+              <b>Notes:</b> {source.notes}
             </p>
           )}
         </div>


### PR DESCRIPTION
For sources, show label first and if no label than show name (in SelectedMedia):
![Screen Shot 2024-06-26 at 1 50 17 PM](https://github.com/mediacloud/web-search/assets/78226696/f6451ec2-aad2-48d8-9f08-b75c5a073c2b)
![Screen Shot 2024-06-26 at 1 50 27 PM](https://github.com/mediacloud/web-search/assets/78226696/db87c556-1cd4-43b0-b1a9-140d6978af67)
closes #661 

Add colon and space to Source show page:
![Screen Shot 2024-06-26 at 1 50 51 PM](https://github.com/mediacloud/web-search/assets/78226696/2f32bcd3-a608-4a0e-84d3-aaca6b6c551b)
closes #644 