### PR TITLE
Profile 403 on User Not Found

### DIFF
--- a/mcweb/backend/users/views.py
+++ b/mcweb/backend/users/views.py
@@ -45,12 +45,15 @@ def profile(request):
             logger.debug("Token not found")
             data = json.dumps({'message': "API Token Not Found"})
             return HttpResponse(data, content_type='application/json', status=403)
+            
     if request.user.id is not None and not user:
         data = _serialized_current_user(request)
     elif user:
         data = json.dumps(_serialized_api_user(user))
     else:
         data = json.dumps({'message': "User Not Found"})
+        return HttpResponse(data, content_type='application/json', status = 403)
+
     return HttpResponse(data, content_type='application/json')
 
 @api_stats  # PLEASE KEEP FIRST!


### PR DESCRIPTION
Small tweak, let's make sure we raise an error if the user data isn't found, so the client can interpret the request without guessing the json value