### PR TITLE
Update login and signup

### DIFF
--- a/mcweb/backend/users/api.py
+++ b/mcweb/backend/users/api.py
@@ -39,7 +39,7 @@ class RequestReset(generics.GenericAPIView):
 
             if reset_type == 'email-confirm':
                 subject = 'Welcome to Media Cloud please verify your email'
-                message = f"Hello, thank you for joining Media Cloud please use this link to verify your email and complete your registration: {reset_url} \n\n Thank you!"
+                message = f"Hello, thank you for signing up. Please use this link to verify your email and complete your registration: {reset_url} \n\n Thank you!"
             elif reset_type == 'password':
                 subject = 'Reset Password'
                 message = f"Hello, please use this link to reset your password: {reset_url} \n\n Thank you!"

--- a/mcweb/frontend/src/features/auth/SignIn.jsx
+++ b/mcweb/frontend/src/features/auth/SignIn.jsx
@@ -48,7 +48,7 @@ export default function SignIn() {
               required
               fullWidth
               id="text"
-              label="Username"
+              label="Username or Email"
               name="username"
               autoComplete="Username"
               autoFocus


### PR DESCRIPTION
Now users can use either username or email to sign in.

- update sign up email text 
- update error message when login fails due to email not being verified yet ("Email not verified, please check your email for verification link")