### PR TITLE
quota.check method, invocation /before/ expensive backend calls to raise quota errors in a more useful way

### DIFF
--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -84,6 +84,7 @@ def handle_provider_errors(func):
 def total_count(request):
     pq = parse_query(request)
     provider = pq_provider(pq)
+    QuotaHistory.check(request.user.id, request.user.is_staff, pq.provider_name)
     relevant_count = provider.count(f"({pq.query_str})", pq.start_date, pq.end_date, **pq.provider_props)
     try:
         total_content_count = provider.count(provider.everything_query(), pq.start_date, pq.end_date, **pq.provider_props)
@@ -103,6 +104,7 @@ def total_count(request):
 def count_over_time(request):
     pq = parse_query(request)
     provider = pq_provider(pq)
+    QuotaHistory.check(request.user.id, request.user.is_staff, pq.provider_name)
     try:
         results = provider.normalized_count_over_time(f"({pq.query_str})", pq.start_date, pq.end_date, **pq.provider_props)
     except UnsupportedOperationException:
@@ -122,6 +124,7 @@ def count_over_time(request):
 def sample(request):
     pq = parse_query(request)
     provider = pq_provider(pq)
+    QuotaHistory.check(request.user.id, request.user.is_staff, pq.provider_name)
     try:
         response = provider.sample(f"({pq.query_str})", pq.start_date, pq.end_date, **pq.provider_props)
     except requests.exceptions.ConnectionError:
@@ -137,6 +140,7 @@ def sample(request):
 # @cache_by_kwargs()
 def story_detail(request):
     pq, params = parse_query_params(request) # unlikely to handle POST!
+    QuotaHistory.check(request.user.id, request.user.is_staff, pq.provider_name)
     story_id = params.get("storyId")
     platform = params.get("platform")
     provider = pq_provider(pq, platform)
@@ -153,6 +157,7 @@ def story_detail(request):
 def sources(request):
     pq = parse_query(request)
     provider = pq_provider(pq)
+    QuotaHistory.check(request.user.id, request.user.is_staff, pq.provider_name)
     try:
         response = provider.sources(f"({pq.query_str})", pq.start_date, pq.end_date, 10, **pq.provider_props)
     except requests.exceptions.ConnectionError:
@@ -166,8 +171,9 @@ def sources(request):
 def download_sources_csv(request):
     queries = parsed_query_state(request) # handles POST!
     pq = queries[0]
-
     provider = pq_provider(pq)
+    QuotaHistory.check(request.user.id, request.user.is_staff, pq.provider_name)
+    
     try:
         data = provider.sources(f"({pq.query_str})", pq.start_date,
                     pq.end_date, **pq.provider_props, sample_size=5000, limit=100)
@@ -195,6 +201,8 @@ def download_sources_csv(request):
 def languages(request):
     pq = parse_query(request)
     provider = pq_provider(pq)
+    QuotaHistory.check(request.user.id, request.user.is_staff, pq.provider_name)
+
     try:
         response = provider.languages(f"({pq.query_str})", pq.start_date, pq.end_date, **pq.provider_props)
     except requests.exceptions.ConnectionError:
@@ -210,6 +218,8 @@ def download_languages_csv(request):
     queries = parsed_query_state(request) # handles POST!
     pq = queries[0]
     provider = pq_provider(pq)
+    QuotaHistory.check(request.user.id, request.user.is_staff, pq.provider_name)
+
     try:
         data = provider.languages(f"({pq.query_str})", pq.start_date,
                     pq.end_date, **pq.provider_props, sample_size=5000, limit=100)
@@ -235,6 +245,8 @@ def download_languages_csv(request):
 def story_list(request):
     pq = parse_query(request)
     provider = pq_provider(pq)
+    QuotaHistory.check(request.user.id, request.user.is_staff, pq.provider_name)
+
     # support returning text content for staff only
     if pq.provider_props.get('expanded') is not None:
         pq.provider_props['expanded'] = pq.provider_props['expanded'] == '1'
@@ -255,6 +267,7 @@ def story_list(request):
 def words(request):
     pq = parse_query(request)
     provider = pq_provider(pq)
+    QuotaHistory.check(request.user.id, request.user.is_staff, pq.provider_name)
     try:
         words = provider.words(f"({pq.query_str})", pq.start_date, pq.end_date, **pq.provider_props)
     except requests.exceptions.ConnectionError:
@@ -272,6 +285,7 @@ def download_words_csv(request):
     queries = parsed_query_state(request) # handles POST!
     pq = queries[0]
     provider = pq_provider(pq)
+    QuotaHistory.check(request.user.id, request.user.is_staff, pq.provider_name)
     try:
         words = provider.words(f"({pq.query_str})", pq.start_date,
                                 pq.end_date, **pq.provider_props, sample_size=5000)
@@ -297,6 +311,7 @@ def download_counts_over_time_csv(request):
     queries = parsed_query_state(request) # handles POST!
     pq = queries[0]
     provider = pq_provider(pq)
+    QuotaHistory.check(request.user.id, request.user.is_staff, pq.provider_name)
     try:
         data = provider.normalized_count_over_time(
             f"({pq.query_str})", pq.start_date, pq.end_date, **pq.provider_props)

--- a/mcweb/backend/users/models.py
+++ b/mcweb/backend/users/models.py
@@ -88,6 +88,15 @@ class QuotaHistory(models.Model):
                                                                week=cls._this_week())
         return matching
 
+
+    @classmethod
+    def check(cls, user_id: int, is_staff:bool, provider:str):
+        matching = cls.current_for(user_id, provider)
+        quota = Profile.user_provider_quota(user_id, provider)
+        if (quota <= matching.hits) and not is_staff:
+            raise OverQuotaException(provider, quota)
+        return matching.hits
+
     @classmethod
     def increment(cls, user_id: int, is_staff: bool, provider: str, amount: int = 1) -> int:
         matching = cls.current_for(user_id, provider)


### PR DESCRIPTION
As written, hopefully an uncontroversial change. 