### PR TITLE
Return list of invalid srcs or collections with API error message.

### DIFF
--- a/dokku-scripts/push.sh
+++ b/dokku-scripts/push.sh
@@ -361,12 +361,14 @@ echo "pushing tag $TAG to $DOKKU_GIT_REMOTE"
 git push $DOKKU_GIT_REMOTE $TAG >/dev/null 2>&1
 echo "================"
 
-# push tag to upstream repos
-for REMOTE in $PUSH_TAG_TO; do
-    echo pushing tag $TAG to $REMOTE
-    git push $REMOTE $TAG
-    echo "================"
-done
+# push tag to upstream repos (unless --unpushed given)
+if [ -z "$MCWEB_UNPUSHED" ]; then
+    for REMOTE in $PUSH_TAG_TO; do
+	echo pushing tag $TAG to $REMOTE
+	git push $REMOTE $TAG
+	echo "================"
+    done
+fi
 
 # for prod/staging: tag config repo and push tag
 if [ -n "$PRIVATE_CONF_REPO" -a -d "$PRIVATE_CONF_REPO" ]; then
@@ -391,7 +393,8 @@ echo "$(date '+%F %T') $APP $REMOTE $TAG" >> push.log
 
 case $BRANCH in
 prod|staging)
-    # outputs message if update needed:
+    # outputs message if update needed
+    # (script needs to be run as root):
     check_crontab_sh_file_git_hashes
     ;;
 esac

