### PR TITLE
EARLIEST_AVAILABLE_DATE handling changes (and more)

### DIFF
--- a/mcweb/.env-template
+++ b/mcweb/.env-template
@@ -27,8 +27,8 @@ DEBUG=True
 # Full URL to the primary database
 DATABASE_URL=postgres://USERNAME@localhost:5432/DB_NAME+
 
-# Earliest available date (unix) for Media Cloud elastic search
-EARLIEST_AVAILABLE_DATE="1609532591"
+# Earliest available date (ISO format) for Media Cloud elastic search
+EARLIEST_AVAILABLE_DATE=2020-01-01
 
 # Full URL of local redis cache
 REDIS_URL=redis://127.0.0.1:6379/1

--- a/mcweb/frontend/src/features/search/query/Search.jsx
+++ b/mcweb/frontend/src/features/search/query/Search.jsx
@@ -97,7 +97,6 @@ export default function Search({ queryIndex }) {
               {platform === PROVIDER_NEWS_WAYBACK_MACHINE && (
                 <Alert severity="warning">
                   Your dates have been limited to the range of available data.
-                  We are still working with the Wayback Machine to ingest the historical data.
                 </Alert>
               )}
               <SearchDatePicker queryIndex={queryIndex} />

--- a/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
+++ b/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
@@ -62,13 +62,6 @@ export default function SearchDatePicker({ queryIndex }) {
 
   // if the platform changes, we want to update the validity of the dates
   useEffect(() => {
-    const {
-      collections,
-      sources,
-      advanced,
-      platform,
-    } = queryState;
-
     // if the queries are empty, change the end date to the latest allowed end date per the platform
     if (isQueryStateEmpty(queryState)) {
       handleChangeToDate(maxDJS);

--- a/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
+++ b/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
@@ -10,37 +10,35 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import dayjs from 'dayjs';
 import { useSnackbar } from 'notistack';
 import { setQueryProperty } from './querySlice';
-import { earliestAllowedStartDate, latestAllowedEndDate } from '../util/platforms';
+import { earliestAllowedStartDate, latestAllowedEndDate, PROVIDER_NEWS_MEDIA_CLOUD } from '../util/platforms';
 import validateDate from '../util/dateValidation';
 import DefaultDates from './DefaultDates';
 import isQueryStateEmpty from '../util/isQueryStateEmpty';
-import getEarliestAvailableDate from '../util/dateHelpers';
 
 export default function SearchDatePicker({ queryIndex }) {
+  // US format date (use "L" format w/ dayjs LocalizedFormat?)
+  const dateFormat = 'MM/DD/YYYY';
+
   const dispatch = useDispatch();
   const { enqueueSnackbar } = useSnackbar();
-  const { earliestAvailableDate } = document.settings;
   const {
     platform, startDate, endDate, isFromDateValid, isToDateValid,
   } = useSelector((state) => state.query[queryIndex]);
 
   const queryState = useSelector((state) => state.query);
 
-  // the minimum date off platform (From Date Picker)
-  const fromDateMin = dayjs(earliestAllowedStartDate(platform)).format('MM/DD/YYYY');
-  // the maximum date based off platform (From Date Picker)
-  const fromDateMax = dayjs(latestAllowedEndDate(platform)).format('MM/DD/YYYY');
-  // the minumum date off platform (To Date Picker)
-  const toDateMin = dayjs(earliestAllowedStartDate(platform)).format('MM/DD/YYYY');
-  // the maximum date off platform (To Date Picker)
-  const toDateMax = dayjs(latestAllowedEndDate(platform)).format('MM/DD/YYYY');
+  // the minimum/maximum dates based on platform for both From and To dates
+  // XXX does this get reexcuted when platform changes???
+  const minDJS = earliestAllowedStartDate(platform); // dayjs
+  const maxDJS = latestAllowedEndDate(platform);     // dayjs
 
   // handler for the fromDate MUI DatePicker
   const handleChangeFromDate = (newValue) => {
-    if (validateDate(dayjs(newValue), dayjs(fromDateMin), dayjs(fromDateMax))) {
+    const newDJS = dayjs(newValue);
+    if (validateDate(newDJS, minDJS, maxDJS)) {
       // if the fromDate is valid, we are going to make this change in state and set the isFromDateValid to true
       dispatch(setQueryProperty({ isFromDateValid: true, queryIndex, property: 'isFromDateValid' }));
-      dispatch(setQueryProperty({ startDate: dayjs(newValue).format('MM/DD/YYYY'), queryIndex, property: 'startDate' }));
+      dispatch(setQueryProperty({ startDate: newDJS.format(dateFormat), queryIndex, property: 'startDate' }));
     } else {
       // we do not save the invalid date, if a user goes onto another tab, the previously valid date will be presented
       // if the date is invalid, we are going to set isToDateValid to false because the date provided is not valid
@@ -50,10 +48,11 @@ export default function SearchDatePicker({ queryIndex }) {
 
   // handler for the toDate MUI DatePicker
   const handleChangeToDate = (newValue) => {
-    if (validateDate(dayjs(newValue), dayjs(toDateMin), dayjs(toDateMax))) {
+    const newDJS = dayjs(newValue);
+    if (validateDate(newDJS, minDJS, maxDJS)) {
       // if the toDate is valid, we are going to make this change in state and set the isToDateValid to true
       dispatch(setQueryProperty({ isToDateValid: true, queryIndex, property: 'isToDateValid' }));
-      dispatch(setQueryProperty({ endDate: dayjs(newValue).format('MM/DD/YYYY'), queryIndex, property: 'endDate' }));
+      dispatch(setQueryProperty({ endDate: newDJS.format(dateFormat), queryIndex, property: 'endDate' }));
     } else {
       // we do not save the invalid date, if a user goes onto another tab, the previously valid date will be presented
       // if the date is invalid, we are going to set isToDateValid to false because the date provided is not valid
@@ -63,19 +62,26 @@ export default function SearchDatePicker({ queryIndex }) {
 
   // if the platform changes, we want to update the validity of the dates
   useEffect(() => {
+    const {
+      collections,
+      sources,
+      advanced,
+      platform,
+    } = queryState;
+
     // if the queries are empty, change the end date to the latest allowed end date per the platform
     if (isQueryStateEmpty(queryState)) {
-      handleChangeToDate(latestAllowedEndDate(platform));
+      handleChangeToDate(maxDJS);
     }
 
     // if the endDate is after than the latest allowed end date, change the end date to the latest allowed date
-    if (dayjs(endDate) > dayjs(toDateMax)) {
-      handleChangeToDate(latestAllowedEndDate(platform));
+    if (dayjs(endDate) > maxDJS) {
+      handleChangeToDate(maxDJS);
       enqueueSnackbar('We changed your end date to match this platform limit', { variant: 'warning' });
     }
     // if the endDate is earlier than the earliest allowed start date, change the start date to the earliest allowed date
-    if (dayjs(startDate) < dayjs(fromDateMin)) {
-      handleChangeFromDate(earliestAllowedStartDate(platform));
+    if (dayjs(startDate) < minDJS) {
+      handleChangeFromDate(minDJS);
       enqueueSnackbar('We changed your start date to match this platform limit', { variant: 'warning' });
     }
     // we don't save invalid dates, so going into another tab would leave these set to false and a correct date
@@ -85,10 +91,12 @@ export default function SearchDatePicker({ queryIndex }) {
 
   return (
     <>
-      <Alert severity="warning">
-        {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-        Reingest of historical data in progress. Search results available from present back to {getEarliestAvailableDate(earliestAvailableDate)}
-      </Alert>
+      {platform === PROVIDER_NEWS_MEDIA_CLOUD && (
+        <Alert severity="warning">
+          {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
+          Reingest of historical data in progress. Search results available from present back to {minDJS.format(dateFormat)}
+        </Alert>
+      )}
       <div className="date-picker-wrapper local-provider">
         <LocalizationProvider dateAdapter={AdapterDateFns}>
           <div className="date-accuracy-alert">
@@ -101,8 +109,8 @@ export default function SearchDatePicker({ queryIndex }) {
               onChange={handleChangeFromDate}
               disableFuture
               disableHighlightToday
-              minDate={dayjs(fromDateMin).toDate()}
-              maxDate={dayjs(fromDateMax).toDate()}
+              minDate={minDJS.toDate()}
+              maxDate={maxDJS.toDate()}
               renderInput={(params) => <TextField {...params} />}
             />
           </div>
@@ -116,8 +124,8 @@ export default function SearchDatePicker({ queryIndex }) {
               onChange={handleChangeToDate}
               disableFuture
               disableHighlightToday
-              minDate={dayjs(toDateMin).toDate()}
-              maxDate={dayjs(toDateMax).toDate()}
+              minDate={minDJS.toDate()}
+              maxDate={maxDJS.toDate()}
               renderInput={(params) => <TextField {...params} />}
             />
           </div>

--- a/mcweb/frontend/src/features/search/util/dateHelpers.js
+++ b/mcweb/frontend/src/features/search/util/dateHelpers.js
@@ -1,8 +1,0 @@
-import dayjs from 'dayjs';
-
-const getEarliestAvailableDate = (earliestAvailableDate) => {
-  const earliestDateObj = dayjs.unix(earliestAvailableDate);
-  return earliestDateObj.format('MM/DD/YYYY');
-};
-
-export default getEarliestAvailableDate;

--- a/mcweb/frontend/src/features/search/util/dateValidation.js
+++ b/mcweb/frontend/src/features/search/util/dateValidation.js
@@ -1,22 +1,13 @@
 import dayjs from 'dayjs';
 
 const validateDate = (currentDate, minDate, maxDate) => {
-  const daysBetweenMinAndtoDate = dayjs(currentDate).diff(dayjs(minDate), 'day');
+  // just in case, make sure dates are dayjs, then convert
+  // to Unix timestamp (int seconds since 1970-01-01)
+  const curr = dayjs(currentDate).unix();
+  const min = dayjs(minDate).unix();
+  const max = dayjs(maxDate).unix();
 
-  const daysBetweenToDateAndMax = dayjs(maxDate).diff(dayjs(currentDate), 'day');
-
-  const daysBetweenMinAndMax = dayjs(maxDate).diff(dayjs(minDate), 'day');
-
-  const currentYear = dayjs(currentDate).year();
-  const minYear = dayjs(minDate).year();
-  const maxYear = dayjs(maxDate).year();
-
-  const isCurrentYearInBetweenMinAndMax = currentYear >= minYear && currentYear <= maxYear;
-
-  const isCurrentDateInBetween = daysBetweenMinAndtoDate <= daysBetweenMinAndMax
-    && daysBetweenToDateAndMax <= daysBetweenMinAndMax;
-
-  return isCurrentYearInBetweenMinAndMax && isCurrentDateInBetween;
+  return curr >= min && curr <= max;
 };
 
 export default validateDate;

--- a/mcweb/frontend/src/features/search/util/platforms.js
+++ b/mcweb/frontend/src/features/search/util/platforms.js
@@ -1,5 +1,4 @@
 import dayjs from 'dayjs';
-import getEarliestAvailableDate from './dateHelpers';
 // keep in sync with mcweb/frontend/views.py
 export const PLATFORM_ONLINE_NEWS = 'onlinenews';
 
@@ -19,20 +18,20 @@ export const PROVIDER_NEWS_MEDIA_CLOUD = providerName(
   PLATFORM_SOURCE_MEDIA_CLOUD,
 );
 
-const { earliestAvailableDate } = document.settings;
+const { earliestAvailableDate } = document.settings; // MC earliest date
 
-// the latest allowed end date for the type of platform
+// the latest allowed end date for the type of platform as dayjs
 export const latestAllowedEndDate = (provider) => {
   const today = dayjs();
   if (provider === PROVIDER_NEWS_WAYBACK_MACHINE) return today.subtract('4', 'day');
-  if (provider === PROVIDER_NEWS_MEDIA_CLOUD) return today.subtract('1', 'day');
+  // allowing today for PROVIDER_NEWS_MEDIA_CLOUD
   return today;
 };
 
-// the earliest starting date for the type of platform
+// the earliest starting date for the type of platform as dayjs
 export const earliestAllowedStartDate = (provider) => {
   if (provider === PROVIDER_NEWS_WAYBACK_MACHINE) return dayjs('2022-08-01');
-  return getEarliestAvailableDate(earliestAvailableDate);
+  return dayjs(earliestAvailableDate);
 };
 
 export const defaultPlatformProvider = (platform) => {

--- a/mcweb/frontend/templates/frontend/index.html
+++ b/mcweb/frontend/templates/frontend/index.html
@@ -21,7 +21,7 @@
             {% else %}
                 document.settings.systemAlert = undefined;
             {% endif %}
-            document.settings.earliestAvailableDate = {{earliest_available_date|safe}};    
+            document.settings.earliestAvailableDate = "{{earliest_available_date|safe}}";
             document.settings.allUrlsCsvEmailMax = {{all_urls_csv_email_max|safe}};
             document.settings.allUrlsCsvEmailMin = {{all_urls_csv_email_min|safe}};
         </script>

--- a/mcweb/frontend/views.py
+++ b/mcweb/frontend/views.py
@@ -1,6 +1,7 @@
 # Python
 import logging
 import os
+import time
 
 # PyPI
 import mc_providers
@@ -24,6 +25,11 @@ from settings import (
 
 logger = logging.getLogger(__name__)
 
+# TEMPORARY! convert Unix timestamp to ISO date
+_EARLIEST_AVAILABLE_DATE = EARLIEST_AVAILABLE_DATE
+if _EARLIEST_AVAILABLE_DATE.isdigit(): # all digits?
+    _EARLIEST_AVAILABLE_DATE = time.strftime("%Y-%m-%d", time.gmtime(int(_EARLIEST_AVAILABLE_DATE)))
+
 @ensure_csrf_cookie
 def index(request):
     # the main entry point for the web app - it just renders the index HTML file to load all the JS
@@ -34,7 +40,7 @@ def index(request):
         all_urls_csv_email_min=ALL_URLS_CSV_EMAIL_MIN,
         analytics_matomo_domain=ANALYTICS_MATOMO_DOMAIN,
         analytics_matomo_id=ANALYTICS_MATOMO_SITE_ID,
-        earliest_available_date=EARLIEST_AVAILABLE_DATE,
+        earliest_available_date=_EARLIEST_AVAILABLE_DATE,
         system_alert=SYSTEM_ALERT,
         sentry_config={
             "sentry_dsn": (SENTRY_DSN or "null"),


### PR DESCRIPTION
Evan:
The 2020 historical ingest is in progress (December and November complete, and adding a month every two days), so I looked at updating EARLIEST_AVAILABLE_DATE, and thought "I love Unix TS as much or more than the next person, but this isn't a friendly place to use them!"

I'm not at ALL sure the min/maxDJS variables will be correct at all times (or if they are, I'm not sure I understand why), so PLEASE look at it carefully before assuming I knew what I was doing, and don't be shy about asking me questions or suggesting changes!!!!!! 

* accept Unix TS or ISO date (YYYY-MM-DD) [for now]
* document.settings.earliestAvailableDate is now string
* update dev config for 2020 historical ingest

As usual, much more, semi-related changes:

SearchDatePicker tweaks:
* remove "We are still working with the Wayback Machine" message
* centralize dateFormat (add comment about localization)
* remove direct access to settings.earliestAvailableDate
* keep min/max dates in dayjs format (avoid reparsing)
* parse newValue once in change handlers
* Only display "Reingest of historical data in progress" for MC
  (was displaying MC start date for Wayback Machine?)

More date-related simplification:
* removed mcweb/frontend/src/features/search/util/dateHelpers.js
* use dayjs.unix() to simplify validateDate function