### PR TITLE
mc_providers_cacher: handle _cache_seconds kwarg

### DIFF
--- a/mcweb/util/cache.py
+++ b/mcweb/util/cache.py
@@ -78,11 +78,10 @@ def cached_function_call(fn: Callable, cache_prefix: str, seconds: int | None = 
 def mc_providers_cacher(fn: Callable, cache_prefix: str, *args, **kwargs) -> tuple[Any, bool]:
     """
     callable passed to mc_providers caching interface.
-    this is the one place that needs to return the was_cached bool
-    (changing the cacheing function API would require an mc_providers major version change)
-    always gets default cache time (could have a separate setting)
+    this is the one place that needs to return the was_cached bool.
     """
-    return cached_function_call(fn, cache_prefix, None, *args, **kwargs)
+    seconds = kwargs.pop("_cache_seconds", None)
+    return cached_function_call(fn, cache_prefix, seconds, *args, **kwargs)
 
 # decorator for caching functions/methods in backend code
 def cache_by_kwargs(seconds: int | None = None):


### PR DESCRIPTION
Allow future version of mc-providers to ask for non-default caching time.
