### PR TITLE
First pass at general-use dokku-scripts/outside script set

### DIFF
--- a/dokku-scripts/outside/README.md
+++ b/dokku-scripts/outside/README.md
@@ -1,0 +1,15 @@
+Run things outside Dokku, for casual developers
+===============================================
+
+NOTE! These scripts assume you have a Dokku app named $USER-mcweb on
+the local host.  For quick tests (deploying a Dokku app takes a while).
+Will set environment variables to access your PostgreSQL and Redis
+services!
+
+Uses mcweb/.env and vars.$USER for basic settings
+
+* run-server.sh: expects mcweb/static mcweb/frontend/static directories (*)
+* run-manage.sh: you supple the command and args
+* run-queue.sh: expects one argument: {user,system,admin}-{fast,slow}
+
+(*) copy from your Dokku container

--- a/dokku-scripts/outside/dokku-vars.sh
+++ b/dokku-scripts/outside/dokku-vars.sh
@@ -1,0 +1,64 @@
+# sourced by dokku-scripts/outside/run-THINGS.sh; establish environment
+
+# using _NAME to avoid collisions with actual config
+
+if [ "x$_BASE_DIR" = x ]; then
+    echo _BASE_DIR not set 1>&2
+    exit 1
+fi
+_WEB_SEARCH=$_BASE_DIR/../..
+_VENV_DIR=$_WEB_SEARCH/venv
+_VENV_BIN=$_VENV_DIR/bin
+_PYTHON=$_VENV_BIN/python
+
+if [ ! -x "$_PYTHON" ]; then
+    echo $_PYTHON not found 1>&2
+fi
+
+_HOSTNAME=$(hostname -f)
+
+dburl() {
+    local SVC=$1
+    ssh dokku@$_HOSTNAME postgres:info $SVC | awk "
+    /Dsn:/ { dsn = \$2 }
+    /Internal ip:/ { ip = \$3
+	print gensub(/^postgres:/, \"postgresql:\", 1, 
+	    gensub(/dokku-postgres-$SVC/, ip, 1, dsn))
+	exit 0
+    }"
+}
+
+redisurl() {
+    local SVC=$1
+    ssh dokku@$_HOSTNAME redis:info $SVC | awk "
+    /Dsn:/ { dsn = \$2 }
+    /Internal ip:/ { ip = \$3
+	print gensub(/dokku-redis-$SVC/, ip, 1, dsn)
+	exit 0
+    }"
+}
+
+_FILES=$_WEB_SEARCH/mcweb/.env
+. $_FILES
+if [ -f vars.$USER ]; then
+    _FILES="$FILES vars.$USER"
+    . $_WEB_SEARCH/vars.$USER
+fi
+
+
+# export everything in all the config files:
+export $(grep -h '^[A-Z]' $_FILES | sed 's/=.*$//')
+
+# NOTE!  Copied mcweb/static mcweb/frontend/static directory trees
+# from a container!!
+
+export ALLOWED_HOSTS=${USER}-mcweb.$_HOSTNAME
+export DATABASE_URL=$(dburl ${USER}-mcweb-db)
+export DEBUG=True
+export OPENBLAS_NUM_THREADS=1
+export REDIS_URL=$(redisurl ${USER}-mcweb-cache)
+export SYSTEM_ALERT="🚨 $USER hand-run instance 🚨"
+
+# XXX check DATABASE_URL and REDIS_URL??
+
+cd $_WEB_SEARCH

--- a/dokku-scripts/outside/run-manage.sh
+++ b/dokku-scripts/outside/run-manage.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+_BASE_DIR=$(dirname $0)
+. $_BASE_DIR/dokku-vars.sh
+
+cd $_WEB_SEARCH
+$_PYTHON mcweb/manage.py "$@"

--- a/dokku-scripts/outside/run-queue.sh
+++ b/dokku-scripts/outside/run-queue.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+_BASE_DIR=$(dirname $0)
+
+QUEUE_NAME=$1
+if echo "$QUEUE_NAME" | egrep -q '^(user|system|admin)-(fast|slow)$'; then
+   echo queue $QUEUE_NAME
+else
+    echo "Need queue name: {user,system,admin}-{fast,slow}" 2>&1
+    exit 1
+fi
+
+$_BASE_DIR/run-manage.sh process_tasks --queue $QUEUE_NAME

--- a/dokku-scripts/outside/run-server.sh
+++ b/dokku-scripts/outside/run-server.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# run web server outside Dokku for casual developers: see README.md
+
+_BASE_DIR=$(dirname $0)
+. $_BASE_DIR/dokku-vars.sh
+
+# will require different ports for multiple users/instances on same server!!
+if [ "x$_OUTSIDE_PORT" = x ]; then
+    _OUTSIDE_PORT=8000
+fi
+
+cd $_WEB_SEARCH
+echo "open URL http://$ALLOWED_HOSTS:$_OUTSIDE_PORT"
+$_VENV_BIN/gunicorn --pythonpath mcweb \
+		    --bind 0.0.0.0:$_OUTSIDE_PORT \
+		    mcweb.wsgi


### PR DESCRIPTION
This PR creates dokku-scripts/outside/run-{server,manage,queue}.sh scripts, cleaned up versions of the scripts Phil uses to run stuff outside Dokku, using the Postgres and Redis services from his Dokku deployed app, for rapid testing and debugging.