--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -278,10 +278,10 @@ def _for_media_cloud(collections: list[int], sources: list[int], all_params: dic
     # that all the queries return the name and uss columns in the same
     # order for UNIONization.  Define the columns names once:
     union_cols = ['name', 'uss']
-
-    srcs_by_id = news_srcs.filter(id__in=sources)\
-                          .annotate(uss=F('url_search_string'))\
-                          .values(*union_cols)
+    filtered_srcs = news_srcs.filter(id__in=sources)
+    srcs_by_id = (filtered_srcs
+                  .annotate(uss=F('url_search_string'))
+                  .values(*union_cols))
 
     coll_srcs = news_srcs.filter(collections__id__in=collections)
     srcs_by_coll_id = coll_srcs.annotate(uss=F('url_search_string'))\
@@ -290,20 +290,31 @@ def _for_media_cloud(collections: list[int], sources: list[int], all_params: dic
     # 1: Validate inputs (if enabled)
     validate = constance.config.VALIDATE_SEARCH_IDS # 0 no, 1 warn, 2 error
     if validate:
-        # WISH: do both in single query SELECT COUNT(SELECT...), COUNT(SELECT...)!
-        if sources and srcs_by_id.count() != len(sources):
-            if validate >= 2:
-                raise UserValueError("invalid source id(s)")
-            logger.warning("invalid source id(s) %s", sources)
+        if sources:
+            # set creation 2-3x slower, so make list of int at first:
+            good_src_ids = list(filtered_srcs.values_list('id', flat=True))
+            if len(good_src_ids) != len(sources):
+                # set of strings:
+                bad_src_id_set = set(sources) - set(map(str, good_src_ids))
+                missing = ",".join(bad_src_id_set)
+                logger.warning("invalid source(s) %s", missing)
+                if validate >= 2:
+                    raise UserValueError(f"invalid source(s): {missing}")
 
         if collections:
-            colls = Collection.objects.filter(
+            coll_base = Collection.objects.filter(
                 id__in=collections,
                 platform=Collection.CollectionPlatforms.ONLINE_NEWS)
-            if colls.count() != len(collections):
+
+            # set creation 2-3x slower, so make list of int at first:
+            good_coll_ids = list(coll_base.values_list('id', flat=True))
+            if len(good_coll_ids) != len(collections):
+                # set of strings:
+                bad_coll_id_set = set(collections) - set(map(str, good_coll_ids))
+                missing = ",".join(bad_coll_id_set)
+                logger.warning("invalid collection(s) %s", missing)
                 if validate >= 2:
-                    raise UserValueError("invalid collection id(s)")
-                logger.warning("invalid collection id(s) %s", collections)
+                    raise UserValueError(f"invalid collection(s) {missing}")
 
     # 2: UNION the four queries: src by src/coll id, alts by src/coll id
 

--- a/mcweb/backend/search/utils.py
+++ b/mcweb/backend/search/utils.py
@@ -272,11 +272,11 @@ def _for_media_cloud(collections: list[int], sources: list[int], all_params: dic
     news_srcs = Source.objects.filter(
         platform=Source.SourcePlatforms.ONLINE_NEWS)
 
-    # Aliased fields end up last, and AlternativeDomain table "domain"
-    # field has to be aliased to "name", so have to alias
-    # url_search_string to "uss" in queries of both table to ensure
-    # that all the queries return the name and uss columns in the same
-    # order for UNIONization.  Define the columns names once:
+    # Aliased fields end up last in results, and AlternativeDomain
+    # table "domain" field has to be aliased to "name", so have to
+    # alias url_search_string to "uss" in queries of both table to
+    # ensure that all the queries return the name and uss columns in
+    # the same order for UNIONization.  Define the columns names once:
     union_cols = ['name', 'uss']
     filtered_srcs = news_srcs.filter(id__in=sources)
     srcs_by_id = (filtered_srcs
@@ -287,50 +287,67 @@ def _for_media_cloud(collections: list[int], sources: list[int], all_params: dic
     srcs_by_coll_id = coll_srcs.annotate(uss=F('url_search_string'))\
                                .values(*union_cols)
 
-    # 1: Validate inputs (if enabled)
-    validate = constance.config.VALIDATE_SEARCH_IDS # 0 no, 1 warn, 2 error
-    if validate:
-        if sources:
-            # set creation 2-3x slower, so make list of int at first:
-            good_src_ids = list(filtered_srcs.values_list('id', flat=True))
-            if len(good_src_ids) != len(sources):
-                # set of strings:
-                bad_src_id_set = set(sources) - set(map(str, good_src_ids))
-                missing = ",".join(bad_src_id_set)
-                logger.warning("invalid source(s) %s", missing)
-                if validate >= 2:
-                    raise UserValueError(f"invalid source(s): {missing}")
-
-        if collections:
-            coll_base = Collection.objects.filter(
-                id__in=collections,
-                platform=Collection.CollectionPlatforms.ONLINE_NEWS)
-
-            # set creation 2-3x slower, so make list of int at first:
-            good_coll_ids = list(coll_base.values_list('id', flat=True))
-            if len(good_coll_ids) != len(collections):
-                # set of strings:
-                bad_coll_id_set = set(collections) - set(map(str, good_coll_ids))
-                missing = ",".join(bad_coll_id_set)
-                logger.warning("invalid collection(s) %s", missing)
-                if validate >= 2:
-                    raise UserValueError(f"invalid collection(s) {missing}")
-
-    # 2: UNION the four queries: src by src/coll id, alts by src/coll id
-
     # alternate domain table base query: need to alias the "domain"
-    # column to "name" to match Source table for UNIONification,
-    # this causes it to appear last, unless url_search_string is ALSO
-    # aliased!
+    # column to "name" to match Source table for UNIONification, this
+    # causes it to appear last in results, so url_search_string is
+    # ALSO aliased to force IT to be last!!
     alts = AlternativeDomain.objects.annotate(name=F('domain'),
                                               uss=F('url_search_string'))\
                                     .values(*union_cols)
 
+    # 1: Validate inputs (if enabled)
+
+    # Contance setting (can be changed via admin UI)
+    # MEANT to be TEMPORARY to allow testing and/or backoff!!
+    # == 0 means no checking
+    # == 1 means log warning (API user sees nothing)
+    # >= 2 means return fatal UserValueError
+
+    # If fatal made permanent (tests removed),
+    # the "No sources found" check below can probably go away.
+    validate = constance.config.VALIDATE_SEARCH_IDS
+    if validate:
+        if sources:       # only perform queries if user supplied ids!
+            # set creation 2-3x slower than list, so make list of int at first
+            # (the common case is all ids are valid):
+            good_src_ids = list(filtered_srcs.values_list('id', flat=True))
+            if len(good_src_ids) != len(sources):
+                # set of strings (would need to convert int to str for formatting):
+                bad_src_id_set = set(sources) - set(map(str, good_src_ids))
+                missing = ",".join(bad_src_id_set)
+                if validate >= 2: # give fatal error (test should be TEMPORARY!)?
+                    raise UserValueError(f"invalid source(s): {missing}")
+                logger.warning("invalid source(s) %s", missing)
+
+        if collections:   # only perform queries if user supplied ids!
+            # set creation 2-3x slower than list, so make list of int at first
+            # (the common case is all ids are valid):
+            good_coll_ids = list(
+                Collection.objects.filter(
+                    id__in=collections,
+                    platform=Collection.CollectionPlatforms.ONLINE_NEWS)
+                .values_list('id', flat=True))
+            if len(good_coll_ids) != len(collections):
+                # set of strings (would need to convert int to str for formatting):
+                bad_coll_id_set = set(collections) - set(map(str, good_coll_ids))
+                missing = ",".join(bad_coll_id_set)
+                if validate >= 2: # give fatal error (test should be TEMPORARY!)?
+                    raise UserValueError(f"invalid collection(s) {missing}")
+                logger.warning("invalid collection(s) %s", missing)
+
+    # 2: UNION the four queries: src by src/coll id, alts by src/coll id
+
+    # Using UNION means we pass one query and get all the results at once:
+    # * avoiding multiple database round trips (the "1+N problem")
+    # * queries can be run in parallel if the SQL optimizer chooses
+    # * using OR in WHERE clause can stop use of indicices
+    # * filters duplicate results
+
     union_queryset = srcs_by_id.union(
         srcs_by_coll_id,
-        # by source ids:
+        # AlternativeDomains by source ids:
         alts.filter(source_id__in=sources),
-        # by collection ids: (using a subquery; but at least reuses it)
+        # AlternativeDomains by collection ids:
         alts.filter(source_id__in=coll_srcs)
     )
 
@@ -364,7 +381,8 @@ def _for_media_cloud(collections: list[int], sources: list[int], all_params: dic
             continue            # skip it.
         url_search_strings[domain].add(row["uss"])
 
-    # error if no output domains w/ non-empty inputs:
+    # error if no output domains w/ non-empty inputs (this can be
+    # removed if VALIDATE_SEARCH_IDS ever made fatal and permanent):
     if ((collections or sources) and
         not domains and
         not url_search_strings):

--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -152,8 +152,8 @@ def handle_provider_errors(func):
             return error_response(str(e), exc=e)
         except UserValueError as e:
             # ValueErrors will be thrown when the user provides bad input
-            # Should be the same handling flow as Runtime errors
-            logger.debug("UserValueError %r", e, exc_info=True)
+            # Should be the same handling flow as Runtime errors.
+            logger.debug("%r", e) # repr includes class name; removed exc_info: too many notes!
             return error_response(str(e), response_type=HttpResponseUnprocessableEntity, exc=e)
         except ProviderException as e:
             # ProviderException includes Provider{Permanent,Mystery}Exceptions.

--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -160,7 +160,8 @@ def handle_provider_errors(func):
             # Log exception/trace as warning to identify cases that
             # can be subclassed into more specific classes (or marked
             # that no traceback is needed).  Send traceback detail to client,
-            # log traceback with user name to aid locating reported problems.
+            # log traceback with user name to aid locating reported problems
+            # (FOR NOW):
             logger.warning("%r for user %s", e, _get_user(), exc_info=True)
             return error_response(str(e), exc=e, traceback=True)
         except Exception as e:


### PR DESCRIPTION
Causes client library to show bad ids in exception message:
```
mediacloud.error.APIResponseError: API Server Error 422. MESSAGE: invalid source(s): 999999998,999999999. ...
```