### PR TITLE
Add recently indexed stories to source pages

### DIFF
--- a/mcweb/backend/search/views.py
+++ b/mcweb/backend/search/views.py
@@ -423,7 +423,7 @@ def download_languages_csv(request):
 @api_stats  # PLEASE KEEP FIRST!
 @handle_provider_errors
 @api_view(['GET'])
-@authentication_classes([TokenAuthentication])  # API-only method for now
+@authentication_classes([TokenAuthentication, SessionAuthentication])
 @permission_classes([IsAuthenticated])
 @handle_429
 @ratelimit(key="user", rate='util.ratelimit_callables.story_list_rate')

--- a/mcweb/frontend/__tests__/RecentlyIndexedStoriesQuery.test.js
+++ b/mcweb/frontend/__tests__/RecentlyIndexedStoriesQuery.test.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-undef */
+import { recentlyIndexedStoriesQuery } from '../src/app/services/searchApi';
+
+test('requests stories indexed in the last 90 days across broad publication bounds', () => {
+  jest.useFakeTimers().setSystemTime(new Date('2026-07-19T12:00:00Z'));
+  try {
+    expect(recentlyIndexedStoriesQuery({
+      sourceId: 42,
+      startDate: '2000-01-01',
+      endDate: '2026-07-19',
+    })).toEqual({
+      url: 'story-list',
+      method: 'GET',
+      params: {
+        q: 'indexed_date:[2026-04-20 TO *]',
+        ss: 42,
+        start: '2000-01-01',
+        end: '2026-07-19',
+        p: 'onlinenews-mediacloud',
+        page_size: 10,
+      },
+    });
+  } finally {
+    jest.useRealTimers();
+  }
+});

--- a/mcweb/frontend/__tests__/SourceShow.test.jsx
+++ b/mcweb/frontend/__tests__/SourceShow.test.jsx
@@ -1,0 +1,83 @@
+/* eslint-disable no-undef, global-require, react/prop-types */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import SourceShow from '../src/features/sources/SourceShow';
+
+jest.mock('react-router-dom', () => ({
+  useParams: () => ({ sourceId: '42' }),
+  Link: ({ children }) => require('react').createElement('a', null, children),
+}));
+
+jest.mock('@mui/material/Box', () => ({ children }) => require('react').createElement('div', null, children));
+jest.mock('@mui/material/Tab', () => (props) => require('react').createElement('test-tab', props));
+jest.mock('@mui/material/Tabs', () => ({ children, onChange }) => (
+  require('react').createElement('test-tabs', { onChange }, children)
+));
+jest.mock('@mui/material/CircularProgress', () => () => require('react').createElement('test-progress'));
+
+jest.mock('../src/features/auth/Permissioned', () => ({
+  PermissionedContributor: ({ children }) => require('react').createElement('div', null, children),
+}));
+jest.mock('../src/features/ui/TabPanelHelper', () => ({ children, value, index }) => (
+  value === index ? require('react').createElement('test-panel', { index }, children) : null
+));
+jest.mock('../src/features/stories/StoriesOverTime', () => () => require('react').createElement('stories-over-time'));
+jest.mock('../src/features/collections/CollectionList', () => () => require('react').createElement('collection-list'));
+jest.mock('../src/features/feeds/FeedStories', () => () => require('react').createElement('feed-stories'));
+jest.mock('../src/features/stories/RecentlyIndexedStories', () => () => (
+  require('react').createElement('recently-indexed-stories')
+));
+jest.mock('../src/features/ui/StatPanel', () => () => require('react').createElement('stat-panel'));
+
+jest.mock('../src/app/services/sourceApi', () => ({
+  useGetSourceQuery: () => ({
+    data: {
+      id: 42,
+      name: 'example.com',
+      label: 'Example',
+      homepage: 'https://example.com',
+      platform: 'online_news',
+      alternative_domains: [],
+      modified_at: '2026-07-01T00:00:00Z',
+    },
+    isLoading: false,
+  }),
+  useListSourcesQuery: () => ({ data: { results: [] }, isLoading: false }),
+}));
+
+beforeEach(() => {
+  global.document = {
+    title: '',
+    settings: {
+      earliestAvailableDate: '2000-01-01',
+      lastMetadataUpdates: {},
+    },
+  };
+});
+
+test('source page separates recently indexed and recently discovered stories', () => {
+  let component;
+  act(() => {
+    component = renderer.create(<SourceShow />);
+  });
+
+  const { root } = component;
+  expect(root.findAllByType('test-tab').map((tab) => tab.props.label)).toEqual([
+    'Collection List',
+    'Coverage Over Time',
+    'Recently Discovered',
+  ]);
+
+  let [panel] = root.findAllByType('test-panel');
+  expect(panel.findAllByType('collection-list')).toHaveLength(1);
+  expect(panel.findAllByType('recently-indexed-stories')).toHaveLength(1);
+  expect(panel.findAllByType('feed-stories')).toHaveLength(0);
+
+  act(() => {
+    root.findByType('test-tabs').props.onChange(null, 2);
+  });
+
+  [panel] = root.findAllByType('test-panel');
+  expect(panel.props.index).toBe(2);
+  expect(panel.findAllByType('feed-stories')).toHaveLength(1);
+});

