### PR TITLE
Updates to Alternative Domains feature

### DIFF
--- a/mcweb/frontend/src/features/sources/ModifySource.jsx
+++ b/mcweb/frontend/src/features/sources/ModifySource.jsx
@@ -278,12 +278,17 @@ export default function ModifySource() {
                 title="The domain that uniquely identifies the Source within our system for
                 searching against the Online News Archive."
               >
-                <th>Alternative Domain</th>
+                <th>Domains</th>
               </Tooltip>
               <th>Delete</th>
             </tr>
           </thead>
           <tbody>
+            <tr>
+              <td>
+                {formState.name}
+              </td>
+            </tr>
             {formState.alternative_domains.map((aD, i) => (
               <tr key={aD ? aD.id : i}>
                 <td>

--- a/mcweb/frontend/src/features/sources/SourceHeader.jsx
+++ b/mcweb/frontend/src/features/sources/SourceHeader.jsx
@@ -1,63 +1,27 @@
-import React, { useState, useRef, useEffect } from 'react';
-import {
-  useParams, Link, Outlet, useNavigate,
-} from 'react-router-dom';
+import React from 'react';
+import { useParams, Link, Outlet } from 'react-router-dom';
 import dayjs from 'dayjs';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Tooltip from '@mui/material/Tooltip';
 import SearchIcon from '@mui/icons-material/Search';
 import HomeIcon from '@mui/icons-material/Home';
-import Autocomplete from '@mui/material/Autocomplete';
-import TextField from '@mui/material/TextField';
-import Alert from '@mui/material/Alert';
-import Dialog from '@mui/material/Dialog';
-import DialogTitle from '@mui/material/DialogTitle';
-import DialogActions from '@mui/material/DialogActions';
-import DialogContent from '@mui/material/DialogContent';
-import DialogContentText from '@mui/material/DialogContentText';
 import CircularProgress from '@mui/material/CircularProgress';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
-import LockClosedIcon from '@mui/icons-material/Lock';
-import ListAltIcon from '@mui/icons-material/ListAlt';
-import {
-  useGetSourceQuery, useDeleteSourceMutation, useRescrapeForFeedsMutation, useLazyListSourcesQuery,
-} from '../../app/services/sourceApi';
-import { useLazyFetchFeedQuery, useListFeedsQuery } from '../../app/services/feedsApi';
-import { useCreateAlternativeDomainMutation } from '../../app/services/alternativeDomainsApi';
-import { PermissionedContributor, PermissionedStaff, ROLE_STAFF } from '../auth/Permissioned';
+import { useGetSourceQuery } from '../../app/services/sourceApi';
+import { PermissionedContributor } from '../auth/Permissioned';
 import urlSerializer from '../search/util/urlSerializer';
-import { platformDisplayName, platformIcon, trimStringForDisplay } from '../ui/uiUtil';
+import { platformDisplayName, platformIcon } from '../ui/uiUtil';
 import { defaultPlatformProvider, defaultPlatformQuery } from '../search/util/platforms';
 import Header from '../ui/Header';
 import ControlBar from '../ui/ControlBar';
-import AlertDialog from '../ui/AlertDialog';
 import MediaNotFound from '../ui/MediaNotFound';
-
-const MIN_QUERY_LEN = 1; // don't query for super short things
-const MAX_RESULTS = 10; // per endpoint
-const MAX_MATCH_DISPLAY_LEN = 50; // make sure labels are too long
+import AdvancedMenu from './util/AdvancedMenu';
+import FeedMenu from './util/FeedMenu';
 
 export default function SourceHeader() {
   const params = useParams();
-  const navigate = useNavigate();
   const sourceId = Number(params.sourceId);
-
-  const [openRefetch, setOpenRefetch] = useState(false);
-  const [openDelete, setOpenDelete] = useState(false);
-  const [openRescrape, setOpenRescrape] = useState(false);
-  const [openCreateAlternativeDomain, setOpenCreateAlternativeDomain] = useState(false);
-  const [openNewAlternativeDomain, setOpenNewAlternativeDomain] = useState(false);
-  const [openSearch, setOpenSearch] = useState(false);
-  const [openAdConfirm, setOpenAdConfirm] = useState(false);
-  const [alternativeDomain, setAlternativeDomain] = useState('');
-  const [sourceOptions, setSourceOptions] = useState([]);
-  const [selectedSource, setSelectedSource] = useState({
-    id: '',
-    label: '',
-  });
-
-  const autocompleteRef = useRef(null);
 
   const {
     data: source,
@@ -65,85 +29,13 @@ export default function SourceHeader() {
     error,
   } = useGetSourceQuery(sourceId);
 
-  const {
-    data: feeds,
-    isLoading: feedsAreLoading,
-  } = useListFeedsQuery({ source_id: sourceId });
-
-  const [
-    sourceTrigger,
-    { isFetching: isSourceSearchFetching, data: sourceSearchResults },
-  ] = useLazyListSourcesQuery();
-
-  const [fetchFeedTrigger] = useLazyFetchFeedQuery();
-  const [deleteSource] = useDeleteSourceMutation();
-  const [scrapeForFeeds] = useRescrapeForFeedsMutation();
-  const [createAlternativeDomain,
-    { error: alternativeDomainError }] = useCreateAlternativeDomainMutation();
-
-  // Handle when user wants to turn this source into an alternative domain, this will delete the source and move
-  // the sources feeds and collection to the alternative domain source
-  const handleCreateAlternativeDomain = async () => {
-    try {
-      await createAlternativeDomain({ source_id: selectedSource.id, alternative_domain_id: sourceId });
-      navigate(`/sources/${selectedSource.id}`);
-      setOpenAdConfirm(false);
-      setOpenCreateAlternativeDomain(false);
-    } catch (e) {
-      setOpenAdConfirm(false);
-      setOpenCreateAlternativeDomain(false);
-    }
-  };
-
-  const handleAddAlternativeDomain = async () => {
-    try {
-      await createAlternativeDomain({ source_id: sourceId, alternative_domain: alternativeDomain });
-    } catch (e) {
-      setOpenNewAlternativeDomain(false);
-      return;
-    }
-    setOpenNewAlternativeDomain(false);
-  };
-
-  const defaultSelectionHandler = (e, value) => {
-    if (value.id) {
-      setSelectedSource({ id: value.id, label: value.label, name: value.name });
-      setOpenCreateAlternativeDomain(true);
-    }
-  };
-
-  useEffect(() => {
-    if (sourceSearchResults) {
-      const existingOptionIds = sourceOptions
-        .filter((o) => o.type === 'source')
-        .map((o) => o.id);
-      const newOptions = sourceSearchResults.results.filter(
-        (s) => !existingOptionIds.includes(s.id),
-      );
-      setSourceOptions(
-        newOptions.slice(0, MAX_RESULTS).map((s) => ({
-          displayGroup: 'Sources',
-          type: 'source',
-          id: s.id,
-          value: s.id,
-          name: s.name,
-          label: `${trimStringForDisplay(
-            s.label || s.name,
-            MAX_MATCH_DISPLAY_LEN,
-          )}`,
-        })),
-      );
-    }
-  }, [sourceSearchResults]);
-
-  if (isLoading || feedsAreLoading) {
+  if (isLoading) {
     return <CircularProgress size="75px" />;
   }
 
   if (error) { return <MediaNotFound source />; }
 
   const PlatformIcon = platformIcon(source.platform);
-  const feedCount = feeds ? feeds.count : 0;
 
   return (
     <>
@@ -170,11 +62,6 @@ export default function SourceHeader() {
         )}
       </Header>
       <ControlBar>
-        {alternativeDomainError && (
-        <Alert sx={{ marginBottom: '10px' }} severity="error">
-          {alternativeDomainError.data || 'An error occurred while creating the alternative domain.'}
-        </Alert>
-        )}
         <Button variant="outlined" startIcon={<SearchIcon titleAccess="search our directory" />}>
           <a
             href={`/search?${urlSerializer([{
@@ -199,277 +86,13 @@ export default function SourceHeader() {
           <a href={source.homepage} target="_blank" rel="noreferrer">Visit Homepage</a>
         </Button>
 
-        <Button variant="outlined" startIcon={<LockOpenIcon titleAccess="admin-edit" />}>
-          <Link to={`/sources/${sourceId}/edit`}>Edit Source</Link>
-        </Button>
-
-        <PermissionedStaff role={ROLE_STAFF}>
-          <AlertDialog
-            outsideTitle="Delete Source"
-            title={`Delete ${platformDisplayName(source.platform)} Source #${sourceId}: ${source.name}`}
-            content={`Are you sure you want to delete ${platformDisplayName(source.platform)}
-                Source #${sourceId}: ${source.name} permanently?`}
-            dispatchNeeded={false}
-            action={deleteSource}
-            actionTarget={sourceId}
-            snackbar
-            snackbarText="Source Deleted!"
-            onClick={() => setOpenDelete(true)}
-            openDialog={openDelete}
-            variant="outlined"
-            navigateNeeded
-            navigateTo="/directory"
-            startIcon={<LockOpenIcon titleAccess="admin-delete" />}
-            secondAction={false}
-            confirmButtonText="delete"
-          />
-        </PermissionedStaff>
-
-        {source.url_search_string && (
-          <Button
-            variant="outlined"
-            disabled
-            startIcon={(
-              <LockClosedIcon
-                titleAccess="child sources should not have feeds"
-              />
-                    )}
-          >
-            Child Sources should not have feeds
-          </Button>
-        )}
-
-        {!source.url_search_string && (
-          <Button
-            variant="outlined"
-            startIcon={(
-              <ListAltIcon
-                titleAccess="source's feeds page"
-              />
-            )}
-          >
-            <Link
-              to={`/sources/${sourceId}/feeds`}
-            >
-              {feedCount === 0 ? 'Add Feeds' : `List Feeds (${feedCount}) `}
-            </Link>
-          </Button>
-        )}
-
         <PermissionedContributor>
-          <AlertDialog
-            outsideTitle="Refetch Feeds"
-            title={`Refetch all of ${source.name} feeds`}
-            content="Are you sure you would like to refetch all feeds for this source?
-                      After confirming the feeds will be queued for refetching.
-                      You can check back at this page in a few minutes to see changes"
-            dispatchNeeded={false}
-            action={fetchFeedTrigger}
-            actionTarget={{ source_id: sourceId }}
-            snackbar
-            snackbarText="Feeds Queued!"
-            onClick={() => setOpenRefetch(true)}
-            openDialog={openRefetch}
-            variant="outlined"
-            startIcon={<LockOpenIcon titleAccess="admin-edit" />}
-            secondAction={false}
-            confirmButtonText="refetch feeds"
-            disabled={!!source.url_search_string}
-          />
-
-          {!source.url_search_string && (
-            <Button variant="outlined" startIcon={<LockOpenIcon titleAccess="admin-create" />}>
-              <Link to={`/sources/${sourceId}/feeds/create`}>Create Feed</Link>
-            </Button>
-          )}
-
-          {source.platform === 'online_news' && (
-
-            <AlertDialog
-              outsideTitle="Rescrape Source"
-              title={`Rescrape Source ${source.name} for new Feeds`}
-              content={`Are you sure you would like to rescrape ${source.name} for new feeds?
-             Confirming will place this source in a queue to be rescraped for new feeds`}
-              dispatchNeeded={false}
-              action={scrapeForFeeds}
-              actionTarget={sourceId}
-              snackbar
-              snackbarText="Source Queued for Rescraping"
-              onClick={() => setOpenRescrape(true)}
-              openDialog={openRescrape}
-              variant="outlined"
-              navigateNeeded={false}
-              startIcon={<LockOpenIcon titleAccess="admin-delete" />}
-              secondAction={false}
-              confirmButtonText="Rescrape"
-              disabled={!!source.url_search_string}
-            />
-          )}
-        </PermissionedContributor>
-
-        <PermissionedStaff role={ROLE_STAFF}>
-          <Button
-            onClick={() => setOpenCreateAlternativeDomain(true)}
-            variant="outlined"
-            startIcon={(
-              <LockOpenIcon
-                titleAccess="admin-delete"
-              />
-            )}
-            disabled={!!source.url_search_string}
-          >
-            Turn Source Into Alternative Domain
+          <Button variant="outlined" startIcon={<LockOpenIcon titleAccess="admin-edit" />}>
+            <Link to={`/sources/${sourceId}/edit`}>Edit Source</Link>
           </Button>
-          <Dialog
-            open={openCreateAlternativeDomain}
-            onClose={() => setOpenCreateAlternativeDomain(false)}
-          >
-            <DialogTitle id="alert-dialog-title">
-              {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-              Choose a Source to Create Alternative Domain for {source.name}.
-              {' '}
-            </DialogTitle>
-            <DialogContent>
-              <DialogContentText sx={{ marginBottom: '10px' }}>
-                First search for a source in the searchbar and hit &quot;Enter&quot; to search.
-                Then click a source and &quot;Submit&quot; when the correct source is selected.
-              </DialogContentText>
-              <Autocomplete
-                ref={autocompleteRef}
-                id="quick-source-search"
-                open={openSearch}
-                filterOptions={(x) => x} /* let the server filter optons */
-                onOpen={() => {}}
-                onClose={() => {
-                  setOpenSearch(false);
-                }}
-                blurOnSelect
-                isOptionEqualToValue={(option, value) => option.id === value.id}
-                getOptionLabel={(option) => option.label}
-                noOptionsText="No matches"
-                groupBy={(option) => option.displayGroup}
-                options={[...sourceOptions]}
-                loading={isSourceSearchFetching}
-                onChange={defaultSelectionHandler}
-                renderInput={(renderParams) => (
-                  <TextField
-                    // eslint-disable-next-line react/jsx-props-no-spreading
-                    {...renderParams}
-                    label="Find a source to create an alternative domain for"
-                    value={source}
-                    disabled={isSourceSearchFetching}
-                    InputProps={{
-                      ...renderParams.InputProps,
-                      endAdornment: (
-                        <>
-                          {isSourceSearchFetching ? (
-                            <CircularProgress color="inherit" size={20} />
-                          ) : null}
-                          {renderParams.InputProps.endAdornment}
-                        </>
-                      ),
-                    }}
-                    onKeyUp={(event) => {
-                      if (event.key === 'Enter') {
-                        const { value } = event.target;
-                        setOpenSearch(true);
-                        setSourceOptions([]);
 
-                        // only search if str is long enough
-                        if (value.length > MIN_QUERY_LEN) {
-                          // setLastRequestTime(Date.now());
-                          sourceTrigger({ name: value });
-                        }
-                      }
-                    }}
-                  />
-                )}
-              />
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={() => setOpenCreateAlternativeDomain(false)}>Cancel</Button>
-              <Button
-                onClick={() => setOpenAdConfirm(true)}
-                disabled={!selectedSource.id}
-              >
-                Submit
-              </Button>
-            </DialogActions>
-          </Dialog>
-          {/* Turn source into alternative domain confirmation modal */}
-          <Dialog
-            open={openAdConfirm}
-            onClose={() => setOpenAdConfirm(false)}
-          >
-            <DialogTitle>
-              {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-              Are you sure you want to turn this source into an alternative domain for another source?
-            </DialogTitle>
-            <DialogContent>
-              <DialogContentText>
-                {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-                Are you sure you want to turn {source.label || source.name} into an alternative domain for
-                {' '}
-                {selectedSource.label || selectedSource.name}
-                ? This will delete
-                {' '}
-                {source.label || source.name}
-                {' '}
-                and will transfer all collections and feeds to
-                {' '}
-                {selectedSource.label || selectedSource.name}
-                .
-              </DialogContentText>
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={() => setOpenAdConfirm(false)}>Cancel</Button>
-              <Button onClick={() => handleCreateAlternativeDomain()}>Confirm</Button>
-            </DialogActions>
-          </Dialog>
-        </PermissionedStaff>
-        <PermissionedContributor>
-          <Button
-            onClick={() => setOpenNewAlternativeDomain(true)}
-            variant="outlined"
-            startIcon={(
-              <LockOpenIcon
-                titleAccess="admin-delete"
-              />
-            )}
-            disabled={!!source.url_search_string}
-          >
-            Create New Alternative Domain
-          </Button>
-          <Dialog
-            open={openNewAlternativeDomain}
-            onClose={() => setOpenNewAlternativeDomain(false)}
-          >
-            <DialogTitle>
-              {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-              Add an Alternative Domain for {source.name}, this should be the canonical domain and should not be a source already.
-              {' '}
-
-            </DialogTitle>
-            <DialogContent>
-              <TextField
-                autoFocus
-                margin="dense"
-                id="ad-name"
-                label="Alternative Domain"
-                type="text"
-                fullWidth
-                variant="standard"
-                onChange={(e) => setAlternativeDomain(e.target.value)}
-                value={alternativeDomain || ''}
-                placeholder="eg...huffpost.com"
-              />
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={() => setOpenNewAlternativeDomain(false)}>Cancel</Button>
-              <Button onClick={() => handleAddAlternativeDomain()}>Confirm</Button>
-            </DialogActions>
-          </Dialog>
-
+          <FeedMenu source={source} disabled={!!source.url_search_string} />
+          <AdvancedMenu source={source} />
         </PermissionedContributor>
       </ControlBar>
       <Outlet />

--- a/mcweb/frontend/src/features/sources/SourceHeader.jsx
+++ b/mcweb/frontend/src/features/sources/SourceHeader.jsx
@@ -91,7 +91,10 @@ export default function SourceHeader() {
             <Link to={`/sources/${sourceId}/edit`}>Edit Source</Link>
           </Button>
 
-          <FeedMenu source={source} disabled={!!source.url_search_string} />
+          <FeedMenu
+            source={source}
+            disabled={!!source.url_search_string}
+          />
           <AdvancedMenu source={source} />
         </PermissionedContributor>
       </ControlBar>

--- a/mcweb/frontend/src/features/sources/SourceShow.jsx
+++ b/mcweb/frontend/src/features/sources/SourceShow.jsx
@@ -128,8 +128,11 @@ export default function SourceShow() {
         {(source.alternative_domains[0]) && (
           <div className="row">
             {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-            <b>Alternative Domains:</b>
+            <b>Domains:</b>
             <ul>
+              <li key={source.domain}>
+                {source.name}
+              </li>
               {source.alternative_domains.map((aD) => (
                 <li key={aD.domain}>
                   {aD.domain}

--- a/mcweb/frontend/src/features/sources/SourceShow.jsx
+++ b/mcweb/frontend/src/features/sources/SourceShow.jsx
@@ -120,26 +120,23 @@ export default function SourceShow() {
         </div>
         )}
         {source.notes && (
-        <p>
+        <div>
           {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
           <b>Notes:</b> {source.notes && renderNotes(source.notes, false)}
-        </p>
+        </div>
         )}
         {(source.alternative_domains[0]) && (
-        <div>
           <div className="row">
             {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-            <p><b>Alternative Domains</b>:
-              <ul>
-                {source.alternative_domains.map((aD) => (
-                  <li>
-                    {aD.domain}
-                  </li>
-                ))}
-              </ul>
-            </p>
+            <b>Alternative Domains:</b>
+            <ul>
+              {source.alternative_domains.map((aD) => (
+                <li key={aD.domain}>
+                  {aD.domain}
+                </li>
+              ))}
+            </ul>
           </div>
-        </div>
         )}
         <p>
           {/* eslint-disable-next-line react/jsx-one-expression-per-line */}

--- a/mcweb/frontend/src/features/sources/util/AdvancedMenu.jsx
+++ b/mcweb/frontend/src/features/sources/util/AdvancedMenu.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSnackbar } from 'notistack';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -26,6 +27,7 @@ export default function AdvancedMenu({
   source,
 }) {
   const navigate = useNavigate();
+  const { enqueueSnackbar } = useSnackbar();
 
   const autocompleteRef = useRef(null);
 
@@ -60,6 +62,19 @@ export default function AdvancedMenu({
     }
   };
 
+  const handleConvertIntoAlternativeDomain = () => {
+    createAlternativeDomain({ source_id: selectedSource.id, alternative_domain_id: source.id });
+    setOpenAdvanced(false);
+    setOpenCreateAlternativeDomain(false);
+    setOpenAdConfirm(false);
+    navigate(`/sources/${selectedSource.id}`);
+    enqueueSnackbar(
+      `Source #${source.id} (${source.name}) converted into an alternative domain  
+      for Source #${selectedSource.id} (${selectedSource.name})`,
+      { variant: 'success' },
+    );
+  };
+
   useEffect(() => {
     if (sourceSearchResults) {
       const existingOptionIds = sourceOptions
@@ -85,19 +100,9 @@ export default function AdvancedMenu({
   }, [sourceSearchResults]);
 
   useEffect(() => {
-    setOpenAdConfirm(false);
-  }, [alternativeDomainError]);
-
-  useEffect(() => {
     if (altDomain) {
       setOpenNewAlternativeDomain(false);
       setOpenAdvanced(false);
-      setAlternativeDomain('');
-      setOpenCreateAlternativeDomain(false);
-      setOpenAdConfirm(false);
-      if (altDomain.source) {
-        navigate(`/sources/${altDomain.source}`);
-      }
     }
   }, [altDomain]);
 
@@ -129,10 +134,11 @@ export default function AdvancedMenu({
               variant="outlined"
               startIcon={(
                 <LockOpenIcon
-                  titleAccess="admin-delete"
+                  titleAccess="convert-source-to-ad"
                 />
             )}
               disabled={!!source.url_search_string}
+              sx={{ marginRight: '5px' }}
             >
               Convert Source Into Alternative Domain
             </Button>
@@ -142,18 +148,21 @@ export default function AdvancedMenu({
             >
               {alternativeDomainError && (
               <Alert severity="error" sx={{ marginBottom: '10px' }}>
-                {console.log(alternativeDomainError)}
                 Error creating alternative domain:
                 {' '}
-                {alternativeDomainError?.data}
+                {/*  eslint-disable-next-line no-console */}
+                {alternativeDomainError?.data || console.error(alternativeDomainError)}
               </Alert>
               )}
               <DialogTitle id="alert-dialog-title">
                 {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-                Choose a Source to Create Alternative Domain for {source.name}.
-                {' '}
+                Choose a Source for {source.name} to be converted into to an Alternative Domain.
               </DialogTitle>
               <DialogContent>
+                <Alert severity="error" sx={{ marginBottom: '10px' }}>
+                  Converting a source into an alternative domain will delete the source,
+                  this change can not be undone.
+                </Alert>
                 <DialogContentText sx={{ marginBottom: '10px' }}>
                   First search for a source in the searchbar and hit &quot;Enter&quot; to search.
                   Then click a source and &quot;Submit&quot; when the correct source is selected.
@@ -245,11 +254,15 @@ export default function AdvancedMenu({
                   {selectedSource.label || selectedSource.name}
                   .
                 </DialogContentText>
+                <Alert severity="error" sx={{ marginTop: '10px' }}>
+                  Converting a source into an alternative domain will delete the source,
+                  this change can not be undone.
+                </Alert>
               </DialogContent>
               <DialogActions>
                 <Button onClick={() => setOpenAdConfirm(false)}>Cancel</Button>
                 <Button
-                  onClick={() => createAlternativeDomain({ source_id: selectedSource.id, alternative_domain_id: source.id })}
+                  onClick={handleConvertIntoAlternativeDomain}
                 >
                   Confirm
                 </Button>
@@ -262,9 +275,10 @@ export default function AdvancedMenu({
               variant="outlined"
               startIcon={(
                 <LockOpenIcon
-                  titleAccess="admin-delete"
+                  titleAccess="create-alternative-domain"
                 />
             )}
+              sx={{ marginRight: '5px' }}
               disabled={!!source.url_search_string}
             >
               Create Alternative Domain
@@ -275,10 +289,10 @@ export default function AdvancedMenu({
             >
               {alternativeDomainError && (
               <Alert severity="error" sx={{ marginBottom: '10px' }}>
-                {console.log(alternativeDomainError)}
                 Error creating alternative domain:
                 {' '}
-                {alternativeDomainError?.data || 'Unknown error'}
+                {/*  eslint-disable-next-line no-console */}
+                {alternativeDomainError?.data || console.error(alternativeDomainError)}
               </Alert>
               )}
               <DialogTitle>

--- a/mcweb/frontend/src/features/sources/util/AdvancedMenu.jsx
+++ b/mcweb/frontend/src/features/sources/util/AdvancedMenu.jsx
@@ -1,0 +1,348 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContentText from '@mui/material/DialogContentText';
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+import CircularProgress from '@mui/material/CircularProgress';
+import Button from '@mui/material/Button';
+import Alert from '@mui/material/Alert';
+import LockOpenIcon from '@mui/icons-material/LockOpen';
+import PropTypes from 'prop-types';
+import AlertDialog from '../../ui/AlertDialog';
+import { trimStringForDisplay, platformDisplayName } from '../../ui/uiUtil';
+import { PermissionedStaff, PermissionedContributor, ROLE_STAFF } from '../../auth/Permissioned';
+import { useCreateAlternativeDomainMutation } from '../../../app/services/alternativeDomainsApi';
+import { useLazyListSourcesQuery, useDeleteSourceMutation } from '../../../app/services/sourceApi';
+
+const MIN_QUERY_LEN = 3; // don't query for super short things
+const MAX_RESULTS = 10; // per endpoint
+const MAX_MATCH_DISPLAY_LEN = 50; // make sure labels are too long
+
+export default function AdvancedMenu({
+  source,
+}) {
+  const navigate = useNavigate();
+
+  const autocompleteRef = useRef(null);
+
+  const [openDelete, setOpenDelete] = useState(false);
+  const [openCreateAlternativeDomain, setOpenCreateAlternativeDomain] = useState(false);
+  const [openNewAlternativeDomain, setOpenNewAlternativeDomain] = useState(false);
+  const [alternativeDomain, setAlternativeDomain] = useState('');
+  const [sourceOptions, setSourceOptions] = useState([]);
+  const [openAdConfirm, setOpenAdConfirm] = useState(false);
+  const [openSearch, setOpenSearch] = useState(false);
+  const [openAdvanced, setOpenAdvanced] = useState(false);
+
+  const [selectedSource, setSelectedSource] = useState({
+    id: '',
+    label: '',
+  });
+
+  const [createAlternativeDomain,
+    { data: altDomain, error: alternativeDomainError }] = useCreateAlternativeDomainMutation();
+
+  const [
+    sourceTrigger,
+    { isFetching: isSourceSearchFetching, data: sourceSearchResults },
+  ] = useLazyListSourcesQuery();
+
+  const [deleteSource] = useDeleteSourceMutation();
+
+  const defaultSelectionHandler = (e, value) => {
+    if (value.id) {
+      setSelectedSource({ id: value.id, label: value.label, name: value.name });
+      setOpenCreateAlternativeDomain(true);
+    }
+  };
+
+  useEffect(() => {
+    if (sourceSearchResults) {
+      const existingOptionIds = sourceOptions
+        .filter((o) => o.type === 'source')
+        .map((o) => o.id);
+      const newOptions = sourceSearchResults.results.filter(
+        (s) => !existingOptionIds.includes(s.id),
+      );
+      setSourceOptions(
+        newOptions.slice(0, MAX_RESULTS).map((s) => ({
+          displayGroup: 'Sources',
+          type: 'source',
+          id: s.id,
+          value: s.id,
+          name: s.name,
+          label: `${trimStringForDisplay(
+            s.label || s.name,
+            MAX_MATCH_DISPLAY_LEN,
+          )}`,
+        })),
+      );
+    }
+  }, [sourceSearchResults]);
+
+  useEffect(() => {
+    setOpenAdConfirm(false);
+  }, [alternativeDomainError]);
+
+  useEffect(() => {
+    if (altDomain) {
+      setOpenNewAlternativeDomain(false);
+      setOpenAdvanced(false);
+      setAlternativeDomain('');
+      setOpenCreateAlternativeDomain(false);
+      setOpenAdConfirm(false);
+      if (altDomain.source) {
+        navigate(`/sources/${altDomain.source}`);
+      }
+    }
+  }, [altDomain]);
+
+  return (
+    <>
+      <Button
+        onClick={() => setOpenAdvanced(true)}
+        variant="outlined"
+        startIcon={(
+          <LockOpenIcon
+            titleAccess="admin-advanced"
+          />
+        )}
+        disabled={!!source.url_search_string}
+      >
+        Advanced Options...
+      </Button>
+      <Dialog
+        open={openAdvanced}
+        onClose={() => setOpenAdvanced(false)}
+        maxWidth="md"
+        fullWidth
+      >
+        <DialogContent>
+          {/* CONVERT SOURCE TO AD SEARCH MODAL  */}
+          <PermissionedStaff role={ROLE_STAFF}>
+            <Button
+              onClick={() => setOpenCreateAlternativeDomain(true)}
+              variant="outlined"
+              startIcon={(
+                <LockOpenIcon
+                  titleAccess="admin-delete"
+                />
+            )}
+              disabled={!!source.url_search_string}
+            >
+              Convert Source Into Alternative Domain
+            </Button>
+            <Dialog
+              open={openCreateAlternativeDomain}
+              onClose={() => setOpenCreateAlternativeDomain(false)}
+            >
+              {alternativeDomainError && (
+              <Alert severity="error" sx={{ marginBottom: '10px' }}>
+                {console.log(alternativeDomainError)}
+                Error creating alternative domain:
+                {' '}
+                {alternativeDomainError?.data}
+              </Alert>
+              )}
+              <DialogTitle id="alert-dialog-title">
+                {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
+                Choose a Source to Create Alternative Domain for {source.name}.
+                {' '}
+              </DialogTitle>
+              <DialogContent>
+                <DialogContentText sx={{ marginBottom: '10px' }}>
+                  First search for a source in the searchbar and hit &quot;Enter&quot; to search.
+                  Then click a source and &quot;Submit&quot; when the correct source is selected.
+                </DialogContentText>
+                <Autocomplete
+                  ref={autocompleteRef}
+                  id="quick-source-search"
+                  open={openSearch}
+                  filterOptions={(x) => x} /* let the server filter optons */
+                  onOpen={() => {}}
+                  onClose={() => {
+                    setOpenSearch(false);
+                  }}
+                  blurOnSelect
+                  isOptionEqualToValue={(option, value) => option.id === value.id}
+                  getOptionLabel={(option) => option.label}
+                  noOptionsText="No matches"
+                  groupBy={(option) => option.displayGroup}
+                  options={[...sourceOptions]}
+                  loading={isSourceSearchFetching}
+                  onChange={defaultSelectionHandler}
+                  renderInput={(renderParams) => (
+                    <TextField
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                      {...renderParams}
+                      label="Find a source to create an alternative domain for"
+                      value={source}
+                      disabled={isSourceSearchFetching}
+                      InputProps={{
+                        ...renderParams.InputProps,
+                        endAdornment: (
+                          <>
+                            {isSourceSearchFetching ? (
+                              <CircularProgress color="inherit" size={20} />
+                            ) : null}
+                            {renderParams.InputProps.endAdornment}
+                          </>
+                        ),
+                      }}
+                      onKeyUp={(event) => {
+                        if (event.key === 'Enter') {
+                          const { value } = event.target;
+                          setOpenSearch(true);
+                          setSourceOptions([]);
+
+                          // only search if str is long enough
+                          if (value.length > MIN_QUERY_LEN) {
+                          // setLastRequestTime(Date.now());
+                            sourceTrigger({ name: value });
+                          }
+                        }
+                      }}
+                    />
+                  )}
+                />
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={() => setOpenCreateAlternativeDomain(false)}>Cancel</Button>
+                <Button
+                  onClick={() => setOpenAdConfirm(true)}
+                  disabled={!selectedSource.id}
+                >
+                  Submit
+                </Button>
+              </DialogActions>
+            </Dialog>
+
+            {/* CONVERTING SOURCE TO ALTERNATIVE DOMAIN CONFIRMATION MODAL */}
+            <Dialog
+              open={openAdConfirm}
+              onClose={() => setOpenAdConfirm(false)}
+            >
+              <DialogTitle>
+                {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
+                Are you sure you want to turn this source into an alternative domain for another source?
+              </DialogTitle>
+              <DialogContent>
+                <DialogContentText>
+                  {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
+                  Are you sure you want to turn {source.label || source.name} into an alternative domain for
+                  {' '}
+                  {selectedSource.label || selectedSource.name}
+                  ? This will delete
+                  {' '}
+                  {source.label || source.name}
+                  {' '}
+                  and will transfer all collections and feeds to
+                  {' '}
+                  {selectedSource.label || selectedSource.name}
+                  .
+                </DialogContentText>
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={() => setOpenAdConfirm(false)}>Cancel</Button>
+                <Button
+                  onClick={() => createAlternativeDomain({ source_id: selectedSource.id, alternative_domain_id: source.id })}
+                >
+                  Confirm
+                </Button>
+              </DialogActions>
+            </Dialog>
+          </PermissionedStaff>
+          <PermissionedContributor>
+            <Button
+              onClick={() => setOpenNewAlternativeDomain(true)}
+              variant="outlined"
+              startIcon={(
+                <LockOpenIcon
+                  titleAccess="admin-delete"
+                />
+            )}
+              disabled={!!source.url_search_string}
+            >
+              Create Alternative Domain
+            </Button>
+            <Dialog
+              open={openNewAlternativeDomain}
+              onClose={() => setOpenNewAlternativeDomain(false)}
+            >
+              {alternativeDomainError && (
+              <Alert severity="error" sx={{ marginBottom: '10px' }}>
+                {console.log(alternativeDomainError)}
+                Error creating alternative domain:
+                {' '}
+                {alternativeDomainError?.data || 'Unknown error'}
+              </Alert>
+              )}
+              <DialogTitle>
+                {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
+                Add an Alternative Domain for {source.name},{' '}
+                this should be the canonical domain and should not be a source already.
+              </DialogTitle>
+              <DialogContent>
+                <TextField
+                  autoFocus
+                  margin="dense"
+                  id="ad-name"
+                  label="Alternative Domain"
+                  type="text"
+                  fullWidth
+                  variant="standard"
+                  onChange={(e) => setAlternativeDomain(e.target.value)}
+                  value={alternativeDomain || ''}
+                  placeholder="eg...huffpost.com"
+                />
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={() => setOpenNewAlternativeDomain(false)}>Cancel</Button>
+                <Button onClick={() => createAlternativeDomain({ source_id: source.id, alternative_domain: alternativeDomain })}>
+                  Confirm
+                </Button>
+              </DialogActions>
+            </Dialog>
+
+          </PermissionedContributor>
+          {/* DELETE SOURCE */}
+          <PermissionedStaff role={ROLE_STAFF}>
+            <AlertDialog
+              outsideTitle="Delete Source"
+              title={`Delete ${platformDisplayName(source.platform)} Source #${source.id}: ${source.name}`}
+              content={`Are you sure you want to delete ${platformDisplayName(source.platform)}
+                          Source #${source.id}: ${source.name} permanently?`}
+              dispatchNeeded={false}
+              action={deleteSource}
+              actionTarget={source.id}
+              snackbar
+              snackbarText="Source Deleted!"
+              onClick={() => setOpenDelete(true)}
+              openDialog={openDelete}
+              variant="outlined"
+              navigateNeeded
+              navigateTo="/directory"
+              startIcon={<LockOpenIcon titleAccess="admin-delete" />}
+              secondAction={false}
+              confirmButtonText="delete"
+            />
+          </PermissionedStaff>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+AdvancedMenu.propTypes = {
+  source: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    platform: PropTypes.string.isRequired,
+    url_search_string: PropTypes.string,
+  }).isRequired,
+};

--- a/mcweb/frontend/src/features/sources/util/AdvancedMenu.jsx
+++ b/mcweb/frontend/src/features/sources/util/AdvancedMenu.jsx
@@ -6,12 +6,15 @@ import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContentText from '@mui/material/DialogContentText';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 import Autocomplete from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
 import CircularProgress from '@mui/material/CircularProgress';
 import Button from '@mui/material/Button';
 import Alert from '@mui/material/Alert';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
+import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
 import PropTypes from 'prop-types';
 import AlertDialog from '../../ui/AlertDialog';
 import { trimStringForDisplay, platformDisplayName } from '../../ui/uiUtil';
@@ -39,6 +42,7 @@ export default function AdvancedMenu({
   const [openAdConfirm, setOpenAdConfirm] = useState(false);
   const [openSearch, setOpenSearch] = useState(false);
   const [openAdvanced, setOpenAdvanced] = useState(false);
+  const [anchorEl, setAnchorEl] = useState(null);
 
   const [selectedSource, setSelectedSource] = useState({
     id: '',
@@ -54,6 +58,11 @@ export default function AdvancedMenu({
   ] = useLazyListSourcesQuery();
 
   const [deleteSource] = useDeleteSourceMutation();
+
+  const handleMenuOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+    setOpenAdvanced(true);
+  };
 
   const defaultSelectionHandler = (e, value) => {
     if (value.id) {
@@ -109,38 +118,38 @@ export default function AdvancedMenu({
   return (
     <>
       <Button
-        onClick={() => setOpenAdvanced(true)}
+        onClick={handleMenuOpen}
         variant="outlined"
         startIcon={(
           <LockOpenIcon
             titleAccess="admin-advanced"
           />
         )}
+        endIcon={<KeyboardArrowDown />}
         disabled={!!source.url_search_string}
       >
-        Advanced Options...
+        Advanced Options
       </Button>
-      <Dialog
+      <Menu
         open={openAdvanced}
         onClose={() => setOpenAdvanced(false)}
         maxWidth="md"
         fullWidth
+        anchorEl={anchorEl}
       >
-        <DialogContent>
+        <MenuItem>
           {/* CONVERT SOURCE TO AD SEARCH MODAL  */}
           <PermissionedStaff role={ROLE_STAFF}>
             <Button
               onClick={() => setOpenCreateAlternativeDomain(true)}
-              variant="outlined"
               startIcon={(
                 <LockOpenIcon
                   titleAccess="convert-source-to-ad"
                 />
             )}
               disabled={!!source.url_search_string}
-              sx={{ marginRight: '5px' }}
             >
-              Convert Source Into Alternative Domain
+              Convert Source Into Alternative Domain...
             </Button>
             <Dialog
               open={openCreateAlternativeDomain}
@@ -268,32 +277,34 @@ export default function AdvancedMenu({
                 </Button>
               </DialogActions>
             </Dialog>
+
           </PermissionedStaff>
+        </MenuItem>
+        <MenuItem>
           <PermissionedContributor>
             <Button
               onClick={() => setOpenNewAlternativeDomain(true)}
-              variant="outlined"
               startIcon={(
                 <LockOpenIcon
                   titleAccess="create-alternative-domain"
                 />
             )}
-              sx={{ marginRight: '5px' }}
               disabled={!!source.url_search_string}
             >
-              Create Alternative Domain
+              Create Alternative Domain...
             </Button>
+
             <Dialog
               open={openNewAlternativeDomain}
               onClose={() => setOpenNewAlternativeDomain(false)}
             >
               {alternativeDomainError && (
-              <Alert severity="error" sx={{ marginBottom: '10px' }}>
-                Error creating alternative domain:
-                {' '}
-                {/*  eslint-disable-next-line no-console */}
-                {alternativeDomainError?.data || console.error(alternativeDomainError)}
-              </Alert>
+                <Alert severity="error" sx={{ marginBottom: '10px' }}>
+                  Error creating alternative domain:
+                  {' '}
+                  {/*  eslint-disable-next-line no-console */}
+                  {alternativeDomainError?.data || console.error(alternativeDomainError)}
+                </Alert>
               )}
               <DialogTitle>
                 {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
@@ -323,7 +334,9 @@ export default function AdvancedMenu({
             </Dialog>
 
           </PermissionedContributor>
-          {/* DELETE SOURCE */}
+        </MenuItem>
+        {/* DELETE SOURCE */}
+        <MenuItem>
           <PermissionedStaff role={ROLE_STAFF}>
             <AlertDialog
               outsideTitle="Delete Source"
@@ -337,7 +350,7 @@ export default function AdvancedMenu({
               snackbarText="Source Deleted!"
               onClick={() => setOpenDelete(true)}
               openDialog={openDelete}
-              variant="outlined"
+              variant="text"
               navigateNeeded
               navigateTo="/directory"
               startIcon={<LockOpenIcon titleAccess="admin-delete" />}
@@ -345,8 +358,9 @@ export default function AdvancedMenu({
               confirmButtonText="delete"
             />
           </PermissionedStaff>
-        </DialogContent>
-      </Dialog>
+        </MenuItem>
+
+      </Menu>
     </>
   );
 }

--- a/mcweb/frontend/src/features/sources/util/FeedMenu.jsx
+++ b/mcweb/frontend/src/features/sources/util/FeedMenu.jsx
@@ -1,0 +1,159 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import ListAltIcon from '@mui/icons-material/ListAlt';
+import LockOpenIcon from '@mui/icons-material/LockOpen';
+import LockClosedIcon from '@mui/icons-material/Lock';
+import AlertDialog from '../../ui/AlertDialog';
+import { useListFeedsQuery, useLazyFetchFeedQuery } from '../../../app/services/feedsApi';
+import { useRescrapeForFeedsMutation } from '../../../app/services/sourceApi';
+
+export default function FeedMenu({ source, disabled }) {
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+  const [openRefetch, setOpenRefetch] = useState(false);
+  const [openRescrape, setOpenRescrape] = useState(false);
+
+  const {
+    data: feeds,
+  } = useListFeedsQuery({ source_id: source.id });
+  const [fetchFeedTrigger] = useLazyFetchFeedQuery();
+  const [scrapeForFeeds] = useRescrapeForFeedsMutation();
+
+  const handleRescrape = () => {
+    setOpenRescrape(true);
+    setOpen(false);
+  };
+
+  const handleRefetch = () => {
+    setOpenRefetch(true);
+    setOpen(false);
+  };
+
+  const handleCreateFeed = () => {
+    navigate(`/sources/${source.id}/feeds/create`);
+    setOpen(false);
+  };
+
+  const handleListFeeds = () => {
+    navigate(`/sources/${source.id}/feeds`);
+    setOpen(false);
+  };
+
+  const feedCount = feeds ? feeds.count : 0;
+
+  return (
+    <>
+      {source.url_search_string && (
+      <Button
+        variant="outlined"
+        disabled={disabled}
+        startIcon={(
+          <LockClosedIcon
+            titleAccess="child sources should not have feeds"
+          />
+                    )}
+      >
+        Child Sources should not have feeds
+      </Button>
+      )}
+
+      <Button
+        variant="outlined"
+        onClick={() => setOpen(true)}
+        startIcon={(
+          <ListAltIcon
+            titleAccess="feeds options"
+          />
+        )}
+      >
+        {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
+        Feeds Options ({feedCount})...
+      </Button>
+      <Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        maxWidth="md"
+      >
+        <DialogContent>
+          {/* LIST FEEDS */}
+          <Button
+            variant="outlined"
+            startIcon={(
+              <ListAltIcon
+                titleAccess="source's feeds page"
+              />
+            )}
+            onClick={handleListFeeds}
+          >
+            {`List Feeds (${feedCount})`}
+          </Button>
+
+          {/* REFETCH FEEDS */}
+          <AlertDialog
+            outsideTitle="Refetch Feeds"
+            title={`Refetch all of ${source.name} feeds`}
+            content="Are you sure you would like to refetch all feeds for this source?
+                                After confirming the feeds will be queued for refetching.
+                                You can check back at this page in a few minutes to see changes"
+            dispatchNeeded={false}
+            action={fetchFeedTrigger}
+            actionTarget={{ source_id: source.id }}
+            snackbar
+            snackbarText="Feeds Queued!"
+            onClick={handleRefetch}
+            openDialog={openRefetch}
+            variant="outlined"
+            startIcon={<LockOpenIcon titleAccess="admin-edit" />}
+            secondAction={false}
+            confirmButtonText="refetch feeds"
+            disabled={!!source.url_search_string}
+          />
+          {/* CREATE FEED */}
+          <Button
+            variant="outlined"
+            startIcon={<LockOpenIcon titleAccess="admin-create" />}
+            onClick={handleCreateFeed}
+          >
+            Create Feed
+          </Button>
+
+          {/* RESCRAPE SOURCE FOR FEEDS */}
+          <AlertDialog
+            outsideTitle="Rescrape Source"
+            title={`Rescrape Source ${source.name} for new Feeds`}
+            content={`Are you sure you would like to rescrape ${source.name} for new feeds?
+                       Confirming will place this source in a queue to be rescraped for new feeds`}
+            dispatchNeeded={false}
+            action={scrapeForFeeds}
+            actionTarget={source.id}
+            snackbar
+            snackbarText="Source Queued for Rescraping"
+            onClick={handleRescrape}
+            openDialog={openRescrape}
+            variant="outlined"
+            navigateNeeded={false}
+            startIcon={<LockOpenIcon titleAccess="admin-delete" />}
+            secondAction={false}
+            confirmButtonText="Rescrape"
+            disabled={!!source.url_search_string}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+FeedMenu.propTypes = {
+  source: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    platform: PropTypes.string.isRequired,
+    url_search_string: PropTypes.string,
+  }).isRequired,
+  disabled: PropTypes.bool.isRequired,
+};

--- a/mcweb/frontend/src/features/sources/util/FeedMenu.jsx
+++ b/mcweb/frontend/src/features/sources/util/FeedMenu.jsx
@@ -2,11 +2,12 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import Button from '@mui/material/Button';
-import Dialog from '@mui/material/Dialog';
-import DialogContent from '@mui/material/DialogContent';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 import ListAltIcon from '@mui/icons-material/ListAlt';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
 import LockClosedIcon from '@mui/icons-material/Lock';
+import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
 import AlertDialog from '../../ui/AlertDialog';
 import { useListFeedsQuery, useLazyFetchFeedQuery } from '../../../app/services/feedsApi';
 import { useRescrapeForFeedsMutation } from '../../../app/services/sourceApi';
@@ -16,12 +17,18 @@ export default function FeedMenu({ source, disabled }) {
   const [open, setOpen] = useState(false);
   const [openRefetch, setOpenRefetch] = useState(false);
   const [openRescrape, setOpenRescrape] = useState(false);
+  const [anchorEl, setAnchorEl] = useState(null);
 
   const {
     data: feeds,
   } = useListFeedsQuery({ source_id: source.id });
   const [fetchFeedTrigger] = useLazyFetchFeedQuery();
   const [scrapeForFeeds] = useRescrapeForFeedsMutation();
+
+  const handleMenuOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+    setOpen(true);
+  };
 
   const handleRescrape = () => {
     setOpenRescrape(true);
@@ -63,37 +70,37 @@ export default function FeedMenu({ source, disabled }) {
 
       <Button
         variant="outlined"
-        onClick={() => setOpen(true)}
+        onClick={handleMenuOpen}
         startIcon={(
           <ListAltIcon
             titleAccess="feeds options"
           />
         )}
+        endIcon={<KeyboardArrowDown />}
       >
         {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-        Feeds Options ({feedCount})...
+        Feeds Options ({feedCount})
       </Button>
-      <Dialog
+      <Menu
         open={open}
         onClose={() => setOpen(false)}
         maxWidth="md"
+        anchorEl={anchorEl}
       >
-        <DialogContent>
+        <MenuItem>
           {/* LIST FEEDS */}
           <Button
-            variant="outlined"
             startIcon={(
               <ListAltIcon
                 titleAccess="source's feeds page"
               />
             )}
             onClick={handleListFeeds}
-            sx={{ marginRight: '5px' }}
-
           >
             {`List Feeds (${feedCount})`}
           </Button>
-
+        </MenuItem>
+        <MenuItem>
           {/* REFETCH FEEDS */}
           <AlertDialog
             outsideTitle="Refetch Feeds"
@@ -108,23 +115,24 @@ export default function FeedMenu({ source, disabled }) {
             snackbarText="Feeds Queued!"
             onClick={handleRefetch}
             openDialog={openRefetch}
-            variant="outlined"
+            variant="text"
             startIcon={<LockOpenIcon titleAccess="admin-edit" />}
             secondAction={false}
             confirmButtonText="refetch feeds"
             disabled={!!source.url_search_string}
           />
-
+        </MenuItem>
+        <MenuItem>
           {/* CREATE FEED */}
           <Button
-            variant="outlined"
+            variant="text"
             startIcon={<LockOpenIcon titleAccess="admin-create" />}
             onClick={handleCreateFeed}
-            sx={{ marginLeft: '5px', marginRight: '5px' }}
           >
             Create Feed
           </Button>
-
+        </MenuItem>
+        <MenuItem>
           {/* RESCRAPE SOURCE FOR FEEDS */}
           <AlertDialog
             outsideTitle="Rescrape Source"
@@ -138,15 +146,15 @@ export default function FeedMenu({ source, disabled }) {
             snackbarText="Source Queued for Rescraping"
             onClick={handleRescrape}
             openDialog={openRescrape}
-            variant="outlined"
+            variant="text"
             navigateNeeded={false}
             startIcon={<LockOpenIcon titleAccess="admin-delete" />}
             secondAction={false}
             confirmButtonText="Rescrape"
             disabled={!!source.url_search_string}
           />
-        </DialogContent>
-      </Dialog>
+        </MenuItem>
+      </Menu>
     </>
   );
 }

--- a/mcweb/frontend/src/features/sources/util/FeedMenu.jsx
+++ b/mcweb/frontend/src/features/sources/util/FeedMenu.jsx
@@ -94,16 +94,6 @@ export default function FeedMenu({ source, disabled }) {
             {`List Feeds (${feedCount})`}
           </Button>
 
-          {/* CREATE FEED */}
-          <Button
-            variant="outlined"
-            startIcon={<LockOpenIcon titleAccess="admin-create" />}
-            onClick={handleCreateFeed}
-            sx={{ marginLeft: '5px', marginRight: '5px' }}
-          >
-            Create Feed
-          </Button>
-
           {/* REFETCH FEEDS */}
           <AlertDialog
             outsideTitle="Refetch Feeds"
@@ -124,6 +114,16 @@ export default function FeedMenu({ source, disabled }) {
             confirmButtonText="refetch feeds"
             disabled={!!source.url_search_string}
           />
+
+          {/* CREATE FEED */}
+          <Button
+            variant="outlined"
+            startIcon={<LockOpenIcon titleAccess="admin-create" />}
+            onClick={handleCreateFeed}
+            sx={{ marginLeft: '5px', marginRight: '5px' }}
+          >
+            Create Feed
+          </Button>
 
           {/* RESCRAPE SOURCE FOR FEEDS */}
           <AlertDialog

--- a/mcweb/frontend/src/features/sources/util/FeedMenu.jsx
+++ b/mcweb/frontend/src/features/sources/util/FeedMenu.jsx
@@ -88,8 +88,20 @@ export default function FeedMenu({ source, disabled }) {
               />
             )}
             onClick={handleListFeeds}
+            sx={{ marginRight: '5px' }}
+
           >
             {`List Feeds (${feedCount})`}
+          </Button>
+
+          {/* CREATE FEED */}
+          <Button
+            variant="outlined"
+            startIcon={<LockOpenIcon titleAccess="admin-create" />}
+            onClick={handleCreateFeed}
+            sx={{ marginLeft: '5px', marginRight: '5px' }}
+          >
+            Create Feed
           </Button>
 
           {/* REFETCH FEEDS */}
@@ -112,14 +124,6 @@ export default function FeedMenu({ source, disabled }) {
             confirmButtonText="refetch feeds"
             disabled={!!source.url_search_string}
           />
-          {/* CREATE FEED */}
-          <Button
-            variant="outlined"
-            startIcon={<LockOpenIcon titleAccess="admin-create" />}
-            onClick={handleCreateFeed}
-          >
-            Create Feed
-          </Button>
 
           {/* RESCRAPE SOURCE FOR FEEDS */}
           <AlertDialog


### PR DESCRIPTION
## Re-organize and de-clutter source header
![Screen Shot 2025-07-08 at 11 23 35 AM](https://github.com/user-attachments/assets/3302ee59-bfde-49c6-9272-ec0775c0eb9d)

### Feeds Menu 
![Screen Shot 2025-07-08 at 11 19 44 AM](https://github.com/user-attachments/assets/2d76d849-d4af-453c-9b38-5540193f679d)

### Advanced Menu
![Screen Shot 2025-07-08 at 11 19 57 AM](https://github.com/user-attachments/assets/43446590-b217-409f-ac51-e79f22079f24)

#### Convert Source Menu (add Alerts)
- search modal
![Screen Shot 2025-07-07 at 10 17 16 AM](https://github.com/user-attachments/assets/4829af65-9e42-4c14-b907-1ec4a2f3674e)
-confirmation modal
![Screen Shot 2025-07-07 at 10 18 47 AM](https://github.com/user-attachments/assets/30bbd43c-f5b5-474d-9ae9-33089960facb)


### Update to listing Alternative Domain
- Now listed as "Domains", with the source domain as the first entry (not deletable in modify screen)
![Screen Shot 2025-07-07 at 10 26 49 AM](https://github.com/user-attachments/assets/67aef957-68e4-432a-a32e-6bc6ed008deb)
![Screen Shot 2025-07-07 at 10 27 13 AM](https://github.com/user-attachments/assets/b4ad9789-3054-4d86-a6c0-0ce09159eefd)


