### PR TITLE
Alert banner added to dates to inform earliest dates available

### DIFF
--- a/mcweb/.env-template
+++ b/mcweb/.env-template
@@ -27,7 +27,7 @@ DEBUG=True
 # Full URL to the primary database
 DATABASE_URL=postgres://USERNAME@localhost:5432/DB_NAME+
 
-# Earliest available date for elastic search
+# Earliest available date for Media Cloud elastic search
 EARLIEST_AVAILABLE_DATE="01/01/2022"
 
 # Full URL of local redis cache

--- a/mcweb/.env-template
+++ b/mcweb/.env-template
@@ -27,6 +27,9 @@ DEBUG=True
 # Full URL to the primary database
 DATABASE_URL=postgres://USERNAME@localhost:5432/DB_NAME+
 
+# Earliest available date for elastic search
+EARLIEST_AVAILABLE_DATE="01/01/2022"
+
 # Full URL of local redis cache
 REDIS_URL=redis://127.0.0.1:6379/1
 

--- a/mcweb/.env-template
+++ b/mcweb/.env-template
@@ -27,8 +27,8 @@ DEBUG=True
 # Full URL to the primary database
 DATABASE_URL=postgres://USERNAME@localhost:5432/DB_NAME+
 
-# Earliest available date for Media Cloud elastic search
-EARLIEST_AVAILABLE_DATE="01/01/2022"
+# Earliest available date (unix) for Media Cloud elastic search
+EARLIEST_AVAILABLE_DATE="1609532591"
 
 # Full URL of local redis cache
 REDIS_URL=redis://127.0.0.1:6379/1

--- a/mcweb/frontend/src/Root.jsx
+++ b/mcweb/frontend/src/Root.jsx
@@ -62,9 +62,9 @@ const theme = createTheme({
   },
 });
 
