### PR TITLE
Fix ratio calculation

### DIFF
--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -472,7 +472,8 @@ def providers(request):
 
 def add_ratios(words_data):
     for word in words_data:
-        word["ratio"] = word['count'] / 1000
+        if "ratio" not in word:
+            word["ratio"] = word['count'] / 1000
     return words_data
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ whitenoise==6.2.*
 sentry-sdk==1.39.*
 requests  # let the other dependencies sort out which is the right version
 fasttext==0.9.*
-mc-providers @ git+https://github.com/mediacloud/mc-providers@v3.1.1
+mc-providers @ git+https://github.com/mediacloud/mc-providers@v3.1.2
 mc-manage @ git+https://github.com/mediacloud/mc-manage@v1.1.4
 pycountry==24.6.*
 django-background-tasks-updated==1.2.* # need >= 1.2.6


### PR DESCRIPTION
Figure this is the least destructive way to approach this, since it might be that providers don't return the ratio sometimes? Idk, may be better to just remove add_ratio, all the calls are in-place changes, but I want to imagine that it was originally serving a useful purpose. 