### PR TITLE
Add /api/sources/sources/all-sources/ to list all source ids

### DIFF
--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -403,8 +403,7 @@ def download_all_content_csv(request):
     parsed_queries = parsed_query_state(request) # handles POST!
     data_generator = all_content_csv_generator(parsed_queries, request.user.id, request.user.is_staff)
     filename = all_content_csv_basename(parsed_queries)
-    streamer = csv_stream.CSVStream(filename, data_generator)
-    return streamer.stream()
+    return csv_stream.streaming_csv_response(data_generator, filename)
 
 
 # called by frontend sendTotalAttentionDataEmail

--- a/mcweb/backend/sources/api.py
+++ b/mcweb/backend/sources/api.py
@@ -517,11 +517,13 @@ class SourcesViewSet(viewsets.ModelViewSet):
         # lists all tasks for user (None lists all tasks)
         return Response(get_pending_tasks(request.user))
 
-    @action(detail=False, url_path='all-source-ids')
-    def all_source_ids(self, request):
+    @action(detail=False, url_path='all-sources')
+    def all_sources(self, request):
         """
-        return CSV of all Sources for rss-fetcher
-        (limit by group membership??)
+        Return streaming CSV of ids all Sources.
+        For rss-fetcher to detect deletes.
+        Maybe take optional parameter with list of fields to return?
+        Maybe support "feed_count" column?
         """
         sources = Source.objects.values_list('id')
         return csv_stream.streaming_csv_response(sources.all)

--- a/mcweb/backend/sources/api.py
+++ b/mcweb/backend/sources/api.py
@@ -526,7 +526,7 @@ class SourcesViewSet(viewsets.ModelViewSet):
         Maybe support "feed_count" column?
         """
         sources = Source.objects.values_list('id')
-        return csv_stream.streaming_csv_response(sources.all)
+        return csv_stream.streaming_csv_response(sources.iterator)
 
 
 class SourcesCollectionsViewSet(viewsets.ViewSet):

--- a/mcweb/backend/sources/api.py
+++ b/mcweb/backend/sources/api.py
@@ -477,8 +477,7 @@ class SourcesViewSet(viewsets.ModelViewSet):
 
         filename = "Collection-{}-{}-sources-{}".format(
             collection_id, collection.name, _filename_timestamp())
-        streamer = csv_stream.CSVStream(filename, data_generator)
-        return streamer.stream()
+        return csv_stream.streaming_csv_response(data_generator, filename)
 
     @action(methods=['GET'], detail=False, url_path='sources-from-list')
     def sources_from_list(self, request):
@@ -517,6 +516,15 @@ class SourcesViewSet(viewsets.ModelViewSet):
         """
         # lists all tasks for user (None lists all tasks)
         return Response(get_pending_tasks(request.user))
+
+    @action(detail=False, url_path='all-source-ids')
+    def all_source_ids(self, request):
+        """
+        return CSV of all Sources for rss-fetcher
+        (limit by group membership??)
+        """
+        sources = Source.objects.values_list('id')
+        return csv_stream.streaming_csv_response(sources.all)
 
 
 class SourcesCollectionsViewSet(viewsets.ViewSet):

--- a/mcweb/backend/sources/management/commands/all-sources.py
+++ b/mcweb/backend/sources/management/commands/all-sources.py
@@ -1,23 +1,39 @@
 import time
 
+from django.db.models import Count, Subquery
 from django.core.management.base import BaseCommand, CommandError
 
-from ...models import Source
+from ...models import Feed, Source
 from backend.util import csv_stream
 
 class Command(BaseCommand):
-    help = 'Output CSV of all Sources (test for streaming_csv_response)'
+    help = 'Test generation of CSV for all news Sources with feeds (test for streaming_csv_response)'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--verbose', action='count', default=0)
 
     def handle(self, *args, **options):
-        queryset = Source.objects.values_list('id')
+        # A copy of the query in mcweb.backend.sources.api.SourcesViewSet.with_feeds!!
+        queryset = Source.objects.values_list('id')\
+                                 .filter(platform=Source.SourcePlatforms.ONLINE_NEWS)\
+                                 .annotate(feeds=Count('feed'))\
+                                 .filter(feeds__gt=0)
+        verbosity = int(options["verbose"])
+        if verbosity >= 1:
+            print(queryset.query)
         chunks = lines = 0
         t0 = time.monotonic()
         for c in csv_stream.streaming_csv_response(queryset.iterator).streaming_content:
