### PR TITLE
Add scrape-source and scrape-collection commands to manage.py

### DIFF
--- a/mcweb/backend/sources/management/commands/scrape-collection.py
+++ b/mcweb/backend/sources/management/commands/scrape-collection.py
@@ -1,0 +1,30 @@
+import sys
+
+from django.core.management.base import BaseCommand
+
+from ...tasks import _scrape_collection
+from ...models import Collection
+
+class Command(BaseCommand):
+    help = "Scrape collection"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--queue", action="store_true")
+        parser.add_argument("collection_id", type=int)
+        parser.add_argument("email", type=str)
+
+    def handle(self, *args, **options):
+        cid = options["collection_id"]
+        email = options["email"]
+
+        collection = Collection.objects.get(id=cid)
+        if not collection:
+            print("could not find collection id", cid)
+            sys.exit(1)
+
+        if options["queue"]:
+            # queue to worker process
+            _scrape_collection(cid, email)
+        else:
+            # run in-process
+            _scrape_collection.now(cid, email)

--- a/mcweb/backend/sources/management/commands/scrape-source.py
+++ b/mcweb/backend/sources/management/commands/scrape-source.py
@@ -1,0 +1,29 @@
+import sys
+
+from django.core.management.base import BaseCommand
+
+from ...tasks import _scrape_source
+from ...models import Source
+
+class Command(BaseCommand):
+    help = "Scrape source"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--queue", action="store_true")
+        parser.add_argument("source_id", type=int)
+        parser.add_argument("email", type=str)
+
+    def handle(self, *args, **options):
+        sid = options["source_id"]
+        email = options["email"]
+
+        src = Source.objects.get(id=sid)
+        if not src:
+            print("could not find source id", sid)
+            sys.exit(1)
+
+        if options["queue"]:
+            _scrape_source(sid, src.homepage, src.name, email)
+        else:
+            # run now
+            _scrape_source.now(sid, src.homepage, src.name, email)

--- a/mcweb/backend/sources/tasks.py
+++ b/mcweb/backend/sources/tasks.py
@@ -14,7 +14,6 @@ import traceback
 # PyPI:
 from background_task import background
 from background_task.models import Task, CompletedTask
-from feed_seeker import generate_feed_urls
 from mcmetadata.feeds import normalize_url
 from django.core.management import call_command
 from django.contrib.auth.models import User
@@ -77,6 +76,8 @@ def _scrape_source(source_id: int, homepage: str, name: str, user_email: str) ->
     errors = 0
     try:
         email_body = Source._scrape_source(source_id, homepage, name)
+    except KeyboardInterrupt:  # for debug (seeing where hung)
+        raise
     except:
         logger.exception("Source._scrape_source exception in _scrape_source")
         email_body = f"FATAL ERROR:\n{traceback.format_exc()}"
@@ -137,6 +138,8 @@ def _scrape_collection(collection_id: int, user_email: str) -> None:
         try:
             # remove verbosity=0 for more output!
             add_body_chunk(Source._scrape_source(source.id, source.homepage, source.name, verbosity=0))
+        except KeyboardInterrupt:  # for debug (seeing where hung)
+            raise
         except:
             logger.exception(f"Source._scrape_source exception in _scrape_source {source.id}")
             add_body_chunk(f"ERROR:\n{traceback.format_exc()}") # format_exc has final newline


### PR DESCRIPTION
Both commands take an id number and an email to send results to.  Both commands run "in process" for test/debug unless "--queue" is given, in which case the request is queued as a task.  Make sure CTRL/C causes immediate termination, and gives a full backtrace.