### PR TITLE
Add temporary ES_PARTIAL_RESULTS constance parameter

### DIFF
--- a/mcweb/settings.py
+++ b/mcweb/settings.py
@@ -416,11 +416,12 @@ CONSTANCE_REDIS_CONNECTION = env('REDIS_URL')
 CONSTANCE_CONFIG = {
     "REQUEST_LOGGING_ENABLED": (False, 'Request logging enabled', bool),
     "OLD_MC_PROVIDER": (False, 'Use old (NSA) mc-provider', bool),
+    "ES_PARTIAL_RESULTS": (False, 'ES provider: return partial results', bool),
 }
 
 CONSTANCE_CONFIG_FIELDSETS = {
     "Monitoring Options": ("REQUEST_LOGGING_ENABLED",),
-    "Temporary": ("OLD_MC_PROVIDER",)
+    "Temporary": ("OLD_MC_PROVIDER", "ES_PARTIAL_RESULTS",)
 }
 
 ################


### PR DESCRIPTION
Setting allows using new (Elasticsearch) based provider, and silently returning partial results when queries of some shards (sections of the database) failed due to lack of available memory ("circuit breaker exceptions")