### PR TITLE
Fix sample stories domain link

### DIFF
--- a/mcweb/frontend/src/features/search/results/SampleStoryShow.jsx
+++ b/mcweb/frontend/src/features/search/results/SampleStoryShow.jsx
@@ -1,16 +1,36 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
 import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import CircularProgress from '@mui/material/CircularProgress';
 import { PROVIDER_NEWS_WAYBACK_MACHINE, PROVIDER_NEWS_MEDIA_CLOUD } from '../util/platforms';
 import { googleFaviconUrl } from '../../ui/uiUtil';
 import InfoMenu from '../../ui/InfoMenu';
 import { selectCurrentUser } from '../../auth/authSlice';
+import { useLazyListSourcesQuery } from '../../../app/services/sourceApi';
 
 export default function SampleStoryShow({
   data, lSTP, platform,
 }) {
   const currentUser = useSelector(selectCurrentUser);
+  const navigate = useNavigate();
+  const [sourceTrigger, {
+    data: sourceSearchResults, isLoading,
+  }] = useLazyListSourcesQuery();
+
+  const handleSourceClick = (mediaUrl) => {
+    sourceTrigger({ name: mediaUrl });
+  };
+
+  useEffect(
+    () => {
+      if (sourceSearchResults && sourceSearchResults.results.length > 0) {
+        navigate(`/sources/${sourceSearchResults.results[0].id}`);
+      }
+    },
+    [sourceSearchResults],
+  );
 
   return (
 
@@ -36,7 +56,13 @@ export default function SampleStoryShow({
                   : googleFaviconUrl(`${sampleStory.media_url}`)}
                 alt={`${sampleStory.media_name}`}
               />
-              <a href={sampleStory.media_url} target="_blank" rel="noreferrer">{sampleStory.media_name}</a>
+              <div
+                onClick={() => handleSourceClick(sampleStory.media_url)}
+                style={{ cursor: 'pointer', color: '#d24527', textDecoration: 'underline' }}
+              >
+                {sampleStory.media_name}
+              </div>
+              {isLoading && <CircularProgress size={20} />}
             </td>
 
             <td>{dayjs(sampleStory.publish_date).format('MM-DD-YY')}</td>

--- a/mcweb/frontend/src/features/search/results/SampleStoryShow.jsx
+++ b/mcweb/frontend/src/features/search/results/SampleStoryShow.jsx
@@ -49,7 +49,7 @@ export default function SampleStoryShow({
               <a href={sampleStory.url} target="_blank" rel="noreferrer">{sampleStory.title}</a>
             </td>
 
-            <td>
+            <td className="source-item">
               <img
                 className="google-icon"
                 src={platform === PROVIDER_NEWS_MEDIA_CLOUD ? googleFaviconUrl(`https://${sampleStory.media_url}`)

--- a/mcweb/frontend/src/features/search/results/styles/_results.scss
+++ b/mcweb/frontend/src/features/search/results/styles/_results.scss
@@ -11,3 +11,7 @@
 
   }
 }
+
+.source-item {
+  display: flex;
+}


### PR DESCRIPTION
- The sample stories domain link, now links to the proper source page in directory
<img width="884" alt="Screen Shot 2025-05-08 at 1 17 10 PM" src="https://github.com/user-attachments/assets/93225d3a-b885-4e70-94a0-f8cf18b21be2" />
closes #1076 