### PR TITLE
use logger.prio() not logging.prio()!

### DIFF
--- a/mcweb/backend/sources/tasks.py
+++ b/mcweb/backend/sources/tasks.py
@@ -105,7 +105,7 @@ class ScrapeContext:
 
             # add handler to root logger
             logging.getLogger('').addHandler(self.handler)
-            logging.info("logging rescrape to %s", path) # path includes user, what, id
+            logger.info("logging rescrape to %s", path) # path includes user, what, id
 
         self.body_chunks: list[str] = []
         return self
@@ -154,9 +154,9 @@ class ScrapeContext:
                             self.body(), SCRAPE_FROM_EMAIL, self.recipients)
 
         if value:
-            logging.error("ending rescrape log %s, Exception: %r", self.fname, value)
+            logger.error("ending rescrape log %s, Exception: %r", self.fname, value)
         else:
-            logging.info("ending rescrape log %s (%.3f sec)", self.fname, sec)
+            logger.info("ending rescrape log %s (%.3f sec)", self.fname, sec)
 
         if self.handler:
             logging.getLogger('').removeHandler(self.handler)


### PR DESCRIPTION
quick fix to scraping logging:
messages logged via "logging.info()" (etc) come out as from "root" logger, not module local logger name.