### PR TITLE
fixes for error handling found while running "daily metrics" queries

### DIFF
--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -1,6 +1,7 @@
 # Python
 import datetime as dt
 import json
+import logging
 import time
 from collections import defaultdict
 from typing import Any, Callable, Dict, Generator, Iterable, List, Mapping, NamedTuple, Optional, Tuple
@@ -18,6 +19,8 @@ from settings import ALL_URLS_CSV_EMAIL_MAX, ALL_URLS_CSV_EMAIL_MIN, NEWS_SEARCH
 
 # mcweb/backend/users
 from ..users.models import QuotaHistory
+
+logger = logging.getLogger(__name__)
 
 class ParsedQuery(NamedTuple):
     start_date: dt.datetime
@@ -252,9 +255,14 @@ def _for_wayback_machine(collections: List, sources: List) -> Dict:
 # until/unless it's needed and proven safe.
 _MEDIA_CLOUD_EXTRA_PROPS = [
     'expanded',    # NOTE! view MUST check user has permission!
-    'page_size',
     'sort_order',  # NOTE: built into news-search-api?
     'pagination_token'
+]
+
+# add integer valued parameters here!
+# that might have been converted to string in GET requests
+_MEDIA_CLOUD_INT_PROPS = [
+    'page_size'
 ]
 
 def _copy_media_cloud_extra_props(output: Dict, input: Mapping) -> None:
@@ -265,6 +273,10 @@ def _copy_media_cloud_extra_props(output: Dict, input: Mapping) -> None:
     for prop_name in _MEDIA_CLOUD_EXTRA_PROPS:
         if prop_name in input:
             output[prop_name] = input[prop_name]
+
+    for prop_name in _MEDIA_CLOUD_INT_PROPS:
+        if prop_name in input:
+            output[prop_name] = int(input[prop_name])
 
 def _for_media_cloud_OLD(collections: List, sources: List, all_params: Dict) -> Dict:
     # pull these in at runtime, rather than outside class, so we can make sure the models are loaded

--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -3,7 +3,7 @@ import datetime as dt
 import json
 import logging
 import time
-import traceback
+import traceback as tb
 from typing import Type
 
 # PyPI
@@ -92,7 +92,7 @@ def error_response(msg: str, *, exc: Exception | None = None,
             # show the file, line number, and the line of code (trying to
             # limit payload and info leakage, if neither is a problem, or
             # this turns out to be flakey, could pass back the entire list):
-            response["traceback"] = traceback.format_exception(exc)[-2]
+            response["traceback"] = tb.format_exception(exc)[-2]
     if temporary:
         response["temporary"] = True
     return json_response(response, _class=response_type)

--- a/mcweb/util/cache.py
+++ b/mcweb/util/cache.py
@@ -30,6 +30,18 @@ def cached_function_call(fn: Callable, cache_prefix: str, seconds: int | None = 
     for arg in args:
         elements.append(str(arg))
     for key, val in kwargs.items():
+        # turn set kwargs (domains/url_search_strings) into sorted lists
+        if isinstance(val, set):
+            val = sorted(val)
+        elif isinstance(val, dict):
+            # url_search_strings is (default)dict of sets
+            nval = {}
+            for k2, v2 in sorted(val.items()):
+                if isinstance(v2, set):
+                    nval[k2] = sorted(v2)
+                else:
+                    nval[k2] = v2
+            val = nval
         elements.append(f"{key}\x02{val}")
     readable_key = "\x01".join(elements)
     key = hashlib.md5(readable_key.encode("UTF8")).hexdigest()


### PR DESCRIPTION
…(#946)

* fixes for error handling found while running "daily metrics" queries

* mcweb/backend/search/utils.py: convert page_size to int for new mc_providers

* mcweb/util/cache.py: convert sets into sorted lists in cache keys

* caching: copy dict kwargs!