### PR TITLE
Less text on search errors

### DIFF
--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -10,7 +10,6 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseBadRequest, HttpResponseForbidden, HttpResponse
 from django_ratelimit.decorators import ratelimit
 from django.views.decorators.http import require_http_methods
-from rest_framework.exceptions import APIException
 from mc_providers.exceptions import UnsupportedOperationException, QueryingEverythingUnsupportedQuery
 from mc_providers.exceptions import ProviderException
 from rest_framework.authentication import SessionAuthentication, TokenAuthentication

--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -94,6 +94,10 @@ def total_count(request):
         total_content_count = None
     except requests.exceptions.ConnectionError:
         raise APIException("Search service is currently unavailable. This may be due to a temporary timeout or server issue. Please try again in a few moments.", 504)
+    except RuntimeError: # catches the RuntimeError 500 a bad query string could have triggered this ...
+        raise APIException("Search service is currently unavailable. This may be due to a temporary timeout or server issue. Please try again in a few moments.", 504)
+    except Exception:
+        raise APIException("Search service is currently unavailable. This may be due to a temporary timeout or server issue. Please try again in a few moments.", 504)
     QuotaHistory.increment(request.user.id, request.user.is_staff, pq.provider_name)
     return HttpResponse(json.dumps({"count": {"relevant": relevant_count, "total": total_content_count}}),
                         content_type="application/json", status=200)
@@ -116,6 +120,10 @@ def count_over_time(request):
         results = provider.count_over_time(f"({pq.query_str})", pq.start_date, pq.end_date, **pq.provider_props)
     except requests.exceptions.ConnectionError:
         raise APIException("Search service is currently unavailable. This may be due to a temporary timeout or server issue. Please try again in a few moments.", 504)
+    except RuntimeError: # catches the RuntimeError 500 a bad query string could have triggered this ...
+        raise APIException("Search service is currently unavailable. This may be due to a temporary timeout or server issue. Please try again in a few moments.", 504)
+    except Exception:
+        raise APIException("Search service is currently unavailable. This may be due to a temporary timeout or server issue. Please try again in a few moments.", 504)
     response = results
     QuotaHistory.increment(
         request.user.id, request.user.is_staff, pq.provider_name)
@@ -134,7 +142,11 @@ def sample(request):
     try:
         response = provider.sample(f"({pq.query_str})", pq.start_date, pq.end_date, **pq.provider_props)
     except requests.exceptions.ConnectionError:
-        response = {'error': 'Max Retries Exceeded'}
+        raise APIException("Search service is currently unavailable. This may be due to a temporary timeout or server issue. Please try again in a few moments.", 504)
+    except RuntimeError: # catches the RuntimeError 500 a bad query string could have triggered this ...
+        raise APIException("Search service is currently unavailable. This may be due to a temporary timeout or server issue. Please try again in a few moments.", 504)
+    except Exception:
+        raise APIException("Search service is currently unavailable. This may be due to a temporary timeout or server issue. Please try again in a few moments.", 504)
     QuotaHistory.increment(request.user.id, request.user.is_staff, pq.provider_name)
     return HttpResponse(json.dumps({"sample": response}, default=str), content_type="application/json",
                         status=200)
@@ -169,7 +181,11 @@ def sources(request):
     try:
         response = provider.sources(f"({pq.query_str})", pq.start_date, pq.end_date, 10, **pq.provider_props)
     except requests.exceptions.ConnectionError:
-        response = {'error': 'Max Retries Exceeded'}
+        raise APIException("Search service is currently unavailable. This may be due to a temporary timeout or server issue. Please try again in a few moments.", 504)
+    except RuntimeError: # catches the RuntimeError 500 a bad query string could have triggered this ...
+        raise APIException("Search service is currently unavailable. This may be due to a temporary timeout or server issue. Please try again in a few moments.", 504)
+    except Exception:
+        raise APIException("Search service is currently unavailable. This may be due to a temporary timeout or server issue. Please try again in a few moments.", 504)
     QuotaHistory.increment(request.user.id, request.user.is_staff, pq.provider_name, 4)
     return HttpResponse(json.dumps({"sources": response}, default=str), content_type="application/json",
                         status=200)