-            pl = len(c.split(b"\r\n")) - 1 # page lines, ignore trailing CRLF
-            #print(pl)
-            lines += pl
+            chunk_bytes = len(c)
+            chunk_lines = len(c.split(b"\r\n")) - 1 # page lines, ignore trailing CRLF
+            if verbosity >= 3:
+                print("=== chunk")
+                print(c.decode())
+            elif verbosity >= 2:
+                print(chunk_lines, chunk_bytes)
+            lines += chunk_lines
             chunks += 1
         elapsed = time.monotonic() - t0
-        print(chunks, lines, elapsed)
+        print(chunks, "chunks", lines, "lines", round(elapsed, 6), "sec")
 
 

--- a/mcweb/backend/sources/management/commands/all-sources.py
+++ b/mcweb/backend/sources/management/commands/all-sources.py
@@ -1,0 +1,23 @@
+import time
+
+from django.core.management.base import BaseCommand, CommandError
+
+from ...models import Source
+from backend.util import csv_stream
+
+class Command(BaseCommand):
+    help = 'Output CSV of all Sources (test for streaming_csv_response)'
+
+    def handle(self, *args, **options):
+        queryset = Source.objects.values_list('id')
+        chunks = lines = 0
+        t0 = time.monotonic()
+        for c in csv_stream.streaming_csv_response(queryset.iterator).streaming_content:
+            pl = len(c.split(b"\r\n")) - 1 # page lines, ignore trailing CRLF
+            #print(pl)
+            lines += pl
+            chunks += 1
+        elapsed = time.monotonic() - t0
+        print(chunks, lines, elapsed)
+
+

--- a/mcweb/backend/sources/tasks.py
+++ b/mcweb/backend/sources/tasks.py
@@ -20,10 +20,10 @@ from django.contrib.auth.models import User
 from django.db import transaction
 from django.db.models import Q, QuerySet
 from django.utils import timezone
-from ..util.provider import get_task_provider
-
-
 import numpy as np
+
+
+from ..util.provider import get_task_provider
 
 # mcweb/backend/sources
 from .models import Feed, Source, Collection
