### PR TITLE
Return profile to user in admin panel

### DIFF
--- a/mcweb/backend/users/admin.py
+++ b/mcweb/backend/users/admin.py
@@ -37,12 +37,6 @@ class CustomUserAdmin(BaseUserAdmin):
     form = UserAdminForm
     ordering = ['-date_joined']
     inlines = [ProfileInline]
-
-    def verified_email(self, obj):
-        # Safely get the related profile's verified_email
-        return getattr(obj.profile, 'verified_email', False)
-    verified_email.boolean = True  # Shows as a checkmark in admin
-    verified_email.short_description = "Verified Email"
     
     actions = [mark_inactive]
     
@@ -66,14 +60,11 @@ class CustomUserAdmin(BaseUserAdmin):
             format_html_join('', '<tr><td>{}</td><td>{}</td><td>{}</td></tr>', rows)
         )
     
-    readonly_fields = BaseUserAdmin.readonly_fields + ('current_collection_permissions', 'verified_email')
+    readonly_fields = BaseUserAdmin.readonly_fields + ('current_collection_permissions',)
 
     fieldsets = BaseUserAdmin.fieldsets + (
         ('Collection Permissions', {
             'fields': ('collection_id', "current_collection_permissions"),
-        }),
-        ('Profile Info', {
-            'fields': ('verified_email',),
         }),
     )
     current_collection_permissions.allow_tags = True

--- a/mcweb/backend/users/admin.py
+++ b/mcweb/backend/users/admin.py
@@ -36,6 +36,7 @@ mark_inactive.short_description = "Mark selected users as inactive"
 class CustomUserAdmin(BaseUserAdmin):
     form = UserAdminForm
     ordering = ['-date_joined']
+    inlines = [ProfileInline]
 
     def verified_email(self, obj):
         # Safely get the related profile's verified_email


### PR DESCRIPTION
<img width="1467" height="701" alt="Screenshot 2026-02-20 at 10 01 53 AM" src="https://github.com/user-attachments/assets/bbc88e19-bfef-4b54-8d3f-652e588fad52" />

- also removed the verified email (which had its own section) to now be in the profile section.