### PR TITLE
More Metadata updater updates!

### DIFF
--- a/mcweb/backend/sources/task_utils.py
+++ b/mcweb/backend/sources/task_utils.py
@@ -7,6 +7,7 @@ import datetime as dt
 import json
 import logging
 import time                     # sleep
+from typing import TypeAlias
 
 # PyPI:
 from background_task.tasks import TaskProxy
@@ -23,6 +24,15 @@ logger = logging.getLogger(__name__)
 
 ES_PROVIDER = "onlinenews-mediacloud"
 ES_PLATFORM = Source.SourcePlatforms.ONLINE_NEWS # platform column
+
+ChildSourceDict: TypeAlias = collections.defaultdict[str, list[Source]]
+
+class ChildSources:
+    ALSO = "also"               # process all sources
+    ONLY = "only"               # helpful for debugging!
+    NEVER = "never"
+
+CHILD_SOURCES_DEFAULT = ChildSources.ALSO
 
 def monitored_collections():
     """
@@ -49,11 +59,16 @@ def yesterday_aware(days=0):
 class MetadataUpdater:
     """
     Class for metadata updater tasks, invoked by MetadataUpdaterCommand
-    subclass manage commands
+    subclass manage commands.  Used by AlertSystem (in alerts.py)
+    as well as by UpdateStoriesPerWeek, UpdateSourceLanguage, and
+    FindLastStory in metadata_update.py
     """
+    # bulk_update can handle multiple columns, but it hasn't
+    # been needed yet.  If it is, change this to FIELDS and
+    # make it a list.
     UPDATE_FIELD: str           # Source field to update
 
-    SOURCE_PAGE_SIZE = 5000     # make a command line option?
+    SOURCE_PAGE_SIZE = 5000     # PG query page: make a command line option?
 
     # To add new arguments from the manage.py command line
     # add to MetadataUpdaterCommand.add_arguments
@@ -74,8 +89,8 @@ class MetadataUpdater:
 
         # not (YET) options(!!):
         # currently limited by number of query_string (OR) clauses
-        # so limit parent source batch size:
-        self.parent_batch_size = 32767
+        # so limit PG query page size:
+        self.child_batch_size = self.parent_batch_size = 32767
 
     def verbose(self, level: int, format: str, *args) -> None:
         """
@@ -99,21 +114,27 @@ class MetadataUpdater:
         self.sources_to_update.append(source)
 
     def source_name(self, source):
+        """
+        consistent formatting for logging
+        """
         return source.url_search_string or source.name
 
     def sources_query(self) -> QuerySet:
         q = Source.objects.filter(name__isnull=False,
                                   platform=self.platform)\
                           .order_by("id")
-        if not self.process_child_sources:
+        if self.process_child_sources == ChildSources.NEVER:
             # don't return child sources unless processing them
             q = q.filter(Q(url_search_string__isnull=True) |
                          Q(url_search_string__exact=""))
+        elif self.process_child_sources == ChildSources.ONLY:
+            q = q.filter(url_search_string__isnull=False)
         return q
 
     def run(self) -> None:
         full_query = self.sources_query()
-        parent_sources = []
+        parent_sources: list[Source] = []
+        child_sources: ChildSourceDict = collections.defaultdict(list)
 
         paginator = Paginator(full_query, self.parent_batch_size)
         for page_number in paginator.page_range:
@@ -124,45 +145,36 @@ class MetadataUpdater:
             for source in sources:
                 self.counters["scanned"] += 1
                 if source.url_search_string:
-                    if self.process_child_sources:
-                        self.verbose_source(3, "processing %s", source)
-                        # cannot aggregate by url_search_string
-                        # need to query child sources one at a time;
-                        # COULD handle multiple child sources, and
-                        # even child sources mixed in with parents
-                        # so long as only one parent or child for
-                        # a domain is in the batch!!!
-                        self.process_child_source(source)
-                    else:
+                    if self.process_child_sources == ChildSources.NEVER:
                         self.verbose_source(3, "skipping %s", source)
-                else:
+                    else:
+                        child_sources[source.name].append(source)
+                elif self.process_child_sources != ChildSources.ONLY:
                     # here with a parent source, batch it up
                     parent_sources.append(source)
+                else:
+                    self.verbose_source(3, "skipping %s", source)
             # end for source in sources
 
             if parent_sources:
-                self.process_parent_sources(parent_sources)
+                self.process_parents(parent_sources)
                 parent_sources = []
 
