### PR TITLE
requirements.txt: change mc-providers>=2.2.0 to mc-provider==2.2.*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ whitenoise==6.2.*
 sentry-sdk==1.39.*
 requests  # let the other dependencies sort out which is the right version
 fasttext==0.9.*
-mc-providers>=2.2.0
+mc-providers==2.2.*
 mc-manage @ git+https://github.com/mediacloud/mc-manage@v1.1.4
 pycountry==22.3.*
 django-background-tasks-updated==1.2.* # need >= 1.2.6


### PR DESCRIPTION
to avoid any possible breakage by new version of providers (version with ES support will be 3.0)