### PR TITLE
Used the same pattern as in the scrape tasks, using the admin user as…

### DIFF
--- a/mcweb/backend/sources/tasks.py
+++ b/mcweb/backend/sources/tasks.py
@@ -64,6 +64,7 @@ GOOD = 'good'
 ALERT_HIGH = 'alert_high'
 
 ALERTS_TASK_USERNAME = ADMIN_USERNAME
+ANALYZE_TASK_USERNAME = ADMIN_USERNAME #Temporary fix
 SCRAPE_FROM_EMAIL = EMAIL_NOREPLY
 
 logger = logging.getLogger(__name__)
@@ -469,6 +470,7 @@ def analyze_sources(provider_name: str, sources:List, start_date: dt.datetime, t
     Returns:
         List[Dict[str, str]]: A list of dictionaries containing source IDs and their analyzed data.
     """
+    user = User.objects.get(username=ANALYZE_TASK_USERNAME)
     END_DATE = timezone.now()
     updated_sources = []
     sleep_interval = 60 / 100
@@ -512,7 +514,7 @@ def analyze_sources(provider_name: str, sources:List, start_date: dt.datetime, t
                 primary_language = max(languages, key=lambda x: x["value"])["language"]
                 source.primary_language = primary_language
                 logger.info("Analyzed source %s. Primary language: %s" % (source.name, primary_language))
-                log_action(None,  "update-source-language", ActionHistory.ModelType.SOURCE, source.id, source.name)
+                log_action(user,  "update-source-language", ActionHistory.ModelType.SOURCE, source.id, source.name)
                 updated_sources.append(source)
 
             elif task_name == "update_publication_date":
@@ -528,7 +530,7 @@ def analyze_sources(provider_name: str, sources:List, start_date: dt.datetime, t
                     if source.first_story is None or first_story < source.first_story:
                         source.first_story = first_story
                         logger.info("Analyzed source %s. First story publication date: %s" % (source.name, first_story))
-                        log_action(None,  "update-source-pub-date", ActionHistory.ModelType.SOURCE, source.id, source.name)
+                        log_action(user,  "update-source-pub-date", ActionHistory.ModelType.SOURCE, source.id, source.name)
                         updated_sources.append(source)
 
         except Exception as e:


### PR DESCRIPTION
… context for these background tasks

Chose this route over changing the database constraint- seems like the more compliant fix.

Marked 'tmp' because I think the previously discussed 'task context' buildout might include a more elegant solution to this problem, but that's not an immediate priority.
