### PR TITLE
Use mc-providers v2.2.0 caching argument to allow queries to bypass cache for testing

### DIFF
--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -52,9 +52,7 @@ def pq_provider(pq: ParsedQuery, platform: Optional[str] = None) -> ContentProvi
     take parsed query, return mc_providers ContentProvider.
     (one place to pass new things to mc_providers)
     """
-    # disabled until new mc-providers available!
-    #return provider_by_name(platform or pq.provider_name, pq.api_key, pq.base_url, caching=pq.caching)
-    return provider_by_name(platform or pq.provider_name, pq.api_key, pq.base_url)
+    return provider_by_name(platform or pq.provider_name, pq.api_key, pq.base_url, caching=pq.caching)
 
 def parse_date_str(date_str: str) -> dt.datetime:
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ whitenoise==6.2.*
 sentry-sdk==1.39.*
 requests  # let the other dependencies sort out which is the right version
 fasttext==0.9.*
-mc-providers>=2.1.1
+mc-providers>=2.2.0
 mc-manage @ git+https://github.com/mediacloud/mc-manage@v1.1.4
 pycountry==22.3.*
 django-background-tasks-updated==1.2.* # need >= 1.2.6


### PR DESCRIPTION
infrastructure already in place, uncomments a line of code!