--- a/mcweb/frontend/src/app/services/searchApi.js
+++ b/mcweb/frontend/src/app/services/searchApi.js
@@ -1,6 +1,24 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import dayjs from 'dayjs';
 
 const TIMEOUT_CONST_MS = 5;
+
+export const recentlyIndexedStoriesQuery = ({
+  sourceId,
+  startDate,
+  endDate,
+}) => ({
+  url: 'story-list',
+  method: 'GET',
+  params: {
+    q: `indexed_date:[${dayjs().subtract(90, 'day').format('YYYY-MM-DD')} TO *]`,
+    ss: sourceId,
+    start: startDate,
+    end: endDate,
+    p: 'onlinenews-mediacloud',
+    page_size: 10,
+  },
+});
 
 const timeoutAction = (fetchFunc) => new Promise((resolve) => {
   setTimeout(() => {
@@ -70,6 +88,9 @@ export const searchApi = createApi({
         method: 'GET',
       }),
     }),
+    getRecentlyIndexedStories: builder.query({
+      query: recentlyIndexedStoriesQuery,
+    }),
     getTopWords: builder.mutation({
       queryFn: (queryState, _queryApi, _extraOptions, fetchWithBQ) => {
         const promises = queryState.map((queryObject) => timeoutAction(fetchWithBQ({
@@ -136,6 +157,7 @@ export const {
   useGetCountOverTimeMutation,
   useGetSampleStoriesMutation,
   useGetStoryDetailsQuery,
+  useGetRecentlyIndexedStoriesQuery,
   useGetTopWordsMutation,
   useGetTopLanguagesMutation,
   useSendTotalAttentionDataEmailMutation,

--- a/mcweb/frontend/src/features/feeds/FeedStories.jsx
+++ b/mcweb/frontend/src/features/feeds/FeedStories.jsx
@@ -15,7 +15,7 @@ function FeedStories({ feedId, feed, sourceId }) {
     <div className="results-item-wrapper results-sample-stories">
       <div className="row">
         <div className="col-12">
-          <h1 id="feed-story-title">Latest Stories</h1>
+          <h1 id="feed-story-title">{feed ? 'Latest Stories' : 'Recently Discovered Stories'}</h1>
         </div>
         <div className="row">
 

--- a/mcweb/frontend/src/features/sources/SourceShow.jsx
+++ b/mcweb/frontend/src/features/sources/SourceShow.jsx
@@ -13,6 +13,7 @@ import CollectionList from '../collections/CollectionList';
 import { useGetSourceQuery, useListSourcesQuery } from '../../app/services/sourceApi';
 import StatPanel from '../ui/StatPanel';
 import FeedStories from '../feeds/FeedStories';
+import RecentlyIndexedStories from '../stories/RecentlyIndexedStories';
 import renderNotes from '../collections/util/formatNotesToHTML';
 import getParentSource from './util/getParentSource';
 import getChildSources from './util/getChildSources';
@@ -205,6 +206,13 @@ export default function SourceShow() {
             // eslint-disable-next-line react/jsx-props-no-spreading
                 {...a11yProps(1)}
               />
+              {source.platform === 'online_news' && (
+                <Tab
+                  label="Recently Discovered"
+            // eslint-disable-next-line react/jsx-props-no-spreading
+                  {...a11yProps(2)}
+                />
+              )}
 
             </Tabs>
           </Box>
@@ -215,7 +223,7 @@ export default function SourceShow() {
               </div>
               {source.platform === 'online_news' && (
               <div className="col-6">
-                <FeedStories feed={false} sourceId={sourceId} />
+                <RecentlyIndexedStories sourceId={sourceId} />
               </div>
               )}
             </div>
@@ -223,6 +231,11 @@ export default function SourceShow() {
           <TabPanelHelper value={value} index={1}>
             <StoriesOverTime sourceId={sourceId} collectionId={false} />
           </TabPanelHelper>
+          {source.platform === 'online_news' && (
+            <TabPanelHelper value={value} index={2}>
+              <FeedStories feed={false} sourceId={sourceId} />
+            </TabPanelHelper>
+          )}
         </Box>
       </div>
     </div>

--- a/mcweb/frontend/src/features/stories/RecentlyIndexedStories.jsx
+++ b/mcweb/frontend/src/features/stories/RecentlyIndexedStories.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import dayjs from 'dayjs';
+import CircularProgress from '@mui/material/CircularProgress';
+import { useGetRecentlyIndexedStoriesQuery } from '../../app/services/searchApi';
+import {
+  PROVIDER_NEWS_MEDIA_CLOUD,
+  earliestAllowedStartDate,
+  latestAllowedEndDate,
+} from '../search/util/platforms';
+
+export default function RecentlyIndexedStories({ sourceId }) {
+  const { data, isLoading } = useGetRecentlyIndexedStoriesQuery({
+    sourceId,
+    startDate: earliestAllowedStartDate(PROVIDER_NEWS_MEDIA_CLOUD).format('YYYY-MM-DD'),
+    endDate: latestAllowedEndDate(PROVIDER_NEWS_MEDIA_CLOUD).format('YYYY-MM-DD'),
+  });
+
+  if (isLoading) {
+    return <CircularProgress size="75px" />;
+  }
+  if (!data) return null;
+
+  return (
+    <div className="results-item-wrapper results-sample-stories">
+      <div className="row">
+        <div className="col-12">
+          <h1>Recently Indexed Stories</h1>
+        </div>
+        <div className="row">
+          <div className="col-12">
+            <table className="feed-stories">
+              <thead>
+                <tr className="row">
+                  <th className="col-9">Title</th>
+                  <th className="col-3">Publication Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.stories.map((story) => (
+                  <tr key={story.id || story.url} className="row">
+                    <td className="col-10"><a href={story.url} target="_blank" rel="noreferrer">{story.title}</a></td>
+                    <td className="col-2">{dayjs(story.publish_date).format('MM-DD-YY')}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+RecentlyIndexedStories.propTypes = {
+  sourceId: PropTypes.number.isRequired,
+};


### PR DESCRIPTION
## Summary

- show the ten most recently indexed stories beside a source's collection list
- query the last 90 days of `indexed_date` across the full accepted publication-date range
- move RSS-discovered stories to a dedicated Recently Discovered tab
- allow authenticated browser sessions to use the story-list endpoint

## Testing

- `npm test -- --runInBand mcweb/frontend/__tests__/RecentlyIndexedStoriesQuery.test.js mcweb/frontend/__tests__/SourceShow.test.jsx` — 2 tests passed in the clean network-off verifier
- `npm run build` — passed in the pinned network-off container
- focused ESLint on the new and directly changed frontend files — passed; `SourceShow.jsx` retains the same 12 pre-existing diagnostics as the base
- the full Jest suite has the same three pre-existing failing suites on the base and patched trees; the patch adds two passing suites

Fixes #1280

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1037:start -->
### Verification

[Northset proof-of-pass receipt M-1037](https://northset-oss.github.io/verification-pilot/receipts/M-1037/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-1037:end -->
