### PR TITLE
Remove call to profile in index and remove unused profile endpoint

### DIFF
--- a/mcweb/backend/users/views.py
+++ b/mcweb/backend/users/views.py
@@ -100,6 +100,7 @@ def reset_password(request):
 @permission_classes([IsAuthenticated])
 def profile(request):
     token = request.GET.get('Authorization', None)
+    user = None
     if token:
         try:
             user = _user_from_token(token)
@@ -107,10 +108,12 @@ def profile(request):
             logger.debug("Token not found")
             data = json.dumps({'message': "API Token Not Found"})
             return HttpResponse(data, content_type='application/json', status=403)
-    if request.user.id is not None:
+    if request.user.id is not None and not user:
         data = _serialized_current_user(request)
-    else:
+    elif user:
         data = _serialized_api_user(user)
+    else:
+        data = json.dumps({'message': "User Not Found"})
     return HttpResponse(json.dumps(data), content_type='application/json')
 
 @require_http_methods(["POST"])

--- a/mcweb/frontend/src/app/services/authApi.js
+++ b/mcweb/frontend/src/app/services/authApi.js
@@ -13,9 +13,6 @@ export const api = createApi({
   }),
 
   endpoints: (builder) => ({
-    profile: builder.query({
-      query: () => 'profile',
-    }),
     logout: builder.mutation({
       query: () => ({
         url: 'logout',
@@ -78,7 +75,6 @@ export const api = createApi({
 });
 
 export const {
-  useProfileQuery,
   useLogoutMutation,
   useLoginMutation,
   useRegisterMutation,

--- a/mcweb/frontend/src/index.js
+++ b/mcweb/frontend/src/index.js
@@ -1,18 +1,14 @@
 import renderApp from './Root';
 import getStore from './app/store';
-import { api as authApi } from './app/services/authApi';
 import { saveCsrfToken } from './services/csrfToken';
-import { setCredentials } from './features/auth/authSlice';
 
 // gets the store from store.js
 // dispatches the current query from userApi
 // renders app from App.js (holds all the routing)
 
 async function initializeApp() {
-  const store = getStore();
+  getStore();
   saveCsrfToken();
-  const response = await store.dispatch(authApi.endpoints.profile.initiate());
-  await store.dispatch(setCredentials(response.data));
   renderApp();
 }
 


### PR DESCRIPTION
We were setting the user in index, using the profile endpoint.
We currently get the current user for profile and therefore do not need this api function or call in index.js.

also fixed error with user being referenced before assignment