### PR TITLE
mcweb/backend/search/views.py: delete text in story_detail if not user.is_staff!

### DIFF
--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -142,6 +142,8 @@ def story_detail(request):
     provider = pq_provider(pq, platform)
     story_details = provider.item(story_id)
     QuotaHistory.increment(request.user.id, request.user.is_staff, pq.provider_name)
+    if not request.user.is_staff: # maybe some group membership?
+        del story_details['text']
     return HttpResponse(json.dumps({"story": story_details}, default=str), content_type="application/json",
                         status=200)
 


### PR DESCRIPTION
I was able to get full text as an ordinary user before I added this.

Fortunately(!) story retrieval is broken in production (perhaps in my "parsed query" changes?), but should be working in staging.  This fix is present in pbudne-mcweb.ifill.angwin