### PR TITLE
add query improvement

### DIFF
--- a/mcweb/frontend/src/features/search/query/querySlice.js
+++ b/mcweb/frontend/src/features/search/query/querySlice.js
@@ -145,23 +145,24 @@ const querySlice = createSlice({
     },
     addQuery: (state, { payload }) => {
       const freezeState = state;
+      const lastQuery = freezeState[freezeState.length - 1] || {};
       freezeState.push(
         {
           queryString: '',
           queryList: [[], [], []],
           negatedQueryList: [[], [], []],
-          platform: payload.platform,
-          startDate,
-          endDate: dayjs(latestAllowedEndDate(DEFAULT_PROVIDER)).format('MM/DD/YYYY'),
-          collections: [],
-          previewCollections: [],
-          sources: [],
-          previewSources: [],
+          platform: payload.platform || lastQuery.platform || DEFAULT_PROVIDER,
+          startDate: lastQuery.startDate || startDate,
+          endDate: lastQuery.endDate || dayjs(latestAllowedEndDate(DEFAULT_PROVIDER)).format('MM/DD/YYYY'),
+          collections: [...(lastQuery.collections || [])],
+          previewCollections: [...(lastQuery.previewCollections || [])],
+          sources: [...(lastQuery.sources || [])],
+          previewSources: [...(lastQuery.previewSources || [])],
           lastSearchTime: dayjs().unix(),
           isFromDateValid: true,
           isToDateValid: true,
           anyAll: 'any',
-          advanced: payload.advanced,
+          advanced: payload.advanced || false,
           name: 'Query',
           edited: false,
         },


### PR DESCRIPTION
Change the behavior when adding a query. When adding a query the query maintain the dates and media of the original query, but the query terms are blank.
The result is shown in the image below.
<img width="1278" alt="Screenshot 2024-11-22 at 12 20 26" src="https://github.com/user-attachments/assets/2491b13b-04cc-4b04-887c-c38c46e5a4d0">


<img width="1232" alt="Screenshot 2024-11-22 at 12 20 37" src="https://github.com/user-attachments/assets/1cf9e037-077d-449c-86ca-51d09e0a7b6b">

related to https://github.com/mediacloud/web-search/issues/845