### PR TITLE
periodic/weekly/700.update-pub-date: disable

### DIFF
--- a/periodic/weekly/700.update-pub-date
+++ b/periodic/weekly/700.update-pub-date
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-python mcweb/manage.py sources-meta-update --queue  --task publication_date
+# disabled 2025-08-16 (leaving in place until more complete replacement)
+#python mcweb/manage.py sources-meta-update --queue  --task publication_date


### PR DESCRIPTION
Task runs a whole week, repeatedly, gives dubious result. Leaving in place until more complete replacement/removal.

I've been disabling it by hand (removing the periodic/weekly/700.update-pub-date file from the running container)