### PR TITLE
Fix bugs on update_source_language and update_publication_date tasks

### DIFF
--- a/mcweb/backend/sources/tasks.py
+++ b/mcweb/backend/sources/tasks.py
@@ -15,7 +15,6 @@ import traceback
 import types                    # for TracebackType
 from typing import Dict, List, Tuple
 
-from django.utils.timezone import make_aware
 from mc_providers.exceptions import ProviderParseException
 # PyPI:
 from mcmetadata.feeds import normalize_url
@@ -25,7 +24,6 @@ from django.db import transaction
 from django.db.models import Q, QuerySet
 from django.utils import timezone
 import numpy as np
-from more_itertools.more import first
 
 from ..util.provider import get_task_provider
 

--- a/mcweb/backend/sources/tasks.py
+++ b/mcweb/backend/sources/tasks.py
@@ -505,7 +505,7 @@ def update_publication_date(provider_name:str, batch_size: int = 100) -> None:
     while True:
         # Fetch all sources with a name. first_publication_date may change as older stories are ingested.
         sources_for_publication_date = list(Source.objects.filter(name__isnull=False, id__gt=last_seen_id)\
-                                           .order_by("modified_at")[:batch_size])
+                                           .order_by("id")[:batch_size])
 
         if not sources_for_publication_date:
             logger.info("No new sources to process for publication date analysis.")


### PR DESCRIPTION
This PR introduces the following fixes on the `update_source_language` and `update_publication_date`:

- Tracking processed source IDs during task execution to prevent an infinite loop when a source has no documents in Elasticsearch. This is achieved by processing sources in ascending order by ID and tracking progress using the last seen ID.
- Ensuring tasks do not die when an `mc_providers.exceptions.ProviderParseException` exception is thrown when fetching record counts for a given source.
- Updating the `update_publication_date` task logic to always fetch all sources and update `first_story` only if the value from Elasticsearch is earlier than the current one.

Partially addresses: #1094