### PR TITLE
Add commas to chart rollovers

### DIFF
--- a/mcweb/frontend/src/features/search/results/CountOverTimeChart.jsx
+++ b/mcweb/frontend/src/features/search/results/CountOverTimeChart.jsx
@@ -4,6 +4,11 @@ import HighchartsReact from 'highcharts-react-official';
 import PropTypes from 'prop-types';
 
 export default function CountOverTimeChart({ series, normalized }) {
+  Highcharts.setOptions({
+    lang: {
+      thousandsSep: ',',
+    },
+  });
   const options = {
     chart: {
       type: 'spline',


### PR DESCRIPTION
<img width="307" height="104" alt="Screen Shot 2025-11-20 at 9 23 56 AM" src="https://github.com/user-attachments/assets/cc7f9af6-f4ee-4c92-9f14-806d30d7c2dc" />

closes #653 