### PR TITLE
Add different chart colors depending on query

### DIFF
--- a/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
+++ b/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
@@ -93,7 +93,7 @@ export default function CountOverTimeResults() {
       </Alert>
     );
   } else {
-    const preparedData = prepareCountOverTimeData(data, normalized, chartBy);
+    const preparedData = prepareCountOverTimeData(data, normalized, chartBy, queryState);
     if (preparedData.length !== queryState.length) return null;
     const updatedPrepareCountOverTimeData = preparedData.map(
       (originalDataObj, index) => {

--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -91,7 +91,7 @@ function TotalAttentionResults() {
       </Alert>
     );
   } else {
-    const preparedTAdata = prepareTotalAttentionData(data, normalized);
+    const preparedTAdata = prepareTotalAttentionData(data, normalized, queryState);
 
     if (preparedTAdata.length !== queryState.length) return null;
     const updatedTotalAttentionData = preparedTAdata.map(

--- a/mcweb/frontend/src/features/search/util/getColors.js
+++ b/mcweb/frontend/src/features/search/util/getColors.js
@@ -1,0 +1,35 @@
+import { PARTISAN, GLOBAL } from "./generateComparativeQuery";
+
+const PARTISAN_COLORS = ['#4D1AF1','#C1B0F7','#A211BD','#F58B8B','#E80C0C'];
+const GLOBAL_COLORS = ['#b22033', '#032169', '#008751', '#ffc400', '#000000', '#F3EFEF', '#009b3a', '#ff9933'];
+const DEFAULT_COLORS = ['#2f2d2b', '#d24527', '#f7a44e', '#334cda', '#d23716'];
+
+const getQueryType = (queryState) => {
+    const queryLength = queryState.length;
+    const firstName = queryState[0].name 
+
+    if (queryLength === 5 && firstName === "left") {
+        return PARTISAN
+    } else if (queryLength === 8 && firstName === "united states") {
+        return GLOBAL
+    } 
+    return null
+
+}
+
+export default function getColors(queryState){
+    const queryType = getQueryType(queryState);
+    if (queryType && (queryType === PARTISAN)){
+        return PARTISAN_COLORS;
+    } else if (queryType && (queryType === GLOBAL)){
+        return GLOBAL_COLORS;
+    }
+    return DEFAULT_COLORS;
+}
+
+
+// Partisan
+// [left, center left, center, center right, right]
+
+// Global
+// [us, uk, nigeria, spain, germany, france, brazil, india]

--- a/mcweb/frontend/src/features/search/util/prepareCountOverTimeData.js
+++ b/mcweb/frontend/src/features/search/util/prepareCountOverTimeData.js
@@ -1,11 +1,12 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
+import getColors from './getColors';
 
 export const DAY = 'day';
 export const WEEK = 'week';
 export const MONTH = 'month';
 
-const colors = ['#2f2d2b', '#d24527', '#f7a44e', '#334cda', '#d23716'];
+// const colors = ['#2f2d2b', '#d24527', '#f7a44e', '#334cda', '#d23716'];
 
 const dateHelper = (dateString) => {
   dayjs.extend(utc);
@@ -37,9 +38,9 @@ function groupValues(elements, duration, normalized) {
   return returnData;
 }
 
-export const prepareCountOverTimeData = (results, normalized, chartBy) => {
+export const prepareCountOverTimeData = (results, normalized, chartBy, queryState) => {
   const series = [];
-
+  const colors = getColors(queryState)
   if (chartBy === DAY) {
     results.forEach((result, i) => {
       const preparedData = result.count_over_time.counts.map((r) => [

--- a/mcweb/frontend/src/features/search/util/prepareTotalAttentionData.js
+++ b/mcweb/frontend/src/features/search/util/prepareTotalAttentionData.js
@@ -1,12 +1,16 @@
+import getColors from "./getColors";
 // using EPSILON in the denominator here prevents against div by zero errors
 // (which returns infinity in JS)
 const normalizeData = (relevant, total) => 100 * (relevant
   / (total + Number.EPSILON));
 
-const colors = ['#2f2d2b', '#d24527', '#f7a44e', '#334cda', '#d23716'];
+// const colors = ['#2f2d2b', '#d24527', '#f7a44e', '#334cda', '#d23716'];
 
-const prepareTotalAttentionData = (results, normalized) => {
+
+
+const prepareTotalAttentionData = (results, normalized, queryState) => {
   const series = [];
+  const colors = getColors(queryState);
   results.forEach((result, i) => {
     const { relevant, total } = result.count;
     const prepareData = {};

--- a/mcweb/frontend/src/features/ui/TabDropDownMenu.jsx
+++ b/mcweb/frontend/src/features/ui/TabDropDownMenu.jsx
@@ -77,14 +77,16 @@ export default function TabDropDownMenuItems({
         >
           Compare Across the Globe
         </MenuItem>
+
         {/* Add Color Option */}
-        <MenuItem
+        {/* <MenuItem
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
         >
           Add Color
           <ArrowRight />
-        </MenuItem>
+        </MenuItem> */}
+
         {/* Edit Tab Name Option */}
         <MenuItem onClick={() => {
           handleClose('edit');


### PR DESCRIPTION
## Add different chart colors depending on query

### Partisan colors
![Screen Shot 2024-08-07 at 11 56 30 AM](https://github.com/user-attachments/assets/37d30a39-d9dc-4f4f-b271-c1e7a0f0251b)
Hex codes: ['#4D1AF1','#C1B0F7','#A211BD','#F58B8B','#E80C0C'];

### Global colors
![Screen Shot 2024-08-07 at 11 57 37 AM](https://github.com/user-attachments/assets/3d10e39f-bb7d-4249-abf9-296d16eaf999)
Hex codes: ['#b22033', '#032169', '#008751', '#ffc400', '#000000', '#F3EFEF', '#009b3a', '#ff9933'];

### Otherwise will default to normal
Hex codes: ['#2f2d2b', '#d24527', '#f7a44e', '#334cda', '#d23716']

@rahulbot please verify the colors, easy to change any
closes #729 