### PR TITLE
Use common outgoing connection Session creation code for scraping

### DIFF
--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -11,7 +11,6 @@ from django.http import HttpResponseBadRequest, HttpResponseForbidden, HttpRespo
 from django.views.decorators.http import require_http_methods
 from mc_providers.exceptions import UnsupportedOperationException, QueryingEverythingUnsupportedQuery
 from mc_providers.exceptions import ProviderException
-from requests.adapters import HTTPAdapter
 from rest_framework.authentication import SessionAuthentication, TokenAuthentication
 from rest_framework.decorators import api_view, action, authentication_classes, permission_classes
 from rest_framework.permissions import IsAuthenticated
@@ -50,13 +49,6 @@ logger = logging.getLogger(__name__)
 
 # enable caching for mc_providers results (explicitly referencing pkg for clarity)
 mc_providers.cache.CachingManager.cache_function = mc_providers_cacher
-
-# not used in this file?
-#session = requests.Session()
-#retry = Retry(connect=3, backoff_factor=0.5)
-#adapter = HTTPAdapter(max_retries=retry)
-#session.mount('http://', adapter)
-#session.mount('https://', adapter)
 
 def error_response(msg: str, response_type: HttpResponse | None) -> HttpResponse:
     ResponseClass = response_type or HttpResponseBadRequest

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ djangorestframework-simplejwt[crypto]==5.2.*
 pyhumps==3.8.*
 django-environ==0.9.*
 dj-database-url==1.0.*
-mediacloud-metadata==1.*
+mediacloud-metadata==1.1.*
 python-dateutil==2.8.*
 django-redis==5.2.*
 gunicorn==20.1.*
@@ -19,7 +19,7 @@ mc-manage @ git+https://github.com/mediacloud/mc-manage@v1.1.4
 pycountry==22.3.*
 django-background-tasks-updated==1.2.* # need >= 1.2.6
 django-cors-headers==4.3.*
-feed-seeker==1.0.*
+feed-seeker==1.1.*
 numpy
-pandas
-sitemap-tools @ git+https://github.com/mediacloud/sitemap-tools@v1.0.0
+#pandas
+sitemap-tools @ git+https://github.com/mediacloud/sitemap-tools@v2.0.0


### PR DESCRIPTION
mcmetadata now contains code from story-indexer to make HTTP connections to source sites, use it, and updated sitemap tools in site (re)scrape, AND use connect/read timeouts in scraping to (hopefully) avoid hanging for issue https://github.com/mediacloud/web-search/issues/791

