### PR TITLE
handle empty url_search_string

### DIFF
--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -222,7 +222,7 @@ def _for_media_cloud(collections: List, sources: List, all_params: Dict) -> Dict
     domains = []
     # turn media ids into list of domains
     selected_sources = Source.objects.filter(id__in=sources)
-    domains += [s.name for s in selected_sources if s.url_search_string is None]
+    domains += [s.name for s in selected_sources if not s.url_search_string]
     # turn collections ids into list of domains
     selected_sources_in_collections = Source.objects.filter(collections__id__in=collections)
     selected_sources_in_collections = [s for s in selected_sources_in_collections if s.name is not None]


### PR DESCRIPTION
When url_search_string was an empty string (not NULL), domain wasn't being added to search!!!

This is a quick defensive fix: Ideally, the url_search_string column should always be NULL if not set
(there could be other, yet to be detected places where the empty string is causing trouble)!

All the other places in the same file are safe, but (IMO) use a verbose/clunky construct of converting the column to `bool` and then direct/identity comparisons to `False`, ie;

`bool(s.url_search_string) is False`

But `not bool(s.url_search_string)` identical in effect, and takes advantage of the fact that `bool(thing)` returns a boolean value (well, `bool` is a thin veneer over `int` -- `True + False == 1`)

Furthermore, anything evaluated for an `if` statement is implicitly evaluated for truthiness, as is anything passed to the `not` operator, so `not s.url_search_string` is ALSO identical, and even more concise, and `if s.url_search_string:` is identical to the the more verbose `if bool(s.url_search_string) is not False:`

```
    domains += [s.name for s in selected_sources_in_collections if bool(s.url_search_string) is False]
    # sources_with_url_search_strs += [s for s in selected_sources if bool(s.url_search_string) is not False]
    # sources_with_url_search_strs += [s for s in selected_sources_in_collections if bool(s.url_search_string) is not False]
    domains += [s.name for s in selected_sources if not s.url_search_string]
    domains += [s.name for s in selected_sources_in_collections if bool(s.url_search_string) is False]
    sources_with_url_search_strs += [s for s in selected_sources if bool(s.url_search_string) is not False
    sources_with_url_search_strs += [s for s in selected_sources_in_collections if bool(s.url_search_string) is not False
```

So feel free to change the change my change to match the rest, I just couldn't bring myself to write it that way!