### PR TITLE
Add note to capitalize boolean operators in advanced search

### DIFF
--- a/mcweb/frontend/src/features/search/query/AdvancedSearch.jsx
+++ b/mcweb/frontend/src/features/search/query/AdvancedSearch.jsx
@@ -82,6 +82,7 @@ function AdvancedSearch({ queryIndex }) {
                 </a>
                 {' '}
                 for the choosen platform.
+                Remeber to capitalize the boolean operators.
               </p>
             </div>
             <div className="col-5">


### PR DESCRIPTION
Add note in advanced search description to capitalize boolean operators.
<img width="1115" height="222" alt="Screen Shot 2025-11-26 at 10 21 04 AM" src="https://github.com/user-attachments/assets/d9e9181f-d58b-4262-96d4-43d3d613ca96" />
