### PR TITLE
Mostly config changes

### DIFF
--- a/dokku-scripts/config.sh
+++ b/dokku-scripts/config.sh
@@ -56,6 +56,13 @@ add_extras() {
     done
 }
 
+# mcmetadata uses pylangid3 which uses numpy which uses libopenblas
+# for vector math, creating by default one worker thread per virtual
+# CPU, which sit and spin looking for work.  Use just one thread.  The
+# same setting is used in story-indexer (which actually does language
+# identification, with less CPU time used!
+add_extras "OPENBLAS_NUM_THREADS=1"
+
 # NOTE: same order used by rss-fetcher & story-indexer.
 # used by both run-server.sh (for gunicorn) and mcweb/settings.py
 STATSD_PREFIX=mc.$INSTANCE.web-search

--- a/dokku-scripts/push.sh
+++ b/dokku-scripts/push.sh
@@ -284,6 +284,17 @@ prod|staging)
 	echo 'ADMIN_EMAIL= # gets alerts, scrape errors' >> $USER_CONF
 	echo "SYSTEM_ALERT=\"🚧 ${UNAME}'s dev instance 🚧\"" >> $USER_CONF
     fi
+    case $(hostname) in
+    *.angwin)
+	# make sure dev deployments report stats now that mc-providers reports
+	# counters (to help find instances that are blasting a provider)
+	# NOTE! accepts commented out entry!
+	if ! grep -q 'STATSD_HOST=' $USER_CONF; then
+	    echo "# you can comment out next line if it gives you trouble:" >> $USER_CONF
+	    echo "STATSD_HOST=tarbell.angwin" >> $USER_CONF
+	fi
+	;;
+    esac
     # unset DATABASE/REDIS URLs from .env-template, read user override file
     CONFIG_EXTRAS="$CONFIG_EXTRAS -U DATABASE_URL -U REDIS_URL -F $USER_CONF"
     ;;

--- a/mcweb/util/cache.py
+++ b/mcweb/util/cache.py
@@ -17,7 +17,7 @@ from django.core.cache import cache
 from settings import CACHE_SECONDS
 
 # mcweb.util (local dir)
-from mcweb.util import stats
+import util.stats as stats
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
* Disables parallel threads for language detection (wastes CPU/memory)
* Set STATSD_HOST in dev deployments in angwin cluster (for detections of queries gone wild)
* Fix an import to allow debug of background tasks