### PR TITLE
apply .env file in predeploy, so the variables are available in postd…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,7 @@ else
     
     git clone https://"$GITHUB_USR":"$GITHUB_PAT"@github.com/mediacloud/web-search-config.git
     cp "web-search-config/web-search.$STACK_NAME.sh" mcweb/.env
+    . mcweb/.env
 fi
 
 

--- a/mcweb/frontend/views.py
+++ b/mcweb/frontend/views.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 ANALYTICS_MATOMO_DOMAIN = os.getenv('ANALYTICS_MATOMO_DOMAIN', "null")
 ANALYTICS_MATOMO_SITE_ID = os.getenv('ANALYTICS_MATOMO_SITE_ID', "null")
 SENTRY_DSN = os.getenv('SENTRY_DSN',"null")
-SENTRY_ENV = os.getenv('ENV_NAME', "null")
+SENTRY_ENV = os.getenv('STACK_NAME', "null")
 SENTRY_TRACES_RATE = os.getenv('SENTRY_TRACES_RATE',"null")
 SENTRY_REPLAY_RATE = os.getenv('SENTRY_REPLAY_RATE',"null")
 

--- a/mcweb/settings.py
+++ b/mcweb/settings.py
@@ -255,7 +255,7 @@ try:
         integrations=[
             DjangoIntegration(),
         ],
-        environment=os.getenv('ENV_NAME', None),
+        environment=os.getenv('STACK_NAME', None),
         release=VERSION,
 
         # Set traces_sample_rate to 1.0 to capture 100%


### PR DESCRIPTION
…eploy- and use 'STACK_NAME' for sentry environments