### PR TITLE
Fix error after converting source into ad

### DIFF
--- a/mcweb/frontend/src/features/sources/util/AdvancedMenu.jsx
+++ b/mcweb/frontend/src/features/sources/util/AdvancedMenu.jsx
@@ -76,7 +76,6 @@ export default function AdvancedMenu({
     setOpenAdvanced(false);
     setOpenCreateAlternativeDomain(false);
     setOpenAdConfirm(false);
-    navigate(`/sources/${selectedSource.id}`);
     enqueueSnackbar(
       `Source #${source.id} (${source.name}) converted into an alternative domain  
       for Source #${selectedSource.id} (${selectedSource.name})`,
@@ -112,6 +111,7 @@ export default function AdvancedMenu({
     if (altDomain) {
       setOpenNewAlternativeDomain(false);
       setOpenAdvanced(false);
+      navigate(`/sources/${selectedSource.id}`);
     }
   }, [altDomain]);
 


### PR DESCRIPTION
Fix error when trying to navigate to new source when converting a source into an alternative domain.

closes #1219 