### PR TITLE
for upcoming providers 4.0 integration, use new term field titles.

### DIFF
--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 from typing import Any, Callable, Dict, Generator, Iterable, List, Mapping, NamedTuple, Optional, Tuple
 
 # PyPI
-import constance                # TEMPORARY!
 from django.apps import apps
 from mc_providers import provider_by_name, provider_name, ContentProvider, \
     PLATFORM_TWITTER, PLATFORM_SOURCE_TWITTER, PLATFORM_YOUTUBE,\

--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -365,7 +365,7 @@ def download_words_csv(request):
         headers={'Content-Disposition': f"attachment; filename={filename}.csv"},
     )
     writer = csv.writer(response)
-    cols = ['term', 'count', 'ratio']
+    cols = ['term', 'term_count', 'term_ratio']
     CSVWriterHelper.write_top_words(writer, words, cols)
     return response
 
@@ -472,8 +472,8 @@ def providers(request):
 
 def add_ratios(words_data):
     for word in words_data:
-        if "ratio" not in word:
-            word["ratio"] = word['count'] / 1000
+        if "term_ratio" not in word:
+            word["term_ratio"] = word['count'] / 1000
     return words_data
 
 

--- a/mcweb/backend/util/provider.py
+++ b/mcweb/backend/util/provider.py
@@ -1,4 +1,4 @@
-import constance  
+import constance
 from mc_providers import provider_by_name
 from settings import SENTRY_ENV
 
@@ -17,9 +17,6 @@ def get_provider(name: str, api_key: str, base_url: str|None, caching: int, sess
     # BEGIN TEMPORARY CROCKERY!
     extras = {}
     if name == 'onlinenews-mediacloud':
-        # if mediacloud, and emergency ripcord pulled, revert to (new) NSA-based provider
-        if constance.config.OLD_MC_PROVIDER:
-            name = 'onlinenews-mediacloud-old'
         elif constance.config.ES_PARTIAL_RESULTS:
             # new provider: return results even if some shards failed
             # with circuit breaker tripping:

--- a/mcweb/settings.py
+++ b/mcweb/settings.py
@@ -416,13 +416,12 @@ CONSTANCE_REDIS_CONNECTION = env('REDIS_URL')
 
 CONSTANCE_CONFIG = {
     "REQUEST_LOGGING_ENABLED": (False, 'Request logging enabled', bool),
-    "OLD_MC_PROVIDER": (False, 'Use old (NSA) mc-provider', bool),
     "ES_PARTIAL_RESULTS": (False, 'ES provider: return partial results', bool),
 }
 
 CONSTANCE_CONFIG_FIELDSETS = {
     "Monitoring Options": ("REQUEST_LOGGING_ENABLED",),
-    "Temporary": ("OLD_MC_PROVIDER", "ES_PARTIAL_RESULTS",)
+    "Temporary": ("ES_PARTIAL_RESULTS",)
 }
 
 ################

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ whitenoise==6.2.*
 sentry-sdk==1.39.*
 requests  # let the other dependencies sort out which is the right version
 fasttext==0.9.*
-mc-providers @ git+https://github.com/mediacloud/mc-providers@v3.1.2
+mc-providers @ git+https://github.com/mediacloud/mc-providers@v4.0.latest
 mc-manage @ git+https://github.com/mediacloud/mc-manage@v1.1.4
 pycountry==24.6.*
 django-background-tasks-updated==1.2.* # need >= 1.2.6


### PR DESCRIPTION
Still a draft until changes in 4.0 are released, since its untestable until then. 
First commit was just a best guess of where the change to the term field titles needs to happen- afaict the columns should just be inferred from the dictionary keys returned by providers, but if there's somewhere else to add them I'll find it in testing. 