### PR TITLE
Cleanup for removal of old news-search-api based provider

### DIFF
--- a/mcweb/backend/util/provider.py
+++ b/mcweb/backend/util/provider.py
@@ -17,13 +17,11 @@ def get_provider(name: str, api_key: str, base_url: str|None, caching: int, sess
     # BEGIN TEMPORARY CROCKERY!
     extras = {}
     if name == 'onlinenews-mediacloud':
-        # if mediacloud, and emergency ripcord pulled, revert to (new) NSA-based provider
-        if constance.config.OLD_MC_PROVIDER:
-            name = 'onlinenews-mediacloud-old'
-        elif constance.config.ES_PARTIAL_RESULTS:
-            # new provider: return results even if some shards failed
+        if constance.config.ES_PARTIAL_RESULTS:
+            # ES provider: return results even if some shards failed
             # with circuit breaker tripping:
             extras["partial_responses"] = True
+    # END TEMPORARY CROCKERY!
     logger.debug("pq_provider %s %r", name, extras)
 
     return provider_by_name(name, api_key=api_key, base_url = base_url, caching = caching, 

--- a/mcweb/settings.py
+++ b/mcweb/settings.py
@@ -81,7 +81,6 @@ env = environ.Env(      # @@CONFIGURATION@@ definitions (datatype, default value
     EMAIL_ORGANIZATION=(str, "Media Cloud Development"),
     GIT_REV=(str, ""),
     LOG_LEVEL=(str, "DEBUG"),
-    NEWS_SEARCH_API_URL=(str, "http://ramos.angwin:8000/v1/"),
     PROVIDERS_TIMEOUT=(int, 60*10),
     SCRAPE_ERROR_RECIPIENTS=(list, []),
     SCRAPE_TIMEOUT_SECONDS=(float, 30.0), # http connect/read
@@ -135,7 +134,6 @@ EMAIL_ORGANIZATION = env('EMAIL_ORGANIZATION') # used in subject line
 
 GIT_REV = env("GIT_REV")      # supplied by Dokku, returned by /api/version
 LOG_LEVEL = env('LOG_LEVEL').upper()
-NEWS_SEARCH_API_URL = env('NEWS_SEARCH_API_URL')
 PROVIDERS_TIMEOUT = env('PROVIDERS_TIMEOUT')
 
 RSS_FETCHER_URL = env('RSS_FETCHER_URL')
@@ -416,13 +414,12 @@ CONSTANCE_REDIS_CONNECTION = env('REDIS_URL')
 
 CONSTANCE_CONFIG = {
     "REQUEST_LOGGING_ENABLED": (False, 'Request logging enabled', bool),
-    "OLD_MC_PROVIDER": (False, 'Use old (NSA) mc-provider', bool),
     "ES_PARTIAL_RESULTS": (False, 'ES provider: return partial results', bool),
 }
 
 CONSTANCE_CONFIG_FIELDSETS = {
     "Monitoring Options": ("REQUEST_LOGGING_ENABLED",),
-    "Temporary": ("OLD_MC_PROVIDER", "ES_PARTIAL_RESULTS",)
+    "Temporary": ("ES_PARTIAL_RESULTS",)
 }
 
 ################

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ whitenoise==6.2.*
 sentry-sdk==1.39.*
 requests  # let the other dependencies sort out which is the right version
 fasttext==0.9.*
-mc-providers @ git+https://github.com/mediacloud/mc-providers@v3.1.2
+mc-providers @ git+https://github.com/mediacloud/mc-providers@v4.0.latest
 mc-manage @ git+https://github.com/mediacloud/mc-manage@v1.1.4
 pycountry==24.6.*
 django-background-tasks-updated==1.2.* # need >= 1.2.6


### PR DESCRIPTION
NOTE!

* Leaves in place the red emergency switch to allow returning partial results (due to circuit breaker errors on some shards but not others).  This hasn't been needed, but leaving a little while longer.
* Removes the need to include base_url in ParsedQuery (NamedTuple), but didn't want to yank it because there was a moment in time that base_url was a REQUIRED argument to some routines, and ISTR Xavier's source checker interacted with that, and didn't want to risk causing any merge messes.