### PR TITLE
add cache stats, put loud debug under TRACE_THING, count more paths

### DIFF
--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -49,6 +49,8 @@ from backend.users.exceptions import OverQuotaException
 # mcweb/backend/util
 import backend.util.csv_stream as csv_stream
 
+TRACE_JSON_RESPONSE = False
+
 logger = logging.getLogger(__name__)
 
 # enable caching for mc_providers results (explicitly referencing pkg for clarity)
@@ -63,7 +65,8 @@ def json_response(value: dict | str | None, *, _class: Type[HttpResponse] = Http
     """
     # NOTE! always passing default=str
     j = json.dumps(value, default=str)
-    logger.debug("json_response %d %s", _class.status_code, j) # put under an if?
+    if TRACE_JSON_RESPONSE:
+        logger.debug("json_response %d %s", _class.status_code, j)
     return _class(j, content_type="application/json")
 
 def error_response(msg: str, *, exc: Exception | None = None,

--- a/mcweb/util/cache.py
+++ b/mcweb/util/cache.py
@@ -16,7 +16,19 @@ from django.core.cache import cache
 # mcweb
 from settings import CACHE_SECONDS
 
+# mcweb.util (local dir)
+from mcweb.util import stats
+
 logger = logging.getLogger(__name__)
+
+TRACE_CACHE = False
+
+def trace(format, *args):
+    if TRACE_CACHE:
+        logger.debug(format, *args)
+
+def count_total(which: str) -> None:
+    stats.count(["cache", "total"], labels=[("status", which)])
 
 def cached_function_call(fn: Callable, cache_prefix: str, seconds: int | None = None, *args, **kwargs) -> tuple[Any, bool]:
     """
@@ -48,18 +60,19 @@ def cached_function_call(fn: Callable, cache_prefix: str, seconds: int | None = 
 
     results = cache.get(key)
     if results:
-        # increment counter?
-        logger.debug("found %r", readable_key)
+        trace("found %r", readable_key)
+        count_total("hit")
         return results, True
 
-    logger.debug("not found %r", readable_key)
+    trace("not found %r", readable_key)
+    count_total("miss")
     results = fn(*args, **kwargs)
     if seconds is None:
         # this is the one place where the default value is used.
         # NOTE! used here to allow wacking CACHE_SECONDS in debugger!
         seconds = CACHE_SECONDS
     cache.set(key, results, seconds)
-    logger.debug("set %r", readable_key)
+    trace("set %r", readable_key)
     return results, False
 
 def mc_providers_cacher(fn: Callable, cache_prefix: str, *args, **kwargs) -> tuple[Any, bool]:


### PR DESCRIPTION
I'd just as soon hold off on merging this until the next release (after ES changes deployed)

* add counts for whether cache checks "hit" or "missed"
* disables some debug logging (unless explicitly enabled)
* try and do a better job counting requests