### PR TITLE
Have parsed_query_from_dict take session_id instead of request

### DIFF
--- a/mcweb/backend/search/tasks.py
+++ b/mcweb/backend/search/tasks.py
@@ -44,7 +44,7 @@ def download_all_large_content_csv(queryState: list[dict], user_id: int, user_is
 
 @background(queue=USER_SLOW, remove_existing_tasks=True)
 def _download_all_large_content_csv(queryState: list[dict], user_id: int, user_isStaff: bool, email: str):
-    parsed_queries = [parsed_query_from_dict(q) for q in queryState]
+    parsed_queries = [parsed_query_from_dict(q, session_id=email) for q in queryState]
     # code from: https://stackoverflow.com/questions/17584550/attach-generated-csv-file-to-email-and-send-with-django
 
     # Phil: maybe catch exception, and send email?

--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -85,9 +85,9 @@ _BASE_URL = {
     'onlinenews-mediacloud-old': NEWS_SEARCH_API_URL,
 }
 
-def _get_session_id(request) -> str | None:
+def request_session_id(request) -> str | None:
     if request.user.is_authenticated:
-        user = str(request.user)
+        user = request.user.email
         # XXX include a session hash from request.session?
         return user
     else:
@@ -97,9 +97,10 @@ def parse_query_params(request) -> (ParsedQuery, dict):
     """
     return ParsedQuery plus dict for other params
     """
+    session_id = request_session_id(request)
     if request.method == 'POST':
         payload = json.loads(request.body)
-        return (parsed_query_from_dict(payload.get("queryObject"), request), payload)
+        return (parsed_query_from_dict(payload.get("queryObject"), session_id), payload)
 
     provider_name = request.GET.get("p", 'onlinenews-mediacloud')
     query_str = request.GET.get("q", "*")
@@ -134,14 +135,14 @@ def parse_query_params(request) -> (ParsedQuery, dict):
                      query_str=query_str, provider_props=provider_props,
                      provider_name=provider_name, api_key=api_key,
                      base_url=base_url, caching=caching,
-                     session_id=_get_session_id(request))
+                     session_id=session_id)
     return (pq, request.GET)
 
 def parse_query(request) -> ParsedQuery:
     pq, payload = parse_query_params(request)
     return pq
 
-def parsed_query_from_dict(payload, request) -> ParsedQuery:
+def parsed_query_from_dict(payload: dict, session_id: str) -> ParsedQuery:
     """
     Takes a queryObject dict, returns ParsedQuery
     """
@@ -159,7 +160,7 @@ def parsed_query_from_dict(payload, request) -> ParsedQuery:
                        query_str=query_str, provider_props=provider_props,
                        provider_name=provider_name, api_key=api_key,
                        base_url=base_url, caching=caching,
-                       session_id=_get_session_id(request))
+                       session_id=session_id)
 
 def parsed_query_state(request) -> list[ParsedQuery]:
     """
@@ -173,7 +174,8 @@ def parsed_query_state(request) -> list[ParsedQuery]:
     else:
         queries = json.loads(request.GET.get("qS"))
 
-    pqs = [parsed_query_from_dict(q, request) for q in queries]
+    session_id = request_session_id(request)
+    pqs = [parsed_query_from_dict(q, session_id) for q in queries]
     return pqs
 
 def _get_api_key(provider: str) -> str | None:

--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -38,7 +38,8 @@ from .utils import (
     parse_query_params,
     parsed_query_from_dict,
     parsed_query_state,
-    pq_provider
+    pq_provider,
+    request_session_id
 )
 from .tasks import download_all_large_content_csv, download_all_queries_csv_task
 
@@ -421,8 +422,9 @@ def send_email_large_download_csv(request):
     # NOTE: download_all_content_csv doesn't check count!
     # applying range check to sum of all queries!
     total = 0
+    session_id = request_session_id(request)
     for query in queryState:
-        pq = parsed_query_from_dict(query, request)
+        pq = parsed_query_from_dict(query, session_id)
         provider = pq_provider(pq)
         try:
             total += provider.count(_qs(pq), pq.start_date, pq.end_date, **pq.provider_props)


### PR DESCRIPTION
Fixes https://github.com/mediacloud/web-search/issues/975

Tested on dev instance.

First run didn't have email config,
Second run hung,
Third run sent email!