@@ -345,7 +345,7 @@ def analyze_sources(provider_name: str, sources:QuerySet, start_date: dt.datetim
         return updated_sources
 
     # Pre-filter sources: Only keep those with records in Elasticsearch
-    provider = get_task_provider(provider_name=provider_name, base_url=None, api_key=None, task_name=task_name)
+    provider = get_task_provider(provider_name=provider_name, task_name=task_name)
     sources_with_records = []
     sources_with_no_records = []
 

--- a/mcweb/backend/sources/tasks.py
+++ b/mcweb/backend/sources/tasks.py
@@ -349,8 +349,9 @@ def analyze_sources(provider_name: str, sources:QuerySet, start_date: dt.datetim
     sources_with_records = []
     sources_with_no_records = []
 
+    domain_search_string = provider.domain_search_string()
     for source in sources.iterator():
-        query_str = f"canonical_domain:{source.name}"
+        query_str = f"{domain_search_string}:{source.name}"
         record_count = provider.count(query_str, start_date, END_DATE)
         if record_count > 0:
             sources_with_records.append(source)
@@ -363,7 +364,7 @@ def analyze_sources(provider_name: str, sources:QuerySet, start_date: dt.datetim
     for source in sources_with_records:
         time.sleep(sleep_interval)  # Sleep for 0.6 seconds between requests
         try:
-            query_str = f"canonical_domain:{source.name}"
+            query_str = f"{domain_search_string}:{source.name}"
             if task_name == "update_source_language":
                 languages = provider.languages(query_str, start_date, END_DATE, limit=10)
                 if not languages:

--- a/mcweb/backend/util/csv_stream.py
+++ b/mcweb/backend/util/csv_stream.py
@@ -1,41 +1,53 @@
 import csv
 import io
-from typing import Callable
+from typing import Callable, Iterable
 
 from django.http import StreamingHttpResponse
 
 
 # https://stackoverflow.com/questions/46694898/using-streaminghttpresponse-with-django-rest-framework-csv
-def streaming_csv_response(iterator_func: Callable, filename: str | None = None, chunk_rows: int = 1000):
+def streaming_csv_response(iterator_func: Callable[[], Iterable[tuple]],
+                           filename: str | None = None, chunk_rows: int = 1000):
     """
-    return StreamingHttpResponse with containing CSV encoded rows,
-    with chunk_rows per HTTP chunk; previously streamed HTTP chunks
-    of a single row, which meant a socket write system call, and possibily a
-    single packet per row!
+    returns StreamingHttpResponse with containing CSV encoded rows,
+    with chunk_rows per HTTP chunk to fill packets and ammortize
+    overhead.
 
-    "all-sources" manage command
+    `iterator_func` is a function that returns an iterable that
+    returns row tuples (expects header if any to be the first tuple),
+    hopefully a generator, so all the data doesn't need to be buffered.
+ 
+    The "all-sources" manage command:
     mcweb/backend/sources/management/commands/all-sources.py
     tests this routine!
+
+    Tried taking min chunk size (checking buf.tell() after each writerow)
+    but buf is in unicode characters, not bytes...
     """
-    buf = io.StringIO()
+    buf = io.StringIO(newline='')
     writer = csv.writer(buf)
 
+    # make a single use iterator from iterable (generator)
+    # so that each "for row ..." doesn't restart from top
     iterator = iter(iterator_func())
     def _chunk():
         """
         returns string chunks with chunk_rows each
         """
+        done = False
         while True:
             rows = []
-            for item in iterator:
-                rows.append(item)
+            for row in iterator:
+                rows.append(row)
                 if len(rows) >= chunk_rows:
                     break
+            else:
+                done = True
             writer.writerows(rows)
             chunk = buf.getvalue()
             #print(len(rows), rows[0], rows[-1], len(chunk))
             yield chunk
-            if len(rows) < chunk_rows:
+            if done:
                 return
             buf.seek(0)         # rewind
             buf.truncate(0)     # clear buffer

--- a/mcweb/backend/util/csv_stream.py
+++ b/mcweb/backend/util/csv_stream.py
@@ -21,10 +21,6 @@ def streaming_csv_response(iterator_func: Callable, filename: str | None = None,
     buf = io.StringIO()
     writer = csv.writer(buf)
 
-    # This replaces sending single line HTTP chunks (lots of system calls and network packets)
-    # so it doesn't matter a HUGE amount if this is a little slower than it could be...
-    # writer.writerows() didn't seem to be better than multiple writerow calls.
-
     iterator = iter(iterator_func())
     def _chunk():
         """

--- a/mcweb/backend/util/csv_stream.py
+++ b/mcweb/backend/util/csv_stream.py
@@ -9,10 +9,9 @@ from django.http import StreamingHttpResponse
 def streaming_csv_response(iterator_func: Callable, filename: str | None = None, chunk_rows: int = 1000):
     """
     return StreamingHttpResponse with containing CSV encoded rows,
-    with chunk_rows per HTTP chunk (old solution returned one line per chunk,
-    which meant a socket write system call, and possibily a single packet per row!
-
-    paginates without knowing length of sequence, and without reading ahead.
+    with chunk_rows per HTTP chunk; previously streamed HTTP chunks
+    of a single row, which meant a socket write system call, and possibily a
+    single packet per row!
 
     "all-sources" manage command
     mcweb/backend/sources/management/commands/all-sources.py
@@ -25,7 +24,6 @@ def streaming_csv_response(iterator_func: Callable, filename: str | None = None,
     def _chunk():
         """
         returns string chunks with chunk_rows each
-        without reading ahead.
         """
         while True:
             rows = []

--- a/mcweb/backend/util/csv_stream.py
+++ b/mcweb/backend/util/csv_stream.py
@@ -1,54 +1,53 @@
-from django.http import StreamingHttpResponse
 import csv
+import io
 from typing import Callable
 
-
-# solution pulled from https://gist.github.com/niuware/ba19bbc0169039e89326e1599dba3a87
-
-class CSVBuffer:
-    """An object that implements just the write method of the file-like
-    interface.
-    """
-    def write(self, value):
-        """Return the string to write."""
-        return value
+from django.http import StreamingHttpResponse
 
 
 # https://stackoverflow.com/questions/46694898/using-streaminghttpresponse-with-django-rest-framework-csv
 def streaming_csv_response(iterator_func: Callable, filename: str | None = None, chunk_rows: int = 1000):
     """
     return StreamingHttpResponse with containing CSV encoded rows,
-    with chunk_rows per HTTP chunk
-    """
-    writer = csv.writer(CSVBuffer())
+    with chunk_rows per HTTP chunk (old solution returned one line per chunk,
+    which meant a socket write system call, and possibily a single packet per row!
 
-    # paginate without knowing length of sequence, chunking data.
-    # writer.writerows doesn't return formatted data, as writer.writerow does,
-    # AND it writes lines one at a time?!
+    paginates without knowing length of sequence, and without reading ahead.
+
+    "all-sources" manage command
+    mcweb/backend/sources/management/commands/all-sources.py
+    tests this routine!
+    """
+    buf = io.StringIO()
+    writer = csv.writer(buf)
 
     # This replaces sending single line HTTP chunks (lots of system calls and network packets)
     # so it doesn't matter a HUGE amount if this is a little slower than it could be...
     # writer.writerows() didn't seem to be better than multiple writerow calls.
 
     iterator = iter(iterator_func())
-    def _pager():
+    def _chunk():
         """
-        returns chunks with chunk_rows each
+        returns string chunks with chunk_rows each
+        without reading ahead.
         """
         while True:
             rows = []
             for item in iterator:
-                rows.append(writer.writerow(item))
+                rows.append(item)
                 if len(rows) >= chunk_rows:
                     break
-            chunk = "".join(rows)
-            #print(len(rows), rows[0].strip(), rows[-1].strip(), len(chunk))
+            writer.writerows(rows)
+            chunk = buf.getvalue()
+            #print(len(rows), rows[0], rows[-1], len(chunk))
             yield chunk
             if len(rows) < chunk_rows:
                 return
+            buf.seek(0)         # rewind
+            buf.truncate(0)     # clear buffer
 
-    # 2. Create the StreamingHttpResponse using _pager generator for chunks
-    response = StreamingHttpResponse(_pager(), content_type="text/csv")
+    # 2. Create the StreamingHttpResponse using _chunk generator for chunks
+    response = StreamingHttpResponse(_chunk(), content_type="text/csv")
     if filename:
         # 3. Add additional headers to the response
         response['Content-Disposition'] = f"attachment; filename={filename}.csv"

--- a/mcweb/backend/util/csv_stream.py
+++ b/mcweb/backend/util/csv_stream.py
@@ -3,7 +3,6 @@ import csv
 from typing import Callable
 
 
-
 # solution pulled from https://gist.github.com/niuware/ba19bbc0169039e89326e1599dba3a87
 
 class CSVBuffer:

--- a/mcweb/backend/util/csv_stream.py
+++ b/mcweb/backend/util/csv_stream.py
@@ -3,6 +3,7 @@ import csv
 from typing import Callable
 
 
+
 # solution pulled from https://gist.github.com/niuware/ba19bbc0169039e89326e1599dba3a87
 
 class CSVBuffer:
@@ -14,21 +15,43 @@ class CSVBuffer:
         return value
 
 
-class CSVStream:
-    """Class to stream (download) an iterator to a
-    CSV file."""
+# https://stackoverflow.com/questions/46694898/using-streaminghttpresponse-with-django-rest-framework-csv
+def streaming_csv_response(iterator_func: Callable, filename: str | None = None, chunk_rows: int = 1000):
+    """
+    return StreamingHttpResponse with containing CSV encoded rows,
+    with chunk_rows per HTTP chunk
+    """
+    writer = csv.writer(CSVBuffer())
 
-    def __init__(self, filename: str, iterator_func: Callable):
-        self._filename = filename
-        self._iterator_func = iterator_func
+    # paginate without knowing length of sequence, chunking data.
+    # writer.writerows doesn't return formatted data, as writer.writerow does,
+    # AND it writes lines one at a time?!
 
-    def stream(self):
-        # 1. Create our writer object with the pseudo buffer
-        writer = csv.writer(CSVBuffer())
-        # 2. Create the StreamingHttpResponse using our iterator as streaming content
-        response = StreamingHttpResponse((writer.writerow(data) for data in self._iterator_func()),
-                                         content_type="text/csv")
+    # This replaces sending single line HTTP chunks (lots of system calls and network packets)
+    # so it doesn't matter a HUGE amount if this is a little slower than it could be...
+    # writer.writerows() didn't seem to be better than multiple writerow calls.
+
+    iterator = iter(iterator_func())
+    def _pager():
+        """
+        returns chunks with chunk_rows each
+        """
+        while True:
+            rows = []
+            for item in iterator:
+                rows.append(writer.writerow(item))
+                if len(rows) >= chunk_rows:
+                    break
+            chunk = "".join(rows)
+            #print(len(rows), rows[0].strip(), rows[-1].strip(), len(chunk))
+            yield chunk
+            if len(rows) < chunk_rows:
+                return
+
+    # 2. Create the StreamingHttpResponse using _pager generator for chunks
+    response = StreamingHttpResponse(_pager(), content_type="text/csv")
+    if filename:
         # 3. Add additional headers to the response
-        response['Content-Disposition'] = f"attachment; filename={self._filename}.csv"
-        # 4. Return the response
-        return response
+        response['Content-Disposition'] = f"attachment; filename={filename}.csv"
+    # 4. Return the response
+    return response

--- a/mcweb/backend/util/provider.py
+++ b/mcweb/backend/util/provider.py
@@ -29,10 +29,5 @@ def get_provider(name: str, *, session_id: str, caching: int, api_key: str | Non
             software_id="web-search", session_id = session_id)
 
 
-def provider_session(task_name:str):
-    return 'f{task_name}@{SENTRY_ENV}'
-
-
-def get_task_provider(provider_name: str, task_name: str):
-    session = provider_session(task_name)
-    return get_provider(provider_name, session_id=session, caching=0)
+def get_task_provider(provider_name: str, task_name: str, caching: int = 0):
+    return get_provider(provider_name, session_id=f'{task_name}@{SENTRY_ENV}', caching=caching)

--- a/mcweb/backend/util/provider.py
+++ b/mcweb/backend/util/provider.py
@@ -7,12 +7,13 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def get_provider(name: str, api_key: str, base_url: str|None, caching: int, session_id: str):
+def get_provider(name: str, *, session_id: str, caching: int, api_key: str | None = None):
     """
-    One place to get a provider configured for web use.
+    The one place to call into mc-providers to get a Provider object.
+    This routine is NOT for general use!!!!
+    Search calls should use pq_provider
+    Background tasks should use get_task_provider
     """
-
-    #A default sessionid that's attached to the sentry environment. 
 
     # BEGIN TEMPORARY CROCKERY!
     extras = {}
@@ -22,8 +23,9 @@ def get_provider(name: str, api_key: str, base_url: str|None, caching: int, sess
             # with circuit breaker tripping:
             extras["partial_responses"] = True
     logger.debug("pq_provider %s %r", name, extras)
+    # END TEMPORARY CROCKERY
 
-    return provider_by_name(name, api_key=api_key, base_url = base_url, caching = caching, 
+    return provider_by_name(name, api_key=api_key, caching = caching,
             software_id="web-search", session_id = session_id)
 
 
@@ -31,6 +33,6 @@ def provider_session(task_name:str):
     return 'f{task_name}@{SENTRY_ENV}'
 
 
-def get_task_provider(provider_name: str, api_key: str, base_url: str|None, task_name:str):
+def get_task_provider(provider_name: str, task_name: str):
     session = provider_session(task_name)
-    return get_provider(provider_name, api_key=api_key, base_url=base_url, caching=0, session_id = session)
+    return get_provider(provider_name, session_id=session, caching=0)

--- a/mcweb/settings.py
+++ b/mcweb/settings.py
@@ -81,7 +81,6 @@ env = environ.Env(      # @@CONFIGURATION@@ definitions (datatype, default value
     EMAIL_ORGANIZATION=(str, "Media Cloud Development"),
     GIT_REV=(str, ""),
     LOG_LEVEL=(str, "DEBUG"),
-    NEWS_SEARCH_API_URL=(str, "http://ramos.angwin:8000/v1/"),
     PROVIDERS_TIMEOUT=(int, 60*10),
     SCRAPE_ERROR_RECIPIENTS=(list, []),
     SCRAPE_TIMEOUT_SECONDS=(float, 30.0), # http connect/read
@@ -135,7 +134,6 @@ EMAIL_ORGANIZATION = env('EMAIL_ORGANIZATION') # used in subject line
 
 GIT_REV = env("GIT_REV")      # supplied by Dokku, returned by /api/version
 LOG_LEVEL = env('LOG_LEVEL').upper()
-NEWS_SEARCH_API_URL = env('NEWS_SEARCH_API_URL')
 PROVIDERS_TIMEOUT = env('PROVIDERS_TIMEOUT')
 
 RSS_FETCHER_URL = env('RSS_FETCHER_URL')


### PR DESCRIPTION
Cleanup:
* Improves CSV streaming efficency (write multi-row HTTP chunks)
* Remove "base_url" from ParsedQuery and provider wrappers (was only used for NSA based Provider)
* Adds all-sources manage command for testing CSV streaming
* Use provider.domain_search_string() instead of hardwired "canonical_domain" in analyze sources
* Fixed task session id formatting, removed provider_session (only used once)
* Removed get_task_provider api_key arg (not currently used/needed), add caching (default to zero)
* Removed NEWS_SEARCH_API_URL config param
