### PR TITLE
Add Grant to Footer

### DIFF
--- a/mcweb/frontend/src/features/footer/Footer.jsx
+++ b/mcweb/frontend/src/features/footer/Footer.jsx
@@ -41,6 +41,9 @@ function Footer() {
           .
         </p>
         <p>
+          This material is based upon work supported by the National Science Foundation under Grant No. 2341858.
+        </p>
+        <p>
           v
           {document.settings.appVersion}
         </p>

--- a/mcweb/frontend/src/features/footer/Footer.jsx
+++ b/mcweb/frontend/src/features/footer/Footer.jsx
@@ -41,7 +41,11 @@ function Footer() {
           .
         </p>
         <p>
-          This material is based upon work supported by the National Science Foundation under Grant No. 2341858.
+          This material is based upon work supported by the National Science Foundation under
+          {' '}
+          <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=2341858&HistoricalAwards=false">
+            Grant No. 2341858.
+          </a>
         </p>
         <p>
           v

--- a/mcweb/frontend/src/features/footer/Footer.jsx
+++ b/mcweb/frontend/src/features/footer/Footer.jsx
@@ -22,6 +22,13 @@ function Footer() {
 
         </p>
         <p>
+          This material is based upon work supported by the National Science Foundation under
+          {' '}
+          <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=2341858&HistoricalAwards=false">
+            Grant No. 2341858.
+          </a>
+        </p>
+        <p>
           Need help? Join our
           {' '}
           <a href="https://groups.io/g/mediacloud" target="_blank" rel="noreferrer">discussion group</a>
@@ -39,13 +46,6 @@ function Footer() {
           {' '}
           <a href="https://www.mediacloud.org/legal/media-cloud-terms-of-use" target="_blank" rel="noreferrer">terms of use</a>
           .
-        </p>
-        <p>
-          This material is based upon work supported by the National Science Foundation under
-          {' '}
-          <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=2341858&HistoricalAwards=false">
-            Grant No. 2341858.
-          </a>
         </p>
         <p>
           v


### PR DESCRIPTION
This pull request is building on work done by @JBLarson and in reference to PR #793 
- Add link to NSF Grant in footer
<img width="904" alt="Screen Shot 2024-09-27 at 9 53 16 AM" src="https://github.com/user-attachments/assets/c47a12ba-1e39-4f2f-9965-14195d5e4330">

closes #792 
