### PR TITLE
Stop request_logger proprogation, Add response data to requests.log

### DIFF
--- a/mcweb/util/logging_middleware.py
+++ b/mcweb/util/logging_middleware.py
@@ -6,6 +6,10 @@ from constance import config
 import json
 request_logger = logging.getLogger("request_logger")
 
+# prevent request messages from "bleeding"
+# (in the color/audio sense) into root logger
+request_logger.propagate = False
+
 class RequestLoggingMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
@@ -47,6 +51,11 @@ class RequestLoggingMiddleware:
             exclude_headers = ["Cookie", "X-Csrftoken"]
             log_msg["headers"] = {key: value for key, value in request.headers.items() if key not in exclude_headers}
             log_msg["has_session"] = "sessionid" in request.headers.get("Cookie", {})
+
+            log_msg["response"] = {
+                "code": response.status_code,
+                "reason": response.reason_phrase,
+            }
 
             # Log the request details
             request_logger.info(json.dumps(log_msg))


### PR DESCRIPTION
Set `request_logger.propagate = False` so that requests_logger messages don't appear in messages.log

Add "response" sub-object with "code" and "resason" to requests.log
