### PR TITLE
Add Vitals link to header

### DIFF
--- a/mcweb/frontend/src/features/header/Header.jsx
+++ b/mcweb/frontend/src/features/header/Header.jsx
@@ -11,7 +11,7 @@ import UserMenu from './UserMenu';
 import { assetUrl } from '../ui/uiUtil';
 import { PermissionedStaff, ROLE_STAFF } from '../auth/Permissioned';
 import SystemAlert from './SystemAlert';
-import releases from '../../../static/about/release_history.json';
+import releases from '../about/release_history.json';
 
 const relativeTime = require('dayjs/plugin/relativeTime');
 
@@ -101,7 +101,23 @@ function Header() {
                         About Search API
                       </MenuItem>
                     </a>
+                    {/* <a
+                      href="https://www.vitals.mediacloud.org"
+                      target="_blank"
+                      onClick={handleClose}
+                      style={{ textDecoration: 'none', color: 'black' }}
+                      rel="noreferrer"
+                    >
+                      <MenuItem>
+                        Vitals
+                      </MenuItem>
+                    </a> */}
                   </Menu>
+                  {/* <Button>
+                    <a href="https://www.vitals.mediacloud.org" target="_blank" rel="noreferrer">
+                      Vitals
+                    </a>
+                  </Button> */}
                 </li>
               </ul>
 

--- a/mcweb/frontend/src/features/header/Header.jsx
+++ b/mcweb/frontend/src/features/header/Header.jsx
@@ -49,6 +49,11 @@ function Header() {
                   </li>
                 ))}
                 <li>
+                  <Button>
+                    <a href="https://vitals.mediacloud.org" target="_blank" rel="noreferrer">
+                      Vitals
+                    </a>
+                  </Button>
                   <Button onClick={handleClick}>About</Button>
                   <Menu
                     id="about-menu"
@@ -101,23 +106,7 @@ function Header() {
                         About Search API
                       </MenuItem>
                     </a>
-                    {/* <a
-                      href="https://www.vitals.mediacloud.org"
-                      target="_blank"
-                      onClick={handleClose}
-                      style={{ textDecoration: 'none', color: 'black' }}
-                      rel="noreferrer"
-                    >
-                      <MenuItem>
-                        Vitals
-                      </MenuItem>
-                    </a> */}
                   </Menu>
-                  {/* <Button>
-                    <a href="https://www.vitals.mediacloud.org" target="_blank" rel="noreferrer">
-                      Vitals
-                    </a>
-                  </Button> */}
                 </li>
               </ul>
 


### PR DESCRIPTION
# Add a button with link to Vitals app
<img width="631" height="118" alt="Screen Shot 2025-07-16 at 11 51 55 AM" src="https://github.com/user-attachments/assets/1be28d8f-8605-4258-b4e1-75e373c791cd" />

- fix issue with header reading wrong release notes