### PR TITLE
Fix bug where bar would not show with one result

### DIFF
--- a/mcweb/frontend/src/features/search/results/BarChart.jsx
+++ b/mcweb/frontend/src/features/search/results/BarChart.jsx
@@ -4,7 +4,7 @@ import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import exporting from 'highcharts/modules/exporting';
 
-exporting(Highcharts);
+// exporting(Highcharts);
 
 export default function BarChart({
   normalized, height, title, series,
@@ -48,6 +48,7 @@ export default function BarChart({
     series: series.map((s) => ({
       color: s.color,
       name: s.name,
+      minPointLength: 20,
       data: s.data.map((d) => ({
         y: d.value,
         dataLabels: {

--- a/mcweb/frontend/src/features/search/results/TopLanguages.jsx
+++ b/mcweb/frontend/src/features/search/results/TopLanguages.jsx
@@ -5,7 +5,6 @@ import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Alert from '@mui/material/Alert';
-import Chip from '@mui/material/Chip';
 import BarChart from './BarChart';
 import CSVDialog from '../util/CSVDialog';
 import { LANG } from '../util/getDownloadUrl';
@@ -92,7 +91,7 @@ export default function TopLanguages() {
                   series={[results]}
                   normalized
                   title="Top Languages"
-                  height={100 + (results.data.length * 40)}
+                  height={120 + (results.data.length * 40)}
                 />
               </TabPanelHelper>
             ))}
@@ -121,8 +120,7 @@ export default function TopLanguages() {
       <div className="row">
         <div className="col-4">
           <h2>
-            {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-            Top Languages <Chip color="warning" label="experimental" />
+            Top Languages
           </h2>
           <p>
             {/* eslint-disable-next-line react/jsx-one-expression-per-line */}

--- a/mcweb/frontend/src/features/search/results/TopSources.jsx
+++ b/mcweb/frontend/src/features/search/results/TopSources.jsx
@@ -9,7 +9,6 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Settings from '@mui/icons-material/Settings';
 import Alert from '@mui/material/Alert';
-import Chip from '@mui/material/Chip';
 import BarChart from './BarChart';
 import CSVDialog from '../util/CSVDialog';
 import TabPanelHelper from '../../ui/TabPanelHelper';
@@ -102,7 +101,7 @@ export default function TopSources() {
                 series={[results]}
                 normalized={normalized}
                 title="Top Sources"
-                height={100 + (results.data.length * 40)}
+                height={120 + (results.data.length * 40)}
               />
             </TabPanelHelper>
           ))}
@@ -188,8 +187,7 @@ export default function TopSources() {
       <div className="row">
         <div className="col-4">
           <h2>
-            {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-            Top Sources <Chip color="warning" label="experimental" />
+            Top Sources
           </h2>
           <p>
             {/* eslint-disable-next-line react/jsx-one-expression-per-line */}


### PR DESCRIPTION
- Fix bug where if there was one result in a bar chart, the bar would not show
![Screen Shot 2024-10-24 at 2 14 17 PM](https://github.com/user-attachments/assets/4b6acf0b-9030-4b38-b9d2-21e9401cd96a)
closes #597

- remove `experimental` chip from Top Languages and Top Sources
![Screen Shot 2024-10-24 at 2 14 46 PM](https://github.com/user-attachments/assets/9bcaeb83-4c08-466e-b61e-73fc88e4d942)
closes #759 

- remove option in highcharts to export, it looks like we have been blocked by them from accessing their server to export. We likely we need to make our own exporting server, But I guess screenshots are workable (?)