### PR TITLE
support MC randomized paged story list results (staff-only)

### DIFF
--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -228,6 +228,7 @@ def _for_wayback_machine(collections: List, sources: List) -> Dict:
 # attack, or to leak full text in pagination key), so omitting it
 # until/unless it's needed and proven safe.
 _MEDIA_CLOUD_EXTRA_PROPS = [
+    'randomize',   # NOTE! view MUST check user has permission!
     'expanded',    # NOTE! view MUST check user has permission!
     'sort_order',  # NOTE: built into news-search-api?
     'pagination_token'

--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -437,6 +437,13 @@ def story_list(request):
         if not request.user.is_staff:
             return error_response("You are not permitted to fetch `expanded` stories.", response_type=HttpResponseForbidden)
 
+    # support page random sort, for staff only because compute cost is likely high after a handful of pages
+    if pq.provider_props.get('randomize') is not None:
+        pq.provider_props['randomize'] = pq.provider_props['randomize'] == '1'
+        if not request.user.is_staff:
+            return error_response("You are not permitted to fetch randomized stories due to server load concerns.",
+                                  response_type=HttpResponseForbidden)
+
     # NOTE! indexed_date is default sort key in MC ES provider, so no longer
     # strictly necessary, *BUT* it's presense here means users cannot pass it in
     # as an parameter.  This MAY be a feature, as it's possible to imagine that

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ whitenoise==6.2.*
 sentry-sdk==1.39.*
 requests  # let the other dependencies sort out which is the right version
 fasttext==0.9.*
-mc-providers @ git+https://github.com/mediacloud/mc-providers@v4.4.latest
+mc-providers @ git+https://github.com/mediacloud/mc-providers@v4.5.latest
 mc-manage @ git+https://github.com/mediacloud/mc-manage@v1.1.4
 pycountry==24.6.*
 django-background-tasks-updated==1.2.* # need >= 1.2.6


### PR DESCRIPTION
Adds support for new `randomize` param on story list calls. This is gated to staff only due to real concerns about compute cost against ES index. Pulls in latest mc-providers version that added the feature. Related to https://github.com/mediacloud/mc-providers/pull/90