### PR TITLE
Provider Provider, Moving Temporary Crockery Around

### DIFF
--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -53,10 +53,10 @@ def fill_in_dates(start_date, end_date, existing_counts):
             filled_counts.append({'count': date_count_dict[day_string], 'date': day_string})
     return filled_counts
 
-def pq_provider(pq: ParsedQuery, platform: Optional[str] = None) -> ContentProvider:
+
+def get_provider(name: str, api_key: str, base_url: str, caching: bool, session_id: str):
     """
-    take parsed query, return mc_providers ContentProvider.
-    (one place to pass new things to mc_providers)
+    One place to get a provider configured for web use.
     """
     name = platform or pq.provider_name
     # BEGIN TEMPORARY CROCKERY!
@@ -70,9 +70,18 @@ def pq_provider(pq: ParsedQuery, platform: Optional[str] = None) -> ContentProvi
             # with circuit breaker tripping:
             extras["partial_responses"] = True
     logger.debug("pq_provider %s %r", name, extras)
-    # END TEMPORARY CROCKERY
-    return provider_by_name(name, api_key=pq.api_key, base_url=pq.base_url, caching=pq.caching,
-                            software_id="web-search", session_id=pq.session_id, **extras)
+
+    return provider_by_name(name, api_key=api_key, base_url = base_url, caching = caching, 
+                software_id="web-search", session_id = session_id)
+
+def pq_provider(pq: ParsedQuery, platform: Optional[str] = None) -> ContentProvider:
+    """
+    take parsed query, return mc_providers ContentProvider.
+    """
+    name = platform or pq.provider_name
+
+    return get_provider(name, api_key=pq.api_key, base_url=pq.base_url, 
+                        caching=pq.caching, session_id=pq.session_id)
 
 def parse_date_str(date_str: str) -> dt.datetime:
     """

--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -21,7 +21,7 @@ from settings import ALL_URLS_CSV_EMAIL_MAX, ALL_URLS_CSV_EMAIL_MIN, NEWS_SEARCH
 from ..users.models import QuotaHistory
 
 # mcweb/backend/utils/provider
-from ..utils.provider import get_provider
+from ..util.provider import get_provider
 
 logger = logging.getLogger(__name__)
 

--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -20,6 +20,9 @@ from settings import ALL_URLS_CSV_EMAIL_MAX, ALL_URLS_CSV_EMAIL_MIN, NEWS_SEARCH
 # mcweb/backend/users
 from ..users.models import QuotaHistory
 
+# mcweb/backend/utils/provider
+from ..utils.provider import get_provider
+
 logger = logging.getLogger(__name__)
 
 class ParsedQuery(NamedTuple):
@@ -52,27 +55,6 @@ def fill_in_dates(start_date, end_date, existing_counts):
         else:
             filled_counts.append({'count': date_count_dict[day_string], 'date': day_string})
     return filled_counts
-
-
-def get_provider(name: str, api_key: str, base_url: str, caching: bool, session_id: str):
-    """
-    One place to get a provider configured for web use.
-    """
-    name = platform or pq.provider_name
-    # BEGIN TEMPORARY CROCKERY!
-    extras = {}
-    if name == 'onlinenews-mediacloud':
-        # if mediacloud, and emergency ripcord pulled, revert to (new) NSA-based provider
-        if constance.config.OLD_MC_PROVIDER:
-            name = 'onlinenews-mediacloud-old'
-        elif constance.config.ES_PARTIAL_RESULTS:
-            # new provider: return results even if some shards failed
-            # with circuit breaker tripping:
-            extras["partial_responses"] = True
-    logger.debug("pq_provider %s %r", name, extras)
-
-    return provider_by_name(name, api_key=api_key, base_url = base_url, caching = caching, 
-                software_id="web-search", session_id = session_id)
 
 def pq_provider(pq: ParsedQuery, platform: Optional[str] = None) -> ContentProvider:
     """

--- a/mcweb/backend/util/provider.py
+++ b/mcweb/backend/util/provider.py
@@ -4,7 +4,7 @@ from settings import SENTRY_ENV
 
 import logging
 
-logger = logging.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 def get_provider(name: str, api_key: str, base_url: str, caching: int, session_id: str | None):
     """

--- a/mcweb/backend/util/provider.py
+++ b/mcweb/backend/util/provider.py
@@ -1,0 +1,31 @@
+import constance  
+from mc_providers import provider_by_name
+from settings import SENTRY_ENV
+
+def get_provider(name: str, api_key: str, base_url: str, caching: int, session_id: str | None):
+    """
+    One place to get a provider configured for web use.
+    """
+
+    #A default sessionid that's attached to the sentry environment. 
+    if session_id == None:
+        session_id = provider_session("default")
+
+    # BEGIN TEMPORARY CROCKERY!
+    extras = {}
+    if name == 'onlinenews-mediacloud':
+        # if mediacloud, and emergency ripcord pulled, revert to (new) NSA-based provider
+        if constance.config.OLD_MC_PROVIDER:
+            name = 'onlinenews-mediacloud-old'
+        elif constance.config.ES_PARTIAL_RESULTS:
+            # new provider: return results even if some shards failed
+            # with circuit breaker tripping:
+            extras["partial_responses"] = True
+    logger.debug("pq_provider %s %r", name, extras)
+
+    return provider_by_name(name, api_key=api_key, base_url = base_url, caching = caching, 
+            software_id="web-search", session_id = session_id)
+
+
+def provider_session(task_name:str):
+    return 'f{task_name}@{SENTRY_ENV}'

--- a/mcweb/backend/util/provider.py
+++ b/mcweb/backend/util/provider.py
@@ -6,14 +6,12 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-def get_provider(name: str, api_key: str, base_url: str, caching: int, session_id: str | None):
+def get_provider(name: str, api_key: str, base_url: str, caching: int = 0, session_id: str):
     """
     One place to get a provider configured for web use.
     """
 
     #A default sessionid that's attached to the sentry environment. 
-    if session_id == None:
-        session_id = provider_session("default")
 
     # BEGIN TEMPORARY CROCKERY!
     extras = {}

--- a/mcweb/backend/util/provider.py
+++ b/mcweb/backend/util/provider.py
@@ -2,6 +2,10 @@ import constance
 from mc_providers import provider_by_name
 from settings import SENTRY_ENV
 
+import logging
+
+logger = logging.get_logger(__name__)
+
 def get_provider(name: str, api_key: str, base_url: str, caching: int, session_id: str | None):
     """
     One place to get a provider configured for web use.

--- a/mcweb/backend/util/provider.py
+++ b/mcweb/backend/util/provider.py
@@ -6,7 +6,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-def get_provider(name: str, api_key: str, base_url: str, caching: int = 0, session_id: str):
+
+def get_provider(name: str, api_key: str, base_url: str|None, caching: int, session_id: str):
     """
     One place to get a provider configured for web use.
     """
@@ -31,3 +32,8 @@ def get_provider(name: str, api_key: str, base_url: str, caching: int = 0, sessi
 
 def provider_session(task_name:str):
     return 'f{task_name}@{SENTRY_ENV}'
+
+
+def get_task_provider(provider_name: str, api_key: str, base_url: str|None, task_name:str):
+    session = provider_session(task_name)
+    return get_provider(provider_name, api_key=api_key, base_url=base_url, caching=0, session_id = session)


### PR DESCRIPTION
breaks out `get_provider` from pq_provider for better use outside of request context with websearch config details- simplest possible implementation. Possible adjustments: infer base_url from environment, provide default session_id value