### PR TITLE
Remove platform picker from search

### DIFF
--- a/mcweb/frontend/src/features/search/TabbedSearch.jsx
+++ b/mcweb/frontend/src/features/search/TabbedSearch.jsx
@@ -157,7 +157,7 @@ export default function TabbedSearch() {
   return (
     <div className="container search-container">
       <br />
-      <PlatformPicker queryIndex={0} sx={{ paddingTop: 50 }} />
+      {/* <PlatformPicker queryIndex={0} sx={{ paddingTop: 50 }} /> */}
       <Box sx={{ width: '100%' }}>
         <Box sx={{ borderBottom: 1, borderColor: 'divider', marginLeft: 6 }}>
           <Tabs


### PR DESCRIPTION
- Removed PlatformPicker from Search, default to Media Cloud
<img width="1342" height="529" alt="Screen Shot 2026-01-21 at 9 13 51 AM" src="https://github.com/user-attachments/assets/3e8a76dd-e4e5-42bb-a2e7-7a8fd9a917ad" />

closes #1217 