-            nupdate = len(self.sources_to_update)
-            if nupdate > 0:
-                if self.update:
-                    logger.info("starting bulk_update %d", nupdate)
-                    # painfully slow without batch_size?
-                    Source.objects.bulk_update(self.sources_to_update,
-                                               [self.UPDATE_FIELD], batch_size=100)
-                    logger.info("updated %d sources", nupdate)
-                    self.counters["updated"] += nupdate
-                else:
-                    logger.info("found %d sources to update", nupdate)
-                    self.counters["found"] += nupdate
-                self.sources_to_update = []
+            while len(child_sources) >= self.child_batch_size: # unlikely!!
+                self.process_children(child_sources)
+
+            self._update()
 
             if self.sleep_time > 0:
                 self.verbose(3, "sleep %.3f", self.sleep_time)
                 time.sleep(self.sleep_time)
 
         # end for page_number
+
+        if child_sources:
+            while child_sources:
+                self.process_children(child_sources)
+            self._update()
 
         # final log message
         counters = ", ".join(f"{name}: {value}"
@@ -172,6 +184,23 @@ class MetadataUpdater:
         else:
             logger.info("totals: %s (no update)", counters)
 
+    def _update(self):
+        """
+        helper for run; sync any updated sources
+        """
+        nupdate = len(self.sources_to_update)
+        if nupdate > 0:
+            if self.update:
+                logger.info("starting bulk_update %d", nupdate)
+                # painfully slow without batch_size?
+                Source.objects.bulk_update(self.sources_to_update,
+                                           [self.UPDATE_FIELD], batch_size=100)
+                logger.info("updated %d sources", nupdate)
+                self.counters["updated"] += nupdate
+            else:
+                logger.info("found %d sources to update", nupdate)
+                self.counters["found"] += nupdate
+            self.sources_to_update = []
 
     def process_sources(self, *,
                         sources: list[Source],
@@ -188,19 +217,44 @@ class MetadataUpdater:
         """
         raise NotImplementedError("process_sources not implemented")
 
-    def process_parent_sources(self, sources: list[Source]) -> None:
-        self.verbose(2, "process_parent_sources %d", len(sources))
+    def process_parents(self, sources: list[Source]) -> None:
+        self.verbose(2, "process_parents %d", len(sources))
         # NOTE! does not include alternative domain names!!!
         # (would complicate keeping batches below domain list length limit)
+        self.counters["process_parents"] += 1
         self.process_sources(sources=sources,
                              domains=[s.name for s in sources],
                              url_search_strings={})
 
-    def process_child_source(self, source: Source) -> None:
-        self.verbose(2, "process_child_source %s", source.url_search_string)
-        self.process_sources(sources=[source],
+    def process_children(self, sources: ChildSourceDict) -> None:
+        # child sources must not appear in a query with parent or siblings.
+        self.verbose(2, "process_children %s", len(sources))
+        sources_to_process: list[Source] = []
+        url_search_strings: dict[str, list[str]] = {}
+        to_delete: set[str] = set()
+
+        # pick one child source off of list for each parent domain
+        n = 0
+        for name, srcs in sources.items():
+            url_search_strings[name] = [srcs[0].url_search_string]
+            src = srcs.pop(0)
+            if len(srcs) == 0:
+                to_delete.add(name) # mark for deletion
+            sources_to_process.append(src)
+            n += 1
+            if n == self.child_batch_size:
+                break
+
+        # delete empty sources from ChildSourceDict
+        for name in to_delete:
+            self.verbose(3, "popping %s", name)
+            sources.pop(name)
+
+        self.verbose(3, "url_search_strings %s", url_search_strings)
+        self.counters["process_children"] += 1
+        self.process_sources(sources=sources_to_process,
                              domains=[],
-                             url_search_strings={source.name: [source.url_search_string]})
+                             url_search_strings=url_search_strings)
 
 
 class MetadataUpdaterCommand(TaskCommand):
@@ -215,8 +269,10 @@ class MetadataUpdaterCommand(TaskCommand):
         # more debugging/testing needed
         parser.add_argument(
             "--process-child-sources",
-            action="store_true",
-            help=f"Process child sources (w/ url search strings) too."
+            choices=[ChildSources.NEVER, ChildSources.ONLY, ChildSources.ALSO],
+            type=str,
+            default=CHILD_SOURCES_DEFAULT,
+            help=f"Control processing child sources (default: {CHILD_SOURCES_DEFAULT})."
         )
 
         # metadata update tasks were originally implemented


### PR DESCRIPTION
* Handle child sources (and batch them better) #1228
* Changed --process-child-sources to a tri-state: only, *also*, never
* Create ActionHistory rows for language update (part of #1235)
* Tweaked verbose/debug logging