### PR TITLE
Enable gunicorn statistics

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,6 @@
 # if you add new lines to this file, add them to the ps:scale command in dokku-scripts/push.sh!
-web: bin/start-pgbouncer gunicorn --timeout 500 --pythonpath mcweb --bind 0.0.0.0:$PORT mcweb.wsgi
+web: ./run-server.sh
 #
-# run process_tasks workers in a single container under supervisord
+# run process_tasks workers, syslog sink in one container under supervisord
+# (faster startup)
 supervisord: supervisord

--- a/dokku-scripts/config.sh
+++ b/dokku-scripts/config.sh
@@ -55,16 +55,22 @@ add_extras() {
 	EXTRAS="$EXTRAS -S $x"
     done
 }
+
+# NOTE: same order used by rss-fetcher & story-indexer.
+# used by both run-server.sh (for gunicorn) and mcweb/settings.py
+STATSD_PREFIX=mc.$INSTANCE.web-search
+
 # added for all instances:
 # _could_ supply ..._ENV via private conf files, but supplying here makes
 # values consistant, and one place to change for apps that use this script
 # (if moved to devops repo).  Supplying "..._ENV" values separately per
 # facility is to avoid temptation to transmogrify values in code.
+
 add_extras "AIRTABLE_HARDWARE=$HOST" \
 	   "AIRTABLE_ENV=$INSTANCE" \
 	   "AIRTABLE_NAME=$INSTANCE" \
 	   "SENTRY_ENV=$INSTANCE" \
-	   "STATSD_REALM=$INSTANCE"
+	   "STATSD_PREFIX=$STATSD_PREFIX"
 
 # NOTE! vars.py output is shell-safe; it contains only VAR=BASE64ENCODEDVALUE ...
 # Want config:import! Which would avoid need for b64 (--encoded) values

--- a/mcweb/settings.py
+++ b/mcweb/settings.py
@@ -92,7 +92,7 @@ env = environ.Env(      # @@CONFIGURATION@@ definitions (datatype, default value
     SENTRY_PY_PROFILES_RATE=(float, 1.0), # fraction 0 to 1.0
     SENTRY_PY_TRACES_RATE=(float, 1.0),  # fraction 0 to 1.0
     STATSD_HOST=(str, ""),
-    STATSD_REALM=(str, ""),
+    STATSD_PREFIX=(str, ""),
     SYSTEM_ALERT=(str,None),
 )
 environ.Env.read_env(os.path.join(BASE_DIR, '.env'))
@@ -151,7 +151,7 @@ SENTRY_JS_REPLAY_RATE = env('SENTRY_JS_REPLAY_RATE')
 SENTRY_PY_PROFILES_RATE = env('SENTRY_PY_PROFILES_RATE')
 SENTRY_PY_TRACES_RATE = env('SENTRY_PY_TRACES_RATE')
 STATSD_HOST = env('STATSD_HOST')
-STATSD_REALM = env('STATSD_REALM')
+STATSD_PREFIX = env('STATSD_PREFIX')
 SYSTEM_ALERT = env('SYSTEM_ALERT')
 
 # end config

--- a/mcweb/util/stats.py
+++ b/mcweb/util/stats.py
@@ -10,15 +10,13 @@ from typing import TypeAlias
 # PyPI
 import statsd
 
-from settings import STATSD_HOST, STATSD_REALM
+from settings import STATSD_HOST, STATSD_PREFIX
 logger = logging.getLogger(__name__)
 
 Label: TypeAlias = tuple[str, str | int]
 
-if STATSD_HOST and STATSD_REALM:
-    # NOTE: same order used by rss-fetcher & story-indexer
-    prefix = f"mc.{STATSD_REALM}.web-search"
-    statsd_client = statsd.StatsdClient(STATSD_HOST, None, prefix)
+if STATSD_HOST and STATSD_PREFIX:
+    statsd_client = statsd.StatsdClient(STATSD_HOST, None, STATSD_PREFIX)
 else:
     statsd_client = None
 

--- a/run-server.sh
+++ b/run-server.sh
@@ -1,1 +1,13 @@
-gunicorn --timeout 500 --pythonpath mcweb --bind 0.0.0.0:8000 mcweb.wsgi
+#!/bin/sh
+if [ "x$STATSD_PREFIX" != x -a "x$STATSD_HOST" != x ]; then
+    # without port gunicorn treats host as a unix-domain socket!
+    EXTRAS="--statsd-host $STATSD_HOST:8125 --statsd-prefix $STATSD_PREFIX"
+fi
+# for compatibility, if anyone runs this interactively:
+if [ -x bin/start-pgbouncer ]; then
+    START_PGBOUNCER=bin/start-pgbouncer
+fi
+if [ "x$PORT" = x ]; then
+    PORT=8000
+fi
+$START_PGBOUNCER gunicorn --timeout 500 --pythonpath mcweb --bind 0.0.0.0:$PORT $EXTRAS mcweb.wsgi


### PR DESCRIPTION
Changes to the deployment scripts to enable gunicorn to send stats to grafana