### PR TITLE
Update to sitemap-tools v4 for scraping

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,6 @@ django-guardian==3.0.*
 feed-seeker==1.1.*
 numpy
 # NOTE: .latest tag currently applied manually:
-sitemap-tools @ git+https://github.com/mediacloud/sitemap-tools@v3.1.latest
+sitemap-tools @ git+https://github.com/mediacloud/sitemap-tools@v4.0.latest
 supervisor==4.2.*
 statsd_client==1.0.*


### PR DESCRIPTION
Tested manually for single source (tries harder), collection and autoscraper.

* Keep GNewsScraper across home pages (to keep memory of sitemaps visited across multiple guesses at site home page)
* Increase max-depth to 2 when "try_harder" set