-const config = window.sentry_config
+const config = window.sentry_config;
 Sentry.init({
-  
+
   dsn: config.sentry_dsn,
   integrations: [
     Sentry.browserTracingIntegration(),
@@ -77,12 +77,12 @@ Sentry.init({
   // Performance Monitoring
   tracesSampleRate: config.traces_rate,
   // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
-  tracePropagationTargets: [/^https:\/\/search\.mediacloud\.org/, "/^http:\/\/localhost:8000/"],
+  tracePropagationTargets: [/^https:\/\/search\.mediacloud\.org/, '/^http:\/\/localhost:8000/'],
   // Session Replay
   replaysSessionSampleRate: config.replay_rate,
   replaysOnErrorSampleRate: 1.0,
-  _experiments:{
-    profilesSampleRate: config.traces_rate
+  _experiments: {
+    profilesSampleRate: config.traces_rate,
   },
   shouldCreateSpanForRequest: (url) => true,
 });

--- a/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
+++ b/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import TextField from '@mui/material/TextField';
+import Alert from '@mui/material/Alert';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
@@ -83,6 +84,7 @@ export default function SearchDatePicker({ queryIndex }) {
 
   return (
     <>
+      <Alert severity="warning">Historical reingest in progress, current dates available to 01/01/2021</Alert>
       <div className="date-picker-wrapper local-provider">
         <LocalizationProvider dateAdapter={AdapterDateFns}>
           <div className="date-accuracy-alert">

--- a/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
+++ b/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
@@ -14,12 +14,10 @@ import { earliestAllowedStartDate, latestAllowedEndDate } from '../util/platform
 import validateDate from '../util/dateValidation';
 import DefaultDates from './DefaultDates';
 import isQueryStateEmpty from '../util/isQueryStateEmpty';
-
-const utc = require('dayjs/plugin/utc');
+import getEarliestAvailableDate from '../util/dateHelpers';
 
 export default function SearchDatePicker({ queryIndex }) {
   const dispatch = useDispatch();
-  dayjs.extend(utc);
   const { enqueueSnackbar } = useSnackbar();
   const { earliestAvailableDate } = document.settings;
   const {
@@ -88,9 +86,8 @@ export default function SearchDatePicker({ queryIndex }) {
   return (
     <>
       <Alert severity="warning">
-        Historical reingest in progress, current dates available to
-        {/* {dayjs.unix(earliestAvailableDate)} */}
-        {dayjs.utc(earliestAvailableDate).local().format('MM/DD/YYYY')}
+        {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
+        Historical reingest in progress, current dates available to {getEarliestAvailableDate(earliestAvailableDate)}
       </Alert>
       <div className="date-picker-wrapper local-provider">
         <LocalizationProvider dateAdapter={AdapterDateFns}>

--- a/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
+++ b/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
@@ -15,10 +15,13 @@ import validateDate from '../util/dateValidation';
 import DefaultDates from './DefaultDates';
 import isQueryStateEmpty from '../util/isQueryStateEmpty';
 
+const utc = require('dayjs/plugin/utc');
+
 export default function SearchDatePicker({ queryIndex }) {
   const dispatch = useDispatch();
+  dayjs.extend(utc);
   const { enqueueSnackbar } = useSnackbar();
-
+  const { earliestAvailableDate } = document.settings;
   const {
     platform, startDate, endDate, isFromDateValid, isToDateValid,
   } = useSelector((state) => state.query[queryIndex]);
@@ -84,7 +87,11 @@ export default function SearchDatePicker({ queryIndex }) {
 
   return (
     <>
-      <Alert severity="warning">Historical reingest in progress, current dates available to 01/01/2021</Alert>
+      <Alert severity="warning">
+        Historical reingest in progress, current dates available to
+        {/* {dayjs.unix(earliestAvailableDate)} */}
+        {dayjs.utc(earliestAvailableDate).local().format('MM/DD/YYYY')}
+      </Alert>
       <div className="date-picker-wrapper local-provider">
         <LocalizationProvider dateAdapter={AdapterDateFns}>
           <div className="date-accuracy-alert">

--- a/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
+++ b/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
@@ -87,7 +87,7 @@ export default function SearchDatePicker({ queryIndex }) {
     <>
       <Alert severity="warning">
         {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-        Historical reingest in progress, current dates available to {getEarliestAvailableDate(earliestAvailableDate)}
+        Reingest of historical data in progress. Search results available from present back to {getEarliestAvailableDate(earliestAvailableDate)}
       </Alert>
       <div className="date-picker-wrapper local-provider">
         <LocalizationProvider dateAdapter={AdapterDateFns}>

--- a/mcweb/frontend/src/features/search/util/dateHelpers.js
+++ b/mcweb/frontend/src/features/search/util/dateHelpers.js
@@ -1,0 +1,8 @@
+import dayjs from 'dayjs';
+
+const getEarliestAvailableDate = (earliestAvailableDate) => {
+  const earliestDateObj = dayjs.unix(earliestAvailableDate);
+  return earliestDateObj.format('MM/DD/YYYY');
+};
+
+export default getEarliestAvailableDate;

--- a/mcweb/frontend/src/features/search/util/platforms.js
+++ b/mcweb/frontend/src/features/search/util/platforms.js
@@ -1,5 +1,8 @@
 import dayjs from 'dayjs';
 
+const utc = require('dayjs/plugin/utc');
+
+dayjs.extend(utc);
 // keep in sync with mcweb/frontend/views.py
 export const PLATFORM_ONLINE_NEWS = 'onlinenews';
 
@@ -19,6 +22,8 @@ export const PROVIDER_NEWS_MEDIA_CLOUD = providerName(
   PLATFORM_SOURCE_MEDIA_CLOUD,
 );
 
+const { earliestAvailableDate } = document.settings;
+
 // the latest allowed end date for the type of platform
 export const latestAllowedEndDate = (provider) => {
   const today = dayjs();
@@ -30,7 +35,7 @@ export const latestAllowedEndDate = (provider) => {
 // the earliest starting date for the type of platform
 export const earliestAllowedStartDate = (provider) => {
   if (provider === PROVIDER_NEWS_WAYBACK_MACHINE) return dayjs('2022-08-01');
-  return dayjs('2021-01-01');
+  return dayjs.utc(earliestAvailableDate).local().format('MM/DD/YYYY');
 };
 
 export const defaultPlatformProvider = (platform) => {

--- a/mcweb/frontend/src/features/search/util/platforms.js
+++ b/mcweb/frontend/src/features/search/util/platforms.js
@@ -30,7 +30,7 @@ export const latestAllowedEndDate = (provider) => {
 // the earliest starting date for the type of platform
 export const earliestAllowedStartDate = (provider) => {
   if (provider === PROVIDER_NEWS_WAYBACK_MACHINE) return dayjs('2022-08-01');
-  return dayjs('2022-01-01');
+  return dayjs('2021-01-01');
 };
 
 export const defaultPlatformProvider = (platform) => {

--- a/mcweb/frontend/src/features/search/util/platforms.js
+++ b/mcweb/frontend/src/features/search/util/platforms.js
@@ -1,8 +1,5 @@
 import dayjs from 'dayjs';
-
-const utc = require('dayjs/plugin/utc');
-
-dayjs.extend(utc);
+import getEarliestAvailableDate from './dateHelpers';
 // keep in sync with mcweb/frontend/views.py
 export const PLATFORM_ONLINE_NEWS = 'onlinenews';
 
@@ -35,7 +32,7 @@ export const latestAllowedEndDate = (provider) => {
 // the earliest starting date for the type of platform
 export const earliestAllowedStartDate = (provider) => {
   if (provider === PROVIDER_NEWS_WAYBACK_MACHINE) return dayjs('2022-08-01');
-  return dayjs.utc(earliestAvailableDate).local().format('MM/DD/YYYY');
+  return getEarliestAvailableDate(earliestAvailableDate);
 };
 
 export const defaultPlatformProvider = (platform) => {

--- a/mcweb/frontend/templates/frontend/index.html
+++ b/mcweb/frontend/templates/frontend/index.html
@@ -20,7 +20,8 @@
                 document.settings.systemAlert = "{{ system_alert|safe }}";
             {% else %}
                 document.settings.systemAlert = undefined;
-            {% endif %}    
+            {% endif %}
+            document.settings.earliestAvailableDate = {{earliest_available_date|safe}};    
       
         </script>
 

--- a/mcweb/frontend/views.py
+++ b/mcweb/frontend/views.py
@@ -11,6 +11,7 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from settings import (
     ANALYTICS_MATOMO_DOMAIN,
     ANALYTICS_MATOMO_SITE_ID,
+    EARLIEST_AVAILABLE_DATE,
     SENTRY_DSN,
     SENTRY_ENV,
     SENTRY_JS_TRACES_RATE,
@@ -29,6 +30,7 @@ def index(request):
         providers=providers.available_provider_names(),
         analytics_matomo_domain=ANALYTICS_MATOMO_DOMAIN,
         analytics_matomo_id=ANALYTICS_MATOMO_SITE_ID,
+        earliest_available_date=EARLIEST_AVAILABLE_DATE,
         system_alert=SYSTEM_ALERT,
         sentry_config={
             "sentry_dsn": (SENTRY_DSN or "null"),

--- a/mcweb/settings.py
+++ b/mcweb/settings.py
@@ -106,6 +106,8 @@ CSRF_TRUSTED_ORIGINS = env("CSRF_TRUSTED_ORIGINS") # defined as list
 
 DEBUG = env("DEBUG")
 
+EARLIEST_AVAILABLE_DATE = env('EARLIEST_AVAILABLE_DATE') # earliest available date for elastic search
+
 EMAIL_NOREPLY = env('EMAIL_NOREPLY') # email sender address
 EMAIL_ORGANIZATION = env('EMAIL_ORGANIZATION') # used in subject line
 


### PR DESCRIPTION
- It has been requested to add a banner above dates to show how far back we are currently ingested (looks like 01/01/2021)
![Screen Shot 2024-09-04 at 1 37 29 PM](https://github.com/user-attachments/assets/c5d680a2-2c31-4fdb-a8a9-de15192e88c6)

- moved earliest searchable date back to 01/01/2021