### PR TITLE
add helpful admin-only shortcuts to user menu

### DIFF
--- a/mcweb/frontend/src/features/header/UserMenu.jsx
+++ b/mcweb/frontend/src/features/header/UserMenu.jsx
@@ -4,12 +4,14 @@ import PersonIcon from '@mui/icons-material/Person';
 import Menu from '@mui/material/Menu';
 import Button from '@mui/material/Button';
 import MenuItem from '@mui/material/MenuItem';
+import Divider from '@mui/material/Divider';
 import { NavLink, useNavigate, Link } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
 import { useSelector, useDispatch } from 'react-redux';
 import { useLogoutMutation } from '../../app/services/authApi';
 import { selectIsLoggedIn, setCredentials } from '../auth/authSlice';
 import { saveCsrfToken } from '../../services/csrfToken';
+import { PermissionedStaff, ROLE_STAFF } from '../auth/Permissioned';
 
 // to save us typing redundant info when using MUI <Menu>s
 const defaultMenuOriginProps = {
@@ -56,6 +58,56 @@ const UserMenu = () => {
           <MenuItem component={NavLink} to="account" onClick={handleCloseUserMenu}>
             Profile
           </MenuItem>
+
+          <PermissionedStaff role={ROLE_STAFF}>
+            <Divider />
+            <MenuItem
+              href="/adminauth/user/"
+              target="_blank"
+              component="a"
+            >
+              Web User Admin
+            </MenuItem>
+            <MenuItem
+              href="http://localhost:8000/adminsources/collection/"
+              target="_blank"
+              component="a"
+            >
+              Web Collection Admin
+            </MenuItem>
+            <MenuItem
+              href="/adminsources/actionhistory/"
+              target="_blank"
+              component="a"
+            >
+              Web Action History
+            </MenuItem>
+            <Divider />
+            <MenuItem
+              href="https://mediacloud.github.io/sous-chef-kitchen-frontend/"
+              target="_blank"
+              component="a"
+            >
+              Sous Chef
+            </MenuItem>
+            <MenuItem
+              href="https://source-inspector.tarbell.mediacloud.org/"
+              target="_blank"
+              component="a"
+            >
+              Source Inspector
+            </MenuItem>
+            <MenuItem
+              href="https://stats.tarbell.mediacloud.org/"
+              target="_blank"
+              component="a"
+            >
+              Monitoring Dashboard
+            </MenuItem>
+          </PermissionedStaff>
+
+          <Divider />
+
           <MenuItem onClick={handleLogout}>
             Logout
           </MenuItem>

--- a/mcweb/frontend/src/features/header/UserMenu.jsx
+++ b/mcweb/frontend/src/features/header/UserMenu.jsx
@@ -69,7 +69,7 @@ const UserMenu = () => {
               Web User Admin
             </MenuItem>
             <MenuItem
-              href="http://localhost:8000/adminsources/collection/"
+              href="/adminsources/collection/"
               target="_blank"
               component="a"
             >


### PR DESCRIPTION
I constantly lose tabs and don't want to waste time digging up links to the amazing set of support tools we have. So this adds those links to the user menu, only for admins. It looks like this after changes:
<img width="558" height="428" alt="Media_Cloud_—_Media_Cloud_Directory" src="https://github.com/user-attachments/assets/563c6419-8206-4e75-8dfb-3be063021622" />
