### PR TITLE
add command to move feeds off child sources

### DIFF
--- a/mcweb/backend/sources/management/commands/child-source-migrate-feeds.py
+++ b/mcweb/backend/sources/management/commands/child-source-migrate-feeds.py
@@ -33,11 +33,16 @@ class Command(BaseCommand):
         feeds_moved = 0
         for child in child_sources:
             print(f"{prefix}{child.id}: {child.name} child source ({child.url_search_string}) has {child.feed_count} feeds")
-            parent = self._find_parent(child)
-            if parent is None:
+            potential_parents = self._find_potential_parents(child)
+            if len(potential_parents) == 0:
                 print(f"{prefix}  !!! No parent found for child source {child.id} — skipping")
                 continue
+            if len(potential_parents) > 1:
+                ids = ", ".join(str(p.id) for p in potential_parents)
+                print(f"{prefix}  !!! Multiple potential parents found for child source {child.id} ({ids}) — skipping")
+                continue
 
+            parent = potential_parents[0]
             print(f"{prefix}  found parent {parent.id} {parent.name}")
             if dry_run:
                 moved = Feed.objects.filter(source=child).count()
@@ -57,12 +62,11 @@ class Command(BaseCommand):
             .filter(feed_count__gt=0)
         )
 
-    def _find_parent(self, child: Source) -> Source | None:
-        return (
+    def _find_potential_parents(self, child: Source) -> list[Source]:
+        return list(
             Source.objects.filter(name=child.name, platform=child.platform)
             .filter(url_search_string__isnull=True)
             .exclude(id=child.id)
-            .first()
         )
 
     def _move_feeds(self, child: Source, parent: Source) -> int:

--- a/mcweb/backend/sources/management/commands/child-source-migrate-feeds.py
+++ b/mcweb/backend/sources/management/commands/child-source-migrate-feeds.py
@@ -1,0 +1,69 @@
+# mcweb/backend/sources/
+from django.core.management.base import BaseCommand
+from django.db.models import Count
+
+from ...models import Feed, Source
+
+
+class Command(BaseCommand):
+    help = "Find any child sources with feeds and migrate them to the parent source."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--max-sources",
+            type=int,
+            required=True,
+            help="Maximum number of child sources to process.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            type=lambda v: str(v).lower() in ("true", "1", "yes"),
+            default=False,
+            help="If true, print the changes that would be made without modifying any feeds.",
+        )
+
+    def handle(self, *args, **options):
+        max_sources = options["max_sources"]
+        dry_run = options["dry_run"]
+        child_sources = self._child_sources_with_feeds()[:max_sources]
+
+        prefix = "[dry-run] " if dry_run else ""
+        print(f"{prefix}Will look for up to {max_sources} child sources that have feeds (they're NOT supposed to)")
+        sources_cleaned = 0
+        feeds_moved = 0
+        for child in child_sources:
+            print(f"{prefix}{child.id}: {child.name} child source ({child.url_search_string}) has {child.feed_count} feeds")
+            parent = self._find_parent(child)
+            if parent is None:
+                print(f"{prefix}  !!! No parent found for child source {child.id} — skipping")
+                continue
+
+            print(f"{prefix}  found parent {parent.id} {parent.name}")
+            if dry_run:
+                moved = Feed.objects.filter(source=child).count()
+            else:
+                moved = self._move_feeds(child, parent)
+            sources_cleaned += 1
+            feeds_moved += moved
+            print(f"{prefix}  moved {moved} feed(s) to parent {parent.id}")
+
+        print(f"{prefix}Done: fixed {sources_cleaned} child source(s), moved {feeds_moved} feed(s) total")
+
+    def _child_sources_with_feeds(self):
+        return (
+            Source.objects.exclude(url_search_string__isnull=True)
+            .exclude(url_search_string="")
+            .annotate(feed_count=Count("feed"))
+            .filter(feed_count__gt=0)
+        )
+
+    def _find_parent(self, child: Source) -> Source | None:
+        return (
+            Source.objects.filter(name=child.name, platform=child.platform)
+            .filter(url_search_string__isnull=True)
+            .exclude(id=child.id)
+            .first()
+        )
+
+    def _move_feeds(self, child: Source, parent: Source) -> int:
+        return Feed.objects.filter(source=child).update(source=parent)


### PR DESCRIPTION
This adds a new command that can be used to automatically move any feeds on child sources to the parent source, addressing https://github.com/mediacloud/directory-issues/issues/25.

Running a command like `python mcweb/manage.py child-source-migrate-feeds --max-sources 5` produces output like this:
```
Will look for up to 5 child sources that have feeds (they're NOT supposed to)
18204: bbc.co.uk child source (bbc.co.uk/arabic/*) has 12 feeds
  found parent 18897 bbc.co.uk
  moved 12 feed(s) to parent 18897
18957: cbslocal.com child source (newyork.cbslocal.com/*) has 2 feeds
  found parent 323603 cbslocal.com
  moved 2 feed(s) to parent 323603
19090: india.com child source (zeenews.india.com/*) has 1 feeds
  found parent 271589 india.com
  moved 1 feed(s) to parent 271589
19883: yahoo.com child source (sg.news.yahoo.com/*) has 1 feeds
  found parent 19027 yahoo.com
  moved 1 feed(s) to parent 19027
21216: cbslocal.com child source (baltimore.cbslocal.com/*) has 1 feeds
  found parent 323603 cbslocal.com
  moved 1 feed(s) to parent 323603
Done: fixed 5 child source(s), moved 17 feed(s) total
```

Note: a `--dry-run=true` param is available to preview what will happen.

I did a few runs locally with the web app running (dev) and was able to see feeds before and after a move in the correct places.

