### PR TITLE
Return task_utils.yesterday to naive; add yesterday_aware

### DIFF
--- a/mcweb/backend/sources/scrape.py
+++ b/mcweb/backend/sources/scrape.py
@@ -41,7 +41,7 @@ from mc_sitemap_tools.discover import NewsDiscoverer
 # local directory mcweb/backend/sources
 from .action_history import ActionHistoryContext, log_action
 from .models import ActionHistory, Collection, Feed, Source
-from .task_utils import monitored_collections, yesterday
+from .task_utils import monitored_collections, yesterday_aware
 
 # mcweb/backend/util
 from ..util.tasks import TaskLogContext, TaskCommand
@@ -328,7 +328,6 @@ class Scraper:
                     self._add_source_line(f"found existing {from_} feed {url}")
                 logger.info("scrape_source(%d) found existing %s feed %s",
                             source_id, from_, url)
-                # XXX could create ActionHistory!
                 self._feed_counts.confirmed += 1
             else:
                 try:
@@ -533,7 +532,7 @@ def autoscrape(*, options: dict, task_args: dict) -> None:
 
         # get latest date to consider "recently scraped"
         frequency = options["frequency"]
-        recent_rescrape_date = yesterday(frequency)
+        recent_rescrape_date = yesterday_aware(frequency)
         logger.debug("%d days, recent %s", frequency, recent_rescrape_date)
 
         sources = Source.objects
@@ -546,7 +545,7 @@ def autoscrape(*, options: dict, task_args: dict) -> None:
 
         if options["days_old"] is not None:
             days_old = options["days_old"]
-            latest = yesterday(days_old)
+            latest = yesterday_aware(days_old)
             sources = sources.filter(created_at__gt=latest)
             logger.debug("max %d days old: %s", days_old, latest)
 

--- a/mcweb/backend/sources/task_utils.py
+++ b/mcweb/backend/sources/task_utils.py
@@ -34,9 +34,17 @@ def monitored_collections():
 
 def yesterday(days=0):
     """
-    used for ES search ranges
+    returns a naive datetime for use in ES search ranges; mc_provider
+    two_d_aggregation currently only handles timezone naive datetimes
     """
-    return dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=days+1)
+    return dt.datetime.utcnow() - dt.timedelta(days=days+1)
+
+def yesterday_aware(days=0):
+    """
+    return a timezone aware UTC datetime
+    for use in PG queries (for autoscrape)
+    """
+    return yesterday(days).replace(tzinfo=dt.timezone.utc)
 
 class MetadataUpdater:
     """


### PR DESCRIPTION
I had changed task_utils.yesterday to return a TZ aware datetime to quiet warnings when used in PG queries, *BUT* this causes fatal errors in mc_providers which tries to do a subtraction involving a naive datetime.

This PR reverts `yesterday` to returning a naive datetime, and adds 'yesterday_aware` to return a TZ aware version.