@@ -214,7 +230,11 @@ def languages(request):
     try:
         response = provider.languages(f"({pq.query_str})", pq.start_date, pq.end_date, **pq.provider_props)
     except requests.exceptions.ConnectionError:
-        response = {'error': 'Max Retries Exceeded'}
+        raise APIException("Search service is currently unavailable. This may be due to a temporary timeout or server issue. Please try again in a few moments.", 504)
+    except RuntimeError: # catches the RuntimeError 500 a bad query string could have triggered this ...
+        raise APIException("Search service is currently unavailable. This may be due to a temporary timeout or server issue. Please try again in a few moments.", 504)
+    except Exception:
+        raise APIException("Search service is currently unavailable. This may be due to a temporary timeout or server issue. Please try again in a few moments.", 504)
     QuotaHistory.increment(request.user.id, request.user.is_staff, pq.provider_name, 2)
     return HttpResponse(json.dumps({"languages": response}, default=str), content_type="application/json",
                         status=200)
@@ -280,7 +300,11 @@ def words(request):
     try:
         words = provider.words(f"({pq.query_str})", pq.start_date, pq.end_date, **pq.provider_props)
     except requests.exceptions.ConnectionError:
-        response = {'error': 'Max Retries Exceeded'}
+        raise APIException("Search service is currently unavailable. This may be due to a temporary timeout or server issue. Please try again in a few moments.", 504)
+    except RuntimeError: # catches the RuntimeError 500 a bad query string could have triggered this ...
+        raise APIException("Search service is currently unavailable. This may be due to a temporary timeout or server issue. Please try again in a few moments.", 504)
+    except Exception:
+        raise APIException("Search service is currently unavailable. This may be due to a temporary timeout or server issue. Please try again in a few moments.", 504)
     response = add_ratios(words)
     QuotaHistory.increment(request.user.id, request.user.is_staff, pq.provider_name, 4)
     return HttpResponse(json.dumps({"words": response}, default=str), content_type="application/json",

--- a/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
+++ b/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
@@ -85,10 +85,9 @@ export default function CountOverTimeResults() {
   if (error) {
     content = (
       <Alert severity="warning">
-        {console.log(error)}
         Sorry, but something went wrong.
         (
-        {error.note}
+        {error.detail}
         )
       </Alert>
     );

--- a/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
+++ b/mcweb/frontend/src/features/search/results/CountOverTimeResults.jsx
@@ -85,6 +85,7 @@ export default function CountOverTimeResults() {
   if (error) {
     content = (
       <Alert severity="warning">
+        {console.log(error)}
         Sorry, but something went wrong.
         (
         {error.note}

--- a/mcweb/frontend/src/features/search/results/SampleStories.jsx
+++ b/mcweb/frontend/src/features/search/results/SampleStories.jsx
@@ -69,7 +69,7 @@ export default function SampleStories() {
       <Alert severity="warning">
         Sorry, but something went wrong.
         (
-        {error ? error.note : 'No results please try a different query'}
+        {error ? error.detail : 'No results please try a different query'}
         )
       </Alert>
     );

--- a/mcweb/frontend/src/features/search/results/TopLanguages.jsx
+++ b/mcweb/frontend/src/features/search/results/TopLanguages.jsx
@@ -61,7 +61,7 @@ export default function TopLanguages() {
       <Alert severity="warning">
         Sorry, but something went wrong.
         (
-        {error ? error.note : 'No results please try a different query'}
+        {error ? error.detail : 'No results please try a different query'}
         )
       </Alert>
     );

--- a/mcweb/frontend/src/features/search/results/TopSources.jsx
+++ b/mcweb/frontend/src/features/search/results/TopSources.jsx
@@ -72,7 +72,7 @@ export default function TopSources() {
       <Alert severity="warning">
         Sorry, but something went wrong.
         (
-        {error ? error.note : 'No results please try a different query'}
+        {error ? error.detail : 'No results please try a different query'}
         )
       </Alert>
     );

--- a/mcweb/frontend/src/features/search/results/TopWords.jsx
+++ b/mcweb/frontend/src/features/search/results/TopWords.jsx
@@ -64,7 +64,7 @@ export default function TopWords() {
       <Alert severity="warning">
         Sorry, but something went wrong.
         (
-        {error ? error.note : 'No results please try a different query'}
+        {error ? error.detail : 'No results please try a different query'}
         )
       </Alert>
     );
@@ -89,6 +89,7 @@ export default function TopWords() {
               </Tabs>
             </Box>
             {data.map((results, i) => (
+              // eslint-disable-next-line react/no-array-index-key
               <TabPanelHelper value={value} index={i} key={`words-key-${i}`}>
                 <OrderedWordCloud width={600} color="#000" data={results.words} />
               </TabPanelHelper>

--- a/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
+++ b/mcweb/frontend/src/features/search/results/TotalAttentionResults.jsx
@@ -86,7 +86,7 @@ function TotalAttentionResults() {
       <Alert severity="warning">
         Sorry, but something went wrong.
         (
-        {error.note}
+        {error.detail}
         )
       </Alert>
     );

--- a/mcweb/frontend/src/features/search/util/platforms.js
+++ b/mcweb/frontend/src/features/search/util/platforms.js
@@ -25,7 +25,7 @@ export const latestAllowedEndDate = (provider) => {
   const today = dayjs();
   if (provider === PROVIDER_NEWS_WAYBACK_MACHINE) return today.subtract('4', 'day');
   // allowing today for PROVIDER_NEWS_MEDIA_CLOUD
-  return today;
+  return today.subtract('1', 'day');
 };
 
 // the earliest starting date for the type of platform as dayjs

--- a/mcweb/frontend/src/features/ui/TabDropDownMenu.jsx
+++ b/mcweb/frontend/src/features/ui/TabDropDownMenu.jsx
@@ -1,12 +1,9 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import MenuItem from '@mui/material/MenuItem';
 import Menu from '@mui/material/Menu';
-import CircleIcon from '@mui/icons-material/Circle';
 import PropTypes from 'prop-types';
-import ArrowRight from '@mui/icons-material/ArrowRight';
-import CloseIcon from '@mui/icons-material/Close';
 import { PARTISAN, GLOBAL } from '../search/util/generateComparativeQuery';
 import { PROVIDER_NEWS_MEDIA_CLOUD } from '../search/util/platforms';
 
@@ -16,34 +13,34 @@ export default function TabDropDownMenuItems({
   anchorEl, open, handleClose, handleMenuOpen, handleComparative,
 }) {
   const platform = useSelector((state) => state.query[0].platform);
-  const [colorSubMenuOpen, setColorSubMenuOpen] = useState(false);
+  // const [colorSubMenuOpen, setColorSubMenuOpen] = useState(false);
 
-  const handleMouseEnter = () => {
-    setColorSubMenuOpen(true);
-  };
+  // const handleMouseEnter = () => {
+  //   setColorSubMenuOpen(true);
+  // };
 
-  const closeColorSubMenu = (event, color) => {
-    handleClose(color);
-    setColorSubMenuOpen(false);
-  };
+  // const closeColorSubMenu = (event, color) => {
+  //   handleClose(color);
+  //   setColorSubMenuOpen(false);
+  // };
 
-  const colorMenuSizing = () => {
-    if (platform === PROVIDER_NEWS_MEDIA_CLOUD) {
-      return {
-        vertical: -15,
-        horizontal: -232,
-      };
-    }
-    return {
-      vertical: -15,
-      horizontal: -122.5,
-    };
-  };
+  // const colorMenuSizing = () => {
+  //   if (platform === PROVIDER_NEWS_MEDIA_CLOUD) {
+  //     return {
+  //       vertical: -15,
+  //       horizontal: -232,
+  //     };
+  //   }
+  //   return {
+  //     vertical: -15,
+  //     horizontal: -122.5,
+  //   };
+  // };
 
   // mouse leaves main menu
-  const handleMouseLeave = () => {
-    setColorSubMenuOpen(false);
-  };
+  // const handleMouseLeave = () => {
+  //   setColorSubMenuOpen(false);
+  // };
   return (
     <div>
       <MoreVertIcon
@@ -62,7 +59,7 @@ export default function TabDropDownMenuItems({
         {platform === PROVIDER_NEWS_MEDIA_CLOUD && (
         <MenuItem onClick={() => {
           handleComparative(PARTISAN);
-          setColorSubMenuOpen(false);
+          // setColorSubMenuOpen(false);
         }}
         >
           Compare Across Partisanship
@@ -72,7 +69,7 @@ export default function TabDropDownMenuItems({
         {/* compare across the globe, temp disabled until 504 solution */}
         <MenuItem onClick={() => {
           handleComparative(GLOBAL);
-          setColorSubMenuOpen(false);
+          // setColorSubMenuOpen(false);
         }}
         >
           Compare Across the Globe (EN)
@@ -90,7 +87,7 @@ export default function TabDropDownMenuItems({
         {/* Edit Tab Name Option */}
         <MenuItem onClick={() => {
           handleClose('edit');
-          setColorSubMenuOpen(false);
+          // setColorSubMenuOpen(false);
         }}
         >
           Edit Tab Name
@@ -98,10 +95,10 @@ export default function TabDropDownMenuItems({
       </Menu>
 
       {/* Color Submenu */}
-      <Menu
+      {/* <Menu
         hideBackdrop
         style={{ pointerEvents: 'none' }}
-        open={colorSubMenuOpen && open && Boolean(anchorEl)}
+        open={open && Boolean(anchorEl)}
         anchorEl={anchorEl}
         onMouseEnter={() => {
           if (colorSubMenuOpen && open && Boolean(anchorEl)) {
@@ -139,16 +136,20 @@ export default function TabDropDownMenuItems({
             <CloseIcon />
           </MenuItem>
         </div>
-      </Menu>
+      </Menu> */}
     </div>
   );
 }
 
 TabDropDownMenuItems.propTypes = {
   // eslint-disable-next-line react/forbid-prop-types
-  anchorEl: PropTypes.any.isRequired, // either null or svg
+  anchorEl: PropTypes.any, // either null or svg
   open: PropTypes.bool.isRequired,
   handleClose: PropTypes.func.isRequired,
   handleMenuOpen: PropTypes.func.isRequired,
   handleComparative: PropTypes.func.isRequired,
+};
+
+TabDropDownMenuItems.defaultProps = {
+  anchorEl: null,
 };

--- a/mcweb/frontend/src/features/ui/TabPanelHelper.jsx
+++ b/mcweb/frontend/src/features/ui/TabPanelHelper.jsx
@@ -14,11 +14,12 @@ export default function TabPanelHelper(props) {
       hidden={value !== index}
       id={`simple-tabpanel-${index}`}
       aria-labelledby={`simple-tab-${index}`}
+      // eslint-disable-next-line react/jsx-props-no-spreading
       {...other}
     >
       {value === index && (
         <Box sx={{ p: 3 }}>
-          <Typography>{children}</Typography>
+          <Typography component="span">{children}</Typography>
         </Box>
       )}
     </div>


### PR DESCRIPTION
- Catch the timeout error that usually has the very long error message "a bad query string may have caused this, then lists all the sources.
- New error: 
![Screen Shot 2024-12-20 at 9 52 41 AM](https://github.com/user-attachments/assets/e95ebb28-1cee-4b13-acb4-e125e5080758)

Would appreciate feedback if this is a fine error message

- fixed warnings about domnesting

- update MC most recent searchable date to be yesterday