### PR TITLE
Update 'Compare Across the Globe' to Focus on English-Speaking Countries and Add (EN) Label

### DIFF
--- a/mcweb/frontend/src/features/search/util/generateComparativeQuery.js
+++ b/mcweb/frontend/src/features/search/util/generateComparativeQuery.js
@@ -4,8 +4,8 @@ export const REGIONAL = 'regional';
 
 const partisanCollections = [231013063, 231013089, 231013108, 231013109, 231013110];
 const partisanCollectionsNames = ['left', 'center left', 'center', 'center right', 'right'];
-const globalCollections = [34412234, 34412476, 38376341, 34412356, 34412409, 34412146, 34412257, 34412118];
-const globalCollectionsNames = ['united states', 'united kingdom', 'nigeria', 'spain', 'germany', 'france', 'brazil', 'india'];
+const globalCollections = [34412234, 34412476, 34412118, 34412282, 34412126, 34412313, 34412238];
+const globalCollectionsNames = ['united states', 'united kingdom', 'india', 'australia', 'kenya', 'philippines', 'south africa'];
 const regionalCollections = [];
 const regionalCollectionsNames = [];
 

--- a/mcweb/frontend/src/features/ui/TabDropDownMenu.jsx
+++ b/mcweb/frontend/src/features/ui/TabDropDownMenu.jsx
@@ -75,7 +75,7 @@ export default function TabDropDownMenuItems({
           setColorSubMenuOpen(false);
         }}
         >
-          Compare Across the Globe
+          Compare Across the Globe(EN)
         </MenuItem>
 
         {/* Add Color Option */}

--- a/mcweb/frontend/src/features/ui/TabDropDownMenu.jsx
+++ b/mcweb/frontend/src/features/ui/TabDropDownMenu.jsx
@@ -75,7 +75,7 @@ export default function TabDropDownMenuItems({
           setColorSubMenuOpen(false);
         }}
         >
-          Compare Across the Globe(EN)
+          Compare Across the Globe (EN)
         </MenuItem>
 
         {/* Add Color Option */}


### PR DESCRIPTION
Updated the "Compare Across the Globe" tab to include only English-speaking countries, ensuring the query results align with user expectations.
This is shown in the screenshot.
This PR is related to issue #843 .
<img width="273" alt="Screenshot 2024-11-20 at 15 42 54" src="https://github.com/user-attachments/assets/cf440c20-569c-4cdf-ad6c-39093d1a80ab">
<img width="1085" alt="Screenshot 2024-11-20 at 15 43 05" src="https://github.com/user-attachments/assets/e4f22619-c6e2-43f5-9455-c9a354ab363e">
