### PR TITLE
Change warning of date range to be one line

### DIFF
--- a/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
+++ b/mcweb/frontend/src/features/search/query/SearchDatePicker.jsx
@@ -30,7 +30,7 @@ export default function SearchDatePicker({ queryIndex }) {
   // the minimum/maximum dates based on platform for both From and To dates
   // XXX does this get reexcuted when platform changes???
   const minDJS = earliestAllowedStartDate(platform); // dayjs
-  const maxDJS = latestAllowedEndDate(platform);     // dayjs
+  const maxDJS = latestAllowedEndDate(platform); // dayjs
 
   // handler for the fromDate MUI DatePicker
   const handleChangeFromDate = (newValue) => {
@@ -87,7 +87,7 @@ export default function SearchDatePicker({ queryIndex }) {
       {platform === PROVIDER_NEWS_MEDIA_CLOUD && (
         <Alert severity="warning">
           {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-          Reingest of historical data in progress. Search results available from present back to {minDJS.format(dateFormat)}
+          Reingest of historical data in progress. Search results since {minDJS.format('YYYY')} now available.
         </Alert>
       )}
       <div className="date-picker-wrapper local-provider">


### PR DESCRIPTION
## Update DateRange warning to be one line
<img width="638" height="226" alt="Screen Shot 2025-07-16 at 1 35 40 PM" src="https://github.com/user-attachments/assets/bc40d160-06c7-4df0-b707-62e52a50fb81" />

- Getting the date from env var earliest available date
closes #